### PR TITLE
feat(mac): add supabase account flow

### DIFF
--- a/apps/mac/Stet.xcodeproj/project.pbxproj
+++ b/apps/mac/Stet.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6D3A1A992F675F44005DA839 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 6D3A1A982F675F44005DA839 /* KeyboardShortcuts */; };
+		6D8230732F69F4A00096571A /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 6D8230722F69F4A00096571A /* Supabase */; };
 		A7D90C1E4B4D4E5F8A1B2C30 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A7D90C1E4B4D4E5F8A1B2C31 /* Sparkle */; };
 		C80A4F64301851B7005C2101 /* OpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = C80A4F66301851B7005C2101 /* OpenAI */; };
 /* End PBXBuildFile section */
@@ -58,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D8230732F69F4A00096571A /* Supabase in Frameworks */,
 				C80A4F64301851B7005C2101 /* OpenAI in Frameworks */,
 				A7D90C1E4B4D4E5F8A1B2C30 /* Sparkle in Frameworks */,
 				6D3A1A992F675F44005DA839 /* KeyboardShortcuts in Frameworks */,
@@ -124,6 +126,7 @@
 				C80A4F66301851B7005C2101 /* OpenAI */,
 				A7D90C1E4B4D4E5F8A1B2C31 /* Sparkle */,
 				6D3A1A982F675F44005DA839 /* KeyboardShortcuts */,
+				6D8230722F69F4A00096571A /* Supabase */,
 			);
 			productName = Stet;
 			productReference = 6D29DC7D2F5FA23000267DEA /* Stet.app */;
@@ -211,6 +214,7 @@
 				C80A4F65301851B7005C2101 /* XCRemoteSwiftPackageReference "OpenAI" */,
 				A7D90C1E4B4D4E5F8A1B2C32 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				6D3A1A972F675F44005DA839 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+				6D82306D2F69F4A00096571A /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6D29DC7E2F5FA23000267DEA /* Products */;
@@ -426,12 +430,15 @@
 				DEVELOPMENT_TEAM = 67BL3M4FPS;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Stet/Info.plist;
 				"INFOPLIST_KEY_LSApplicationCategoryType[sdk=macosx*]" = "public.app-category.productivity";
 				"INFOPLIST_KEY_LSUIElement[sdk=macosx*]" = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Stet uses System Events to paste your transcript back into the app you were using.";
 				"INFOPLIST_KEY_NSAudioCaptureUsageDescription[sdk=macosx*]" = "Stet temporarily silences other audio while dictation is active.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Stet uses the microphone to capture your dictation.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Stet uses on-device speech recognition to turn your voice into text.";
+				INFOPLIST_KEY_SUPABASE_PUBLISHABLE_KEY = "$(SUPABASE_PUBLISHABLE_KEY)";
+				INFOPLIST_KEY_SUPABASE_URL = "$(SUPABASE_URL)";
 				"INFOPLIST_KEY_SUAutomaticallyUpdate[sdk=macosx*]" = NO;
 				"INFOPLIST_KEY_SUEnableAutomaticChecks[sdk=macosx*]" = NO;
 				"INFOPLIST_KEY_SUEnableInstallerLauncherService[sdk=macosx*]" = YES;
@@ -456,6 +463,8 @@
 				SPARKLE_PUBLIC_ED_KEY = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPABASE_PUBLISHABLE_KEY = sb_publishable_DiDRWukKUQrcdBDUjYmJGw_5N51MiHP;
+				SUPABASE_URL = "https://qtffabmkvbkzarwevfrk.supabase.co";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -477,12 +486,15 @@
 				DEVELOPMENT_TEAM = 67BL3M4FPS;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Stet/Info.plist;
 				"INFOPLIST_KEY_LSApplicationCategoryType[sdk=macosx*]" = "public.app-category.productivity";
 				"INFOPLIST_KEY_LSUIElement[sdk=macosx*]" = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Stet uses System Events to paste your transcript back into the app you were using.";
 				"INFOPLIST_KEY_NSAudioCaptureUsageDescription[sdk=macosx*]" = "Stet temporarily silences other audio while dictation is active.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Stet uses the microphone to capture your dictation.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Stet uses on-device speech recognition to turn your voice into text.";
+				INFOPLIST_KEY_SUPABASE_PUBLISHABLE_KEY = "$(SUPABASE_PUBLISHABLE_KEY)";
+				INFOPLIST_KEY_SUPABASE_URL = "$(SUPABASE_URL)";
 				"INFOPLIST_KEY_SUAutomaticallyUpdate[sdk=macosx*]" = NO;
 				"INFOPLIST_KEY_SUEnableAutomaticChecks[sdk=macosx*]" = NO;
 				"INFOPLIST_KEY_SUEnableInstallerLauncherService[sdk=macosx*]" = YES;
@@ -507,6 +519,8 @@
 				SPARKLE_PUBLIC_ED_KEY = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPABASE_PUBLISHABLE_KEY = "";
+				SUPABASE_URL = "";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -655,6 +669,14 @@
 				minimumVersion = 2.4.0;
 			};
 		};
+		6D82306D2F69F4A00096571A /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase-community/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
 		A7D90C1E4B4D4E5F8A1B2C32 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
@@ -678,6 +700,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6D3A1A972F675F44005DA839 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
 			productName = KeyboardShortcuts;
+		};
+		6D8230722F69F4A00096571A /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6D82306D2F69F4A00096571A /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
 		};
 		A7D90C1E4B4D4E5F8A1B2C31 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/mac/Stet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/mac/Stet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3f428473f819f62531cc599dfe63a7517187db45f36a0b1d6b2075065bde5b96",
+  "originHash" : "a3d2039c4dfad3310aafa4ac31adf96031faaa156d67784e4dbf30980a4b57ca",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -29,6 +29,51 @@
       }
     },
     {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase-community/supabase-swift.git",
+      "state" : {
+        "revision" : "0f8bf83b55709e5530cd842a0185b9abba7a3c6c",
+        "version" : "2.41.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
+        "version" : "4.3.0"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
@@ -44,6 +89,15 @@
       "state" : {
         "revision" : "f039fa6d6338aab5164f3d1be16281524c9a8f89",
         "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/apps/mac/Stet/Core/Supabase/SupabaseService.swift
+++ b/apps/mac/Stet/Core/Supabase/SupabaseService.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Observation
+import Supabase
+
+@MainActor
+@Observable
+final class SupabaseService {
+    static let shared = SupabaseService()
+
+    private enum Configuration {
+        private static let environment = ProcessInfo.processInfo.environment
+        private static let infoDictionary = Bundle.main.infoDictionary ?? [:]
+        private static let placeholderURL = "https://project-name.supabase.co"
+        private static let placeholderKey = "your-project-key"
+
+        static let urlString =
+            resolvedValue(for: "SUPABASE_URL")
+            ?? placeholderURL
+
+        static let projectKey =
+            resolvedValue(for: "SUPABASE_PUBLISHABLE_KEY")
+            ?? placeholderKey
+
+        static var isConfigured: Bool {
+            urlString != placeholderURL &&
+                projectKey != placeholderKey &&
+                !projectKey.isEmpty
+        }
+
+        private static func resolvedValue(for key: String) -> String? {
+            let environmentValue = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let environmentValue, !environmentValue.isEmpty {
+                return environmentValue
+            }
+
+            let infoValue = (infoDictionary[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let infoValue, !infoValue.isEmpty {
+                return infoValue
+            }
+
+            return nil
+        }
+    }
+
+    private enum ServiceError: LocalizedError {
+        case missingConfiguration
+
+        var errorDescription: String? {
+            switch self {
+            case .missingConfiguration:
+                return "Supabase is not configured. Set `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` in the scheme environment or target build settings before signing in."
+            }
+        }
+    }
+
+    let client: SupabaseClient
+    private var authStateTask: Task<Void, Never>?
+
+    private(set) var currentSession: Session?
+    var isConfigured: Bool { Configuration.isConfigured }
+
+    private init() {
+        guard let supabaseURL = URL(string: Configuration.urlString) else {
+            preconditionFailure("Invalid SUPABASE_URL: \(Configuration.urlString)")
+        }
+
+        client = SupabaseClient(
+            supabaseURL: supabaseURL,
+            supabaseKey: Configuration.projectKey
+        )
+        currentSession = client.auth.currentSession
+        authStateTask = Task { @MainActor [weak self, client] in
+            for await (event, session) in client.auth.authStateChanges {
+                AppLogger.info("Supabase auth event: \(String(describing: event))")
+                self?.currentSession = session
+            }
+        }
+    }
+
+    // MARK: - Email Login
+    func signIn(email: String, password: String) async throws {
+        try ensureConfiguration()
+        try await client.auth.signIn(email: email, password: password)
+    }
+
+    func signUp(email: String, password: String) async throws {
+        try ensureConfiguration()
+        try await client.auth.signUp(email: email, password: password)
+    }
+
+    func signOut() async throws {
+        try ensureConfiguration()
+        try await client.auth.signOut()
+    }
+
+    var functions: FunctionsClient {
+        client.functions
+    }
+
+    var relayAuthenticationContext: RelayAuthenticationContext? {
+        guard isConfigured,
+              let currentSession,
+              let supabaseURL = URL(string: Configuration.urlString) else {
+            return nil
+        }
+
+        return RelayAuthenticationContext(
+            functionsBaseURL: supabaseURL.appendingPathComponent("functions/v1"),
+            publishableKey: Configuration.projectKey,
+            accessToken: currentSession.accessToken
+        )
+    }
+
+    private func ensureConfiguration() throws {
+        guard isConfigured else {
+            throw ServiceError.missingConfiguration
+        }
+    }
+}

--- a/apps/mac/Stet/Features/MacShell/Auth/AuthView.swift
+++ b/apps/mac/Stet/Features/MacShell/Auth/AuthView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+internal import Auth
+
+struct AuthView: View {
+    private enum Field: Hashable {
+        case email
+        case password
+    }
+
+    @State private var viewModel = AuthViewModel()
+    private let supabase = SupabaseService.shared
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+    @State private var shouldDismissAfterAuthentication = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            headerCard
+
+            if let session = supabase.currentSession {
+                signedInCard(session: session)
+            } else {
+                signedOutCard
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: 460)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onChange(of: supabase.currentSession == nil) { _, isSignedOut in
+            if !isSignedOut {
+                viewModel.clearFeedback()
+                if shouldDismissAfterAuthentication {
+                    shouldDismissAfterAuthentication = false
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    private var headerCard: some View {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color.accentColor.opacity(0.95), Color.accentColor.opacity(0.65)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 56, height: 56)
+                .overlay {
+                    Image(systemName: "lock.shield.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Stet Account")
+                    .font(.title3.weight(.semibold))
+
+                Text("Use your Supabase account to sign in on this Mac and access cloud-backed features.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.regularMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .strokeBorder(.quaternary, lineWidth: 1)
+        )
+    }
+
+    private func signedInCard(session: Session) -> some View {
+        MacSettingsCard(
+            title: "You're signed in",
+            description: "This Mac is currently connected to your Stet account."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                MacSettingsValueRow(title: "Email") {
+                    Text(session.user.email ?? "Unknown user")
+                        .font(.system(.body, design: .monospaced))
+                }
+
+                MacSettingsValueRow(title: "Status") {
+                    MacSettingsStatusBadge(text: "Active", tint: .green)
+                }
+
+                feedbackView
+
+                HStack {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .keyboardShortcut(.cancelAction)
+
+                    Spacer()
+
+                    Button("Sign Out", role: .destructive) {
+                        Task {
+                            await viewModel.signOut()
+                        }
+                    }
+                    .disabled(viewModel.isLoading)
+                }
+            }
+        }
+    }
+
+    private var signedOutCard: some View {
+        MacSettingsCard(
+            title: "Continue with Email",
+            description: "Enter the email and password for your Supabase account."
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    MacSettingsStatusBadge(
+                        text: supabase.isConfigured ? "Supabase Ready" : "Setup Required",
+                        tint: supabase.isConfigured ? .green : .orange
+                    )
+
+                    Spacer()
+
+                    if viewModel.isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Email")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    TextField("name@example.com", text: $viewModel.email)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($focusedField, equals: .email)
+                        .disableAutocorrection(true)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Password")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    SecureField("Enter your password", text: $viewModel.password)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($focusedField, equals: .password)
+                }
+
+                feedbackView
+
+                HStack(spacing: 12) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                    .keyboardShortcut(.cancelAction)
+
+                    Button("Create Account") {
+                        shouldDismissAfterAuthentication = true
+                        Task {
+                            await viewModel.signUp()
+                        }
+                    }
+                    .disabled(!viewModel.canSubmit)
+
+                    Spacer()
+
+                    Button("Sign In") {
+                        shouldDismissAfterAuthentication = true
+                        Task {
+                            await viewModel.signIn()
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.canSubmit)
+                }
+
+                Text("New accounts may require email confirmation before the first sign-in.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onSubmit {
+            guard viewModel.canSubmit else { return }
+            shouldDismissAfterAuthentication = true
+            Task {
+                await viewModel.signIn()
+            }
+        }
+        .task {
+            if focusedField == nil {
+                focusedField = .email
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var feedbackView: some View {
+        if let error = viewModel.errorMessage {
+            messageRow(text: error, tint: .red)
+        } else if let status = viewModel.statusMessage {
+            messageRow(text: status, tint: .secondary)
+        }
+    }
+
+    private func messageRow(text: String, tint: Color) -> some View {
+        Text(text)
+            .font(.footnote)
+            .foregroundStyle(tint)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(tint.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(tint.opacity(0.16), lineWidth: 1)
+            )
+    }
+}
+
+
+#Preview("Signed Out State") {
+    AuthView()
+        .frame(width: 520, height: 480)
+}

--- a/apps/mac/Stet/Features/MacShell/Auth/AuthViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/Auth/AuthViewModel.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Observation
+
+@Observable
+final class AuthViewModel {
+    private enum AuthAction {
+        case signIn
+        case signUp
+        case signOut
+
+        var failurePrefix: String {
+            switch self {
+            case .signIn:
+                return "Couldn't sign in"
+            case .signUp:
+                return "Couldn't create account"
+            case .signOut:
+                return "Couldn't sign out"
+            }
+        }
+    }
+
+    private enum ValidationError: LocalizedError {
+        case missingEmail
+        case invalidEmail
+        case missingPassword
+
+        var errorDescription: String? {
+            switch self {
+            case .missingEmail:
+                return "Enter the email address for your account."
+            case .invalidEmail:
+                return "Enter a valid email address."
+            case .missingPassword:
+                return "Enter your password before continuing."
+            }
+        }
+    }
+
+    var email = ""
+    var password = ""
+    var isLoading = false
+    var errorMessage: String? = nil
+    var statusMessage: String? = nil
+
+    private let supabase: SupabaseService = .shared
+
+    var canSubmit: Bool {
+        !normalizedEmail.isEmpty && !password.isEmpty && !isLoading
+    }
+
+    @MainActor
+    func signIn() async {
+        await perform(.signIn) { email, password in
+            try await supabase.signIn(email: email, password: password)
+            self.password = ""
+        }
+    }
+
+    @MainActor
+    func signUp() async {
+        await perform(.signUp) { email, password in
+            try await supabase.signUp(email: email, password: password)
+            self.password = ""
+            self.statusMessage = "Account created. If email confirmation is enabled, check your inbox before signing in."
+        }
+    }
+
+    @MainActor
+    func signOut() async {
+        await perform(.signOut) { _, _ in
+            try await supabase.signOut()
+        }
+    }
+
+    @MainActor
+    func clearFeedback() {
+        errorMessage = nil
+        statusMessage = nil
+    }
+
+    private var normalizedEmail: String {
+        email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    @MainActor
+    private func perform(
+        _ action: AuthAction,
+        operation: (_ email: String, _ password: String) async throws -> Void
+    ) async {
+        errorMessage = nil
+        statusMessage = nil
+
+        do {
+            let credentials = try validatedCredentials(for: action)
+            email = credentials.email
+            isLoading = true
+            defer { isLoading = false }
+            try await operation(credentials.email, credentials.password)
+        } catch {
+            errorMessage = message(for: error, action: action)
+        }
+    }
+
+    private func validatedCredentials(
+        for action: AuthAction
+    ) throws -> (email: String, password: String) {
+        switch action {
+        case .signOut:
+            return ("", "")
+        case .signIn, .signUp:
+            let email = normalizedEmail
+            guard !email.isEmpty else { throw ValidationError.missingEmail }
+            guard email.contains("@"), email.contains(".") else { throw ValidationError.invalidEmail }
+            guard !password.isEmpty else { throw ValidationError.missingPassword }
+            return (email, password)
+        }
+    }
+
+    private func message(for error: Error, action: AuthAction) -> String {
+        if let error = error as? LocalizedError, let description = error.errorDescription {
+            return description
+        }
+
+        let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !description.isEmpty else {
+            return action.failurePrefix
+        }
+
+        return "\(action.failurePrefix): \(description)"
+    }
+}

--- a/apps/mac/Stet/Features/MacShell/MacSettingsView.swift
+++ b/apps/mac/Stet/Features/MacShell/MacSettingsView.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import SwiftUI
+internal import Auth
 
 private enum MacSettingsSidebarGroup: String, CaseIterable, Identifiable {
     case workspace = "Workspace"
@@ -103,7 +104,9 @@ struct MacSettingsView: View {
 
     @StateObject private var dictionaryViewModel = DictionaryViewModel()
     @StateObject private var openAISettingsViewModel = MacOpenAISettingsViewModel()
+    private let supabase = SupabaseService.shared
     @State private var selectedTab: MacSettingsTab? = .general
+    @State private var isShowingAccountSheet = false
     @State private var searchText = ""
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
@@ -119,6 +122,10 @@ struct MacSettingsView: View {
             reloadStateFromPreferences()
             synchronizeSelectionWithFilter()
         }
+        .sheet(isPresented: $isShowingAccountSheet) {
+            AuthView()
+                .frame(minWidth: 520, minHeight: 480)
+        }
         .onChange(of: searchText) { _, _ in
             synchronizeSelectionWithFilter()
         }
@@ -131,34 +138,48 @@ struct MacSettingsView: View {
     }
 
     private var sidebar: some View {
-        List(selection: $selectedTab) {
-            if filteredTabs.isEmpty {
-                ContentUnavailableView(
-                    "No Results",
-                    systemImage: "magnifyingglass",
-                    description: Text("Try a different keyword.")
-                )
-                .listRowInsets(EdgeInsets())
-                .listRowBackground(Color.clear)
-                .tag(Optional<MacSettingsTab>.none)
-            } else {
-                ForEach(MacSettingsSidebarGroup.allCases) { group in
-                    let tabs = filteredTabs(in: group)
+        VStack(spacing: 0) {
+            Button {
+                isShowingAccountSheet = true
+            } label: {
+                sidebarAccountRow
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.plain)
 
-                    if !tabs.isEmpty {
-                        Section(group.rawValue) {
-                            ForEach(tabs) { tab in
-                                NavigationLink(value: tab) {
-                                    sidebarRow(for: tab)
+            Divider()
+
+            List(selection: $selectedTab) {
+                if filteredTabs.isEmpty {
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "magnifyingglass",
+                        description: Text("Try a different keyword.")
+                    )
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .tag(Optional<MacSettingsTab>.none)
+                } else {
+                    ForEach(MacSettingsSidebarGroup.allCases) { group in
+                        let tabs = filteredTabs(in: group)
+
+                        if !tabs.isEmpty {
+                            Section(group.rawValue) {
+                                ForEach(tabs) { tab in
+                                    NavigationLink(value: tab) {
+                                        sidebarRow(for: tab)
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+            .environment(\.sidebarRowSize, .large)
+            .listStyle(.sidebar)
         }
-        .environment(\.sidebarRowSize, .large)
-        .listStyle(.sidebar)
         .navigationSplitViewColumnWidth(min: 220, ideal: 250, max: 320)
     }
 
@@ -190,6 +211,55 @@ struct MacSettingsView: View {
         } else {
             Label(tab.title, systemImage: tab.iconName)
         }
+    }
+
+    private var sidebarAccountRow: some View {
+        HStack(spacing: 12) {
+            accountAvatar
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(accountTitle)
+                    .font(.headline)
+                    .lineLimit(1)
+
+                Text(accountSubtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+    }
+
+    private var accountAvatar: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: accountAvatarGradient,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 42, height: 42)
+                .overlay {
+                    Text(accountInitials)
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white)
+                }
+
+            Circle()
+                .fill(supabase.currentSession == nil ? Color.secondary.opacity(0.6) : Color.green)
+                .frame(width: 10, height: 10)
+                .overlay {
+                    Circle()
+                        .stroke(Color(nsColor: .controlBackgroundColor), lineWidth: 2)
+                }
+        }
+        .accessibilityHidden(true)
     }
 
     @ViewBuilder
@@ -240,6 +310,45 @@ struct MacSettingsView: View {
         }
 
         selectedTab = filteredTabs.first
+    }
+
+    private var accountTitle: String {
+        if let email = supabase.currentSession?.user.email, !email.isEmpty {
+            return email
+        }
+
+        return "Stet Account"
+    }
+
+    private var accountSubtitle: String {
+        if supabase.currentSession == nil {
+            return supabase.isConfigured ? "Sign in for relay-backed features" : "Supabase setup required"
+        }
+
+        return "Signed in"
+    }
+
+    private var accountInitials: String {
+        let source = supabase.currentSession?.user.email ?? "Stet"
+        let components = source
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+
+        let letters = components
+            .prefix(2)
+            .compactMap { $0.first.map { String($0).uppercased() } }
+            .joined()
+
+        return letters.isEmpty ? "S" : letters
+    }
+
+    private var accountAvatarGradient: [Color] {
+        if supabase.currentSession == nil {
+            return [Color.secondary.opacity(0.75), Color.secondary.opacity(0.45)]
+        }
+
+        return [Color.accentColor.opacity(0.95), Color.accentColor.opacity(0.65)]
     }
 }
 #endif

--- a/apps/mac/Stet/Info.plist
+++ b/apps/mac/Stet/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SUPABASE_PUBLISHABLE_KEY</key>
+	<string>$(SUPABASE_PUBLISHABLE_KEY)</string>
+	<key>SUPABASE_URL</key>
+	<string>$(SUPABASE_URL)</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add Supabase client wiring and bundle configuration for the mac app
- add a sign in / sign up / sign out sheet for account management
- expose account state from mac settings so relay-backed features can be authenticated
