### PR TITLE
feat(mac): add managed relay execution routing

### DIFF
--- a/apps/mac/Stet/App/MacAppBootstrapper.swift
+++ b/apps/mac/Stet/App/MacAppBootstrapper.swift
@@ -40,6 +40,7 @@ struct MacAppBootstrapper {
     private static let defaultPreferences: [DefaultPreference] = [
         .bool(MacPreferences.pauseMediaDuringDictation, false),
         .string(MacPreferences.transcriptionProvider, DictationProvider.openAI.rawValue),
+        .string(MacPreferences.aiExecutionMode, AIExecutionMode.automatic.rawValue),
         .bool(MacPreferences.rewriteEnabled, false),
         .string(MacPreferences.proxyMode, NetworkProxyMode.system.rawValue),
         .string(MacPreferences.customProxyScheme, CustomProxyScheme.http.rawValue),

--- a/apps/mac/Stet/Core/OpenAI/OpenAITranscriptionService.swift
+++ b/apps/mac/Stet/Core/OpenAI/OpenAITranscriptionService.swift
@@ -182,24 +182,31 @@ struct OpenAITranscriptionService: AudioFileTranscriptionService {
             additionalHeaders: additionalHeaders,
             timeoutInterval: timeoutInterval
         )
-        let boundary = "StetBoundary-\(UUID().uuidString)"
         let url = try transcriptionURL(from: sdkConfiguration)
-        let body = multipartFormBody(
-            boundary: boundary,
-            audioData: audioData,
-            fileType: fileType,
-            model: model,
-            prompt: prompt,
-            languageCode: languageCode
+        let multipart = MultipartFormRequestBody.make(
+            fields: makeMultipartFields(
+                model: model,
+                prompt: prompt,
+                languageCode: languageCode
+            ),
+            file: MultipartFormFile(
+                name: "file",
+                fileName: fileType.stetFileName,
+                contentType: fileType.stetContentType,
+                data: audioData
+            )
         )
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = timeoutInterval
-        request.httpBody = body
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = multipart.body
+        request.setValue(
+            "multipart/form-data; boundary=\(multipart.boundary)",
+            forHTTPHeaderField: "Content-Type"
+        )
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
+        request.setValue(String(multipart.body.count), forHTTPHeaderField: "Content-Length")
 
         if let token = sdkConfiguration.token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -244,71 +251,25 @@ struct OpenAITranscriptionService: AudioFileTranscriptionService {
         return url
     }
 
-    private static func multipartFormBody(
-        boundary: String,
-        audioData: Data,
-        fileType: AudioTranscriptionQuery.FileType,
+    private static func makeMultipartFields(
         model: String,
         prompt: String?,
         languageCode: String?
-    ) -> Data {
-        var body = Data()
-
-        appendMultipartFile(
-            named: "file",
-            fileName: fileType.stetFileName,
-            contentType: fileType.stetContentType,
-            fileData: audioData,
-            boundary: boundary,
-            to: &body
-        )
-        appendMultipartField(named: "model", value: model, boundary: boundary, to: &body)
-        appendMultipartField(named: "response_format", value: "json", boundary: boundary, to: &body)
+    ) -> [MultipartFormField] {
+        var fields: [MultipartFormField] = [
+            .init(name: "model", value: model),
+            .init(name: "response_format", value: "json"),
+        ]
 
         if let prompt {
-            appendMultipartField(named: "prompt", value: prompt, boundary: boundary, to: &body)
+            fields.append(.init(name: "prompt", value: prompt))
         }
 
         if let languageCode {
-            appendMultipartField(named: "language", value: languageCode, boundary: boundary, to: &body)
+            fields.append(.init(name: "language", value: languageCode))
         }
 
-        appendString("--\(boundary)--\r\n", to: &body)
-        return body
-    }
-
-    private static func appendMultipartField(
-        named name: String,
-        value: String,
-        boundary: String,
-        to body: inout Data
-    ) {
-        appendString("--\(boundary)\r\n", to: &body)
-        appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n", to: &body)
-        appendString(value, to: &body)
-        appendString("\r\n", to: &body)
-    }
-
-    private static func appendMultipartFile(
-        named name: String,
-        fileName: String,
-        contentType: String,
-        fileData: Data,
-        boundary: String,
-        to body: inout Data
-    ) {
-        appendString("--\(boundary)\r\n", to: &body)
-        appendString(
-            "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(fileName)\"\r\n",
-            to: &body
-        )
-        appendString("Content-Type: \(contentType)\r\n\r\n", to: &body)
-        body.append(fileData)
-        appendString("\r\n", to: &body)
-    }
-
-    private static func appendString(_ string: String, to body: inout Data) {
-        body.append(Data(string.utf8))
+        return fields
     }
 
     private static func transcriptionText(from responseData: Data, statusCode: Int) -> String? {

--- a/apps/mac/Stet/Core/Speech/ConfigurableSpeechService.swift
+++ b/apps/mac/Stet/Core/Speech/ConfigurableSpeechService.swift
@@ -2,22 +2,54 @@ import Foundation
 
 actor ConfigurableSpeechService: SpeechService, AudioLevelStreaming {
     struct Dependencies: Sendable {
+        var relayAuthenticationContext: @Sendable () async -> RelayAuthenticationContext?
         var makeNetworkSession: @Sendable (NetworkProxySettings) -> URLSession
-        var makeOpenAISpeechService: @Sendable (
+        var makeDirectSpeechService: @Sendable (
             OpenAIConfiguration,
             URLSession,
             Locale,
             @escaping @Sendable () async -> String?
         ) async -> any SpeechService
+        var makeRelaySpeechService: @Sendable (
+            RelayAuthenticationContext,
+            URLSession,
+            Locale,
+            Bool,
+            [String],
+            @escaping @Sendable () async -> String?
+        ) async -> any SpeechService
         var makeRewriteService: @Sendable (OpenAIConfiguration, URLSession) -> any TextRewriteService
 
         static let live = Dependencies(
+            relayAuthenticationContext: {
+                await MainActor.run {
+                    SupabaseService.shared.relayAuthenticationContext
+                }
+            },
             makeNetworkSession: OpenAINetworkSession.makeSession,
-            makeOpenAISpeechService: { configuration, session, locale, promptProvider in
+            makeDirectSpeechService: { configuration, session, locale, promptProvider in
                 await OpenAISpeechService(
                     transcriptionService: OpenAITranscriptionService(
                         configuration: configuration,
                         session: session
+                    ),
+                    locale: locale,
+                    transcriptionPromptProvider: promptProvider
+                )
+            },
+            makeRelaySpeechService: {
+                authentication,
+                session,
+                locale,
+                rewriteEnabled,
+                preferredSpellings,
+                promptProvider in
+                await OpenAISpeechService(
+                    transcriptionService: RelayDictationTranscriptionService(
+                        authentication: authentication,
+                        session: session,
+                        rewriteEnabled: rewriteEnabled,
+                        preferredSpellings: preferredSpellings
                     ),
                     locale: locale,
                     transcriptionPromptProvider: promptProvider
@@ -113,38 +145,53 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelStreaming {
     }
 
     private func makeActiveSession(from snapshot: DictationSettingsSnapshot) async throws -> ActiveSession {
-        let speechService: any SpeechService
-        let networkSession = dependencies.makeNetworkSession(snapshot.proxySettings)
-
-        guard let configuration = snapshot.openAIConfiguration else {
-            throw OpenAIError.missingAPIKey(provider: snapshot.provider)
-        }
-
-        speechService = await dependencies.makeOpenAISpeechService(
-            configuration,
-            networkSession,
-            locale,
-            {
-                nil
-            }
+        let relayAuthentication = await dependencies.relayAuthenticationContext()
+        let route = try DictationExecutionRouteResolver.resolve(
+            snapshot: snapshot,
+            relayAuthentication: relayAuthentication
         )
-
+        let speechService: any SpeechService
         let rewriteService: (any TextRewriteService)?
+        let preferredSpellings: [String]
 
-        if snapshot.isRewriteEnabled {
-            guard let configuration = snapshot.openAIConfiguration else {
-                throw OpenAIError.missingAPIKey(provider: snapshot.provider)
+        switch route {
+        case .direct(let direct):
+            let networkSession = dependencies.makeNetworkSession(direct.proxySettings)
+            speechService = await dependencies.makeDirectSpeechService(
+                direct.configuration,
+                networkSession,
+                locale,
+                {
+                    nil
+                }
+            )
+            preferredSpellings = direct.preferredSpellings
+
+            if direct.rewriteEnabled {
+                rewriteService = dependencies.makeRewriteService(direct.configuration, networkSession)
+            } else {
+                rewriteService = nil
             }
-
-            rewriteService = dependencies.makeRewriteService(configuration, networkSession)
-        } else {
+        case .relay(let relay):
+            let networkSession = dependencies.makeNetworkSession(relay.proxySettings)
+            speechService = await dependencies.makeRelaySpeechService(
+                relay.authentication,
+                networkSession,
+                locale,
+                relay.rewriteEnabled,
+                relay.preferredSpellings,
+                {
+                    Self.makeTranscriptionPrompt(preferredSpellings: relay.preferredSpellings)
+                }
+            )
             rewriteService = nil
+            preferredSpellings = relay.preferredSpellings
         }
 
         return ActiveSession(
             speechService: speechService,
             rewriteService: rewriteService,
-            preferredSpellings: snapshot.personalDictionary
+            preferredSpellings: preferredSpellings
         )
     }
 

--- a/apps/mac/Stet/Core/Speech/DictationExecutionRoute.swift
+++ b/apps/mac/Stet/Core/Speech/DictationExecutionRoute.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+struct RelayAuthenticationContext: Sendable, Equatable {
+    let functionsBaseURL: URL
+    let publishableKey: String
+    let accessToken: String
+
+    nonisolated var relayBaseURL: URL {
+        functionsBaseURL.appendingPathComponent("relay/v1")
+    }
+}
+
+enum AIExecutionError: LocalizedError, Equatable {
+    case managedRequiresAuthenticatedSession
+    case relayNotConfigured
+    case relayInvocationFailed(statusCode: Int?, message: String, requestID: String?)
+    case unsupportedFlowInManagedMode(flow: String)
+
+    nonisolated var errorDescription: String? {
+        switch self {
+        case .managedRequiresAuthenticatedSession:
+            return "Managed Relay requires a signed-in Stet account."
+        case .relayNotConfigured:
+            return "Managed Relay is not configured for this build."
+        case .relayInvocationFailed(let statusCode, let message, let requestID):
+            let requestIDSuffix = requestID.map { " Request ID: \($0)." } ?? ""
+
+            if let statusCode {
+                return "Managed Relay error (\(statusCode)): \(message).\(requestIDSuffix)"
+            }
+
+            return "Managed Relay error: \(message).\(requestIDSuffix)"
+        case .unsupportedFlowInManagedMode(let flow):
+            return "\(flow) is not available in Managed Relay mode yet."
+        }
+    }
+}
+
+enum DictationExecutionRoute: Sendable {
+    struct Direct: Sendable {
+        let configuration: OpenAIConfiguration
+        let proxySettings: NetworkProxySettings
+        let rewriteEnabled: Bool
+        let preferredSpellings: [String]
+    }
+
+    struct Relay: Sendable {
+        let authentication: RelayAuthenticationContext
+        let proxySettings: NetworkProxySettings
+        let rewriteEnabled: Bool
+        let preferredSpellings: [String]
+    }
+
+    case direct(Direct)
+    case relay(Relay)
+}
+
+enum DictationExecutionRouteResolver {
+    nonisolated static func resolve(
+        snapshot: DictationSettingsSnapshot,
+        relayAuthentication: RelayAuthenticationContext?
+    ) throws -> DictationExecutionRoute {
+        if snapshot.executionMode.requiresAuthenticatedSession, relayAuthentication == nil {
+            throw AIExecutionError.managedRequiresAuthenticatedSession
+        }
+
+        if snapshot.executionMode.requiresLocalAPIKey, snapshot.providerConfiguration == nil {
+            throw OpenAIError.missingAPIKey(provider: snapshot.provider)
+        }
+
+        switch snapshot.executionMode {
+        case .automatic:
+            if let relayAuthentication {
+                return .relay(
+                    .init(
+                        authentication: relayAuthentication,
+                        proxySettings: snapshot.proxySettings,
+                        rewriteEnabled: snapshot.isRewriteEnabled,
+                        preferredSpellings: snapshot.personalDictionary
+                    )
+                )
+            }
+
+            guard let configuration = snapshot.providerConfiguration else {
+                throw OpenAIError.missingAPIKey(provider: snapshot.provider)
+            }
+
+            return .direct(
+                .init(
+                    configuration: configuration,
+                    proxySettings: snapshot.proxySettings,
+                    rewriteEnabled: snapshot.isRewriteEnabled,
+                    preferredSpellings: snapshot.personalDictionary
+                )
+            )
+        case .managed:
+            guard let relayAuthentication else {
+                throw AIExecutionError.managedRequiresAuthenticatedSession
+            }
+
+            return .relay(
+                .init(
+                    authentication: relayAuthentication,
+                    proxySettings: snapshot.proxySettings,
+                    rewriteEnabled: snapshot.isRewriteEnabled,
+                    preferredSpellings: snapshot.personalDictionary
+                )
+            )
+        case .byok:
+            guard let configuration = snapshot.providerConfiguration else {
+                throw OpenAIError.missingAPIKey(provider: snapshot.provider)
+            }
+
+            return .direct(
+                .init(
+                    configuration: configuration,
+                    proxySettings: snapshot.proxySettings,
+                    rewriteEnabled: snapshot.isRewriteEnabled,
+                    preferredSpellings: snapshot.personalDictionary
+                )
+            )
+        }
+    }
+}

--- a/apps/mac/Stet/Core/Speech/MultipartFormRequestBody.swift
+++ b/apps/mac/Stet/Core/Speech/MultipartFormRequestBody.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct MultipartFormField: Sendable {
+    let name: String
+    let value: String
+}
+
+struct MultipartFormFile: Sendable {
+    let name: String
+    let fileName: String
+    let contentType: String
+    let data: Data
+}
+
+enum MultipartFormRequestBody {
+    static func make(
+        boundary: String = "StetBoundary-\(UUID().uuidString)",
+        fields: [MultipartFormField],
+        file: MultipartFormFile
+    ) -> (boundary: String, body: Data) {
+        var body = Data()
+
+        appendMultipartFile(file, boundary: boundary, to: &body)
+
+        for field in fields {
+            appendMultipartField(field, boundary: boundary, to: &body)
+        }
+
+        appendString("--\(boundary)--\r\n", to: &body)
+        return (boundary, body)
+    }
+
+    private static func appendMultipartField(
+        _ field: MultipartFormField,
+        boundary: String,
+        to body: inout Data
+    ) {
+        appendString("--\(boundary)\r\n", to: &body)
+        appendString("Content-Disposition: form-data; name=\"\(field.name)\"\r\n\r\n", to: &body)
+        appendString(field.value, to: &body)
+        appendString("\r\n", to: &body)
+    }
+
+    private static func appendMultipartFile(
+        _ file: MultipartFormFile,
+        boundary: String,
+        to body: inout Data
+    ) {
+        appendString("--\(boundary)\r\n", to: &body)
+        appendString(
+            "Content-Disposition: form-data; name=\"\(file.name)\"; filename=\"\(file.fileName)\"\r\n",
+            to: &body
+        )
+        appendString("Content-Type: \(file.contentType)\r\n\r\n", to: &body)
+        body.append(file.data)
+        appendString("\r\n", to: &body)
+    }
+
+    private static func appendString(_ string: String, to body: inout Data) {
+        body.append(Data(string.utf8))
+    }
+}

--- a/apps/mac/Stet/Core/Speech/RelayDictationTranscriptionService.swift
+++ b/apps/mac/Stet/Core/Speech/RelayDictationTranscriptionService.swift
@@ -1,0 +1,310 @@
+import Foundation
+import OpenAI
+
+struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
+    private struct SuccessResponse: Decodable {
+        let text: String
+        let rewritten: Bool
+    }
+
+    private struct ErrorResponse: Decodable {
+        let code: String?
+        let message: String
+        let request_id: String?
+    }
+
+    private enum RequestPolicy {
+        static let minimumTimeoutSeconds: TimeInterval = 90
+        static let maximumTimeoutSeconds: TimeInterval = 150
+        static let timeoutBufferSeconds: TimeInterval = 30
+        static let timeoutPerAudioSecond: TimeInterval = 2
+    }
+
+    private let authentication: RelayAuthenticationContext
+    private let session: URLSession
+    private let rewriteEnabled: Bool
+    private let preferredSpellings: [String]
+
+    init(
+        authentication: RelayAuthenticationContext,
+        session: URLSession = .shared,
+        rewriteEnabled: Bool,
+        preferredSpellings: [String]
+    ) {
+        self.authentication = authentication
+        self.session = session
+        self.rewriteEnabled = rewriteEnabled
+        self.preferredSpellings = preferredSpellings
+    }
+
+    func transcribe(
+        audioFileAt fileURL: URL,
+        languageCode: String?,
+        prompt: String?,
+        audioDurationSeconds: TimeInterval?
+    ) async throws -> String {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw OpenAIError.fileNotFound(fileURL)
+        }
+
+        guard let fileType = AudioTranscriptionQuery.FileType(fileURL: fileURL) else {
+            throw AIExecutionError.relayInvocationFailed(
+                statusCode: nil,
+                message: "The audio format is not supported by Managed Relay.",
+                requestID: nil
+            )
+        }
+
+        let audioData = try Data(contentsOf: fileURL)
+        let timeoutInterval = Self.timeoutInterval(for: audioDurationSeconds)
+        let clientRequestID = UUID().uuidString
+        let request = try Self.makeRequest(
+            authentication: authentication,
+            audioData: audioData,
+            fileType: fileType,
+            languageCode: Self.normalizedText(languageCode),
+            prompt: Self.normalizedText(prompt),
+            rewriteEnabled: rewriteEnabled,
+            preferredSpellings: preferredSpellings,
+            timeoutInterval: timeoutInterval,
+            clientRequestID: clientRequestID
+        )
+
+        AppLogger.info(
+            "Relay transcription request started. requestID=\(clientRequestID) url=\(request.url?.absoluteString ?? "unknown") audioBytes=\(audioData.count) fileType=\(fileType.stetContentType) rewriteEnabled=\(rewriteEnabled) preferredSpellingsCount=\(preferredSpellings.count) timeoutSeconds=\(String(format: "%.1f", timeoutInterval))",
+            category: .dictation
+        )
+
+        do {
+            let (responseData, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                AppLogger.error(
+                    "Relay transcription returned a non-HTTP response. requestID=\(clientRequestID)",
+                    category: .dictation
+                )
+                throw AIExecutionError.relayInvocationFailed(
+                    statusCode: nil,
+                    message: "The relay returned an invalid response.",
+                    requestID: nil
+                )
+            }
+
+            AppLogger.info(
+                "Relay transcription response received. requestID=\(clientRequestID) status=\(httpResponse.statusCode) responseBytes=\(responseData.count) serverRequestID=\(httpResponse.value(forHTTPHeaderField: "x-request-id") ?? "missing")",
+                category: .dictation
+            )
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                AppLogger.error(
+                    "Relay transcription returned an error response. requestID=\(clientRequestID) status=\(httpResponse.statusCode) responsePreview=\(Self.responsePreview(from: responseData))",
+                    category: .dictation
+                )
+                throw Self.mapRelayError(
+                    statusCode: httpResponse.statusCode,
+                    responseData: responseData,
+                    fallbackRequestID: httpResponse.value(forHTTPHeaderField: "x-request-id")
+                )
+            }
+
+            let payload = try JSONDecoder().decode(SuccessResponse.self, from: responseData)
+            let trimmedText = payload.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !trimmedText.isEmpty else {
+                AppLogger.error(
+                    "Relay transcription succeeded but response text was empty. requestID=\(clientRequestID) serverRequestID=\(httpResponse.value(forHTTPHeaderField: "x-request-id") ?? "missing")",
+                    category: .dictation
+                )
+                throw AIExecutionError.relayInvocationFailed(
+                    statusCode: httpResponse.statusCode,
+                    message: "The relay response did not contain any text.",
+                    requestID: httpResponse.value(forHTTPHeaderField: "x-request-id")
+                )
+            }
+
+            AppLogger.info(
+                "Relay transcription completed. requestID=\(clientRequestID) textLength=\(trimmedText.count)",
+                category: .dictation
+            )
+
+            return trimmedText
+        } catch let error as AIExecutionError {
+            AppLogger.error(
+                "Relay transcription failed with managed relay error. requestID=\(clientRequestID) error=\(error.localizedDescription)",
+                category: .dictation
+            )
+            throw error
+        } catch let error as URLError {
+            AppLogger.error(
+                "Relay transcription failed with URL error. requestID=\(clientRequestID) code=\(error.code.rawValue) description=\(error.localizedDescription)",
+                category: .dictation
+            )
+            throw AIExecutionError.relayInvocationFailed(
+                statusCode: nil,
+                message: error.localizedDescription,
+                requestID: nil
+            )
+        } catch {
+            AppLogger.error(
+                "Relay transcription failed with unexpected client error. requestID=\(clientRequestID) type=\(String(describing: type(of: error))) description=\(error.localizedDescription)",
+                category: .dictation
+            )
+            throw AIExecutionError.relayInvocationFailed(
+                statusCode: nil,
+                message: error.localizedDescription,
+                requestID: nil
+            )
+        }
+    }
+
+    private static func normalizedText(_ text: String?) -> String? {
+        guard let text = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else {
+            return nil
+        }
+
+        return text
+    }
+
+    private static func timeoutInterval(for audioDurationSeconds: TimeInterval?) -> TimeInterval {
+        guard let audioDurationSeconds,
+              audioDurationSeconds.isFinite,
+              audioDurationSeconds > 0 else {
+            return RequestPolicy.minimumTimeoutSeconds
+        }
+
+        let paddedTimeout = (audioDurationSeconds * RequestPolicy.timeoutPerAudioSecond) + RequestPolicy.timeoutBufferSeconds
+        return min(
+            max(paddedTimeout, RequestPolicy.minimumTimeoutSeconds),
+            RequestPolicy.maximumTimeoutSeconds
+        )
+    }
+
+    private static func makeRequest(
+        authentication: RelayAuthenticationContext,
+        audioData: Data,
+        fileType: AudioTranscriptionQuery.FileType,
+        languageCode: String?,
+        prompt: String?,
+        rewriteEnabled: Bool,
+        preferredSpellings: [String],
+        timeoutInterval: TimeInterval,
+        clientRequestID: String
+    ) throws -> URLRequest {
+        let url = authentication.relayBaseURL.appendingPathComponent("audio/transcriptions")
+        let multipart = MultipartFormRequestBody.make(
+            fields: makeFields(
+                languageCode: languageCode,
+                prompt: prompt,
+                rewriteEnabled: rewriteEnabled,
+                preferredSpellings: preferredSpellings
+            ),
+            file: MultipartFormFile(
+                name: "file",
+                fileName: fileType.stetFileName,
+                contentType: fileType.stetContentType,
+                data: audioData
+            )
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeoutInterval
+        request.httpBody = multipart.body
+        request.setValue(
+            "multipart/form-data; boundary=\(multipart.boundary)",
+            forHTTPHeaderField: "Content-Type"
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(authentication.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(authentication.publishableKey, forHTTPHeaderField: "Apikey")
+        request.setValue(String(multipart.body.count), forHTTPHeaderField: "Content-Length")
+        request.setValue(clientRequestID, forHTTPHeaderField: "x-request-id")
+        return request
+    }
+
+    private static func makeFields(
+        languageCode: String?,
+        prompt: String?,
+        rewriteEnabled: Bool,
+        preferredSpellings: [String]
+    ) -> [MultipartFormField] {
+        var fields: [MultipartFormField] = []
+
+        if let languageCode {
+            fields.append(.init(name: "language", value: languageCode))
+        }
+
+        if let prompt {
+            fields.append(.init(name: "prompt", value: prompt))
+        }
+
+        if rewriteEnabled {
+            fields.append(.init(name: "rewrite", value: "true"))
+        }
+
+        let normalizedPreferredSpellings = preferredSpellings
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        if !normalizedPreferredSpellings.isEmpty {
+            fields.append(
+                .init(
+                    name: "preferred_spellings",
+                    value: normalizedPreferredSpellings.joined(separator: ", ")
+                )
+            )
+        }
+
+        return fields
+    }
+
+    private static func mapRelayError(
+        statusCode: Int,
+        responseData: Data,
+        fallbackRequestID: String?
+    ) -> AIExecutionError {
+        if let payload = try? JSONDecoder().decode(ErrorResponse.self, from: responseData) {
+            let message = payload.code.map { "[\($0)] \(payload.message)" } ?? payload.message
+            return .relayInvocationFailed(
+                statusCode: statusCode,
+                message: message,
+                requestID: payload.request_id ?? fallbackRequestID
+            )
+        }
+
+        if let rawText = String(data: responseData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawText.isEmpty {
+            return .relayInvocationFailed(
+                statusCode: statusCode,
+                message: rawText,
+                requestID: fallbackRequestID
+            )
+        }
+
+        return .relayInvocationFailed(
+            statusCode: statusCode,
+            message: HTTPURLResponse.localizedString(forStatusCode: statusCode),
+            requestID: fallbackRequestID
+        )
+    }
+
+    private static func responsePreview(from data: Data) -> String {
+        guard let text = String(data: data, encoding: .utf8)?
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else {
+            return "<empty>"
+        }
+
+        let limit = 500
+        if text.count <= limit {
+            return text
+        }
+
+        let endIndex = text.index(text.startIndex, offsetBy: limit)
+        return "\(text[..<endIndex])…"
+    }
+}

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
@@ -7,6 +7,20 @@ struct MacOpenAISettingsView: View {
     var body: some View {
         Form {
             Section {
+                LabeledContent("Execution Mode") {
+                    Picker("Execution Mode", selection: $viewModel.executionMode) {
+                        ForEach(AIExecutionMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(width: 240)
+                }
+
+                Text(viewModel.executionModeDescription)
+                    .foregroundStyle(.secondary)
+
                 LabeledContent("Provider") {
                     Picker("Provider", selection: $viewModel.provider) {
                         ForEach(DictationProvider.allCases) { provider in
@@ -21,7 +35,7 @@ struct MacOpenAISettingsView: View {
                 LabeledContent("Connection") {
                     MacSettingsStatusBadge(
                         text: viewModel.connectionStatusText,
-                        tint: viewModel.shouldHighlightMissingCredential ? .orange : .green
+                        tint: viewModel.connectionNeedsAttention ? .orange : .green
                     )
                 }
             } header: {
@@ -55,22 +69,25 @@ struct MacOpenAISettingsView: View {
             }
 
             Section {
-                SecureField(viewModel.credentialPlaceholder, text: $viewModel.apiKey)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
+                Group {
+                    SecureField(viewModel.credentialPlaceholder, text: $viewModel.apiKey)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
 
-                HStack(spacing: 10) {
-                    Button("Save Key") {
-                        viewModel.saveCredential()
-                    }
+                    HStack(spacing: 10) {
+                        Button("Save Key") {
+                            viewModel.saveCredential()
+                        }
 
-                    Button("Clear Key", role: .destructive) {
-                        viewModel.clearCredential()
+                        Button("Clear Key", role: .destructive) {
+                            viewModel.clearCredential()
+                        }
                     }
                 }
+                .disabled(viewModel.isCredentialEditingDisabled)
 
-                if viewModel.shouldHighlightMissingCredential {
-                    Text("Add a \(viewModel.provider.displayName) API key before using cloud transcription, translation, or rewrite.")
+                if let missingCredentialMessage = viewModel.missingCredentialMessage {
+                    Text(missingCredentialMessage)
                         .foregroundStyle(.orange)
                 }
 
@@ -78,6 +95,8 @@ struct MacOpenAISettingsView: View {
                     .foregroundStyle(viewModel.credentialMessageIsError ? .red : .secondary)
             } header: {
                 Text(viewModel.credentialFieldTitle)
+            } footer: {
+                Text(viewModel.credentialSectionDescription)
             }
         }
         .formStyle(.grouped)

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
@@ -4,6 +4,13 @@ import Foundation
 
 @MainActor
 final class MacOpenAISettingsViewModel: ObservableObject {
+    @Published var executionMode: AIExecutionMode = .automatic {
+        didSet {
+            guard hasLoadedState else { return }
+            settingsStore.saveExecutionMode(executionMode)
+            updateCredentialMessage()
+        }
+    }
     @Published var provider: DictationProvider = .openAI {
         didSet {
             guard hasLoadedState else { return }
@@ -35,18 +42,33 @@ final class MacOpenAISettingsViewModel: ObservableObject {
     @Published private(set) var credentialMessageIsError = false
 
     private let settingsStore: DictationSettingsStore
+    private let relaySessionProvider: @MainActor @Sendable () -> Bool
     private var hasLoadedState = false
 
-    init(settingsStore: DictationSettingsStore = DictationSettingsStore()) {
+    init(
+        settingsStore: DictationSettingsStore = DictationSettingsStore(),
+        relaySessionProvider: @escaping @MainActor @Sendable () -> Bool = {
+            SupabaseService.shared.currentSession != nil
+        }
+    ) {
         self.settingsStore = settingsStore
+        self.relaySessionProvider = relaySessionProvider
     }
 
-    var shouldHighlightMissingCredential: Bool {
-        apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    var connectionNeedsAttention: Bool {
+        switch executionMode {
+        case .automatic:
+            return !hasRelaySession && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .managed:
+            return !hasRelaySession
+        case .byok:
+            return apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 
     func load() {
         hasLoadedState = false
+        executionMode = settingsStore.loadExecutionMode()
         provider = settingsStore.loadProvider()
         rewriteEnabled = settingsStore.loadRewriteEnabled()
         translationTargetLanguage = settingsStore.loadTranslationTargetLanguage()
@@ -57,7 +79,14 @@ final class MacOpenAISettingsViewModel: ObservableObject {
     }
 
     var connectionStatusText: String {
-        shouldHighlightMissingCredential ? "Missing Key" : "Configured"
+        switch executionMode {
+        case .automatic:
+            return hasRelaySession ? "Relay Active" : (connectionNeedsAttention ? "Missing Key" : "Direct Fallback")
+        case .managed:
+            return hasRelaySession ? "Relay Only" : "Sign In Required"
+        case .byok:
+            return connectionNeedsAttention ? "Missing Key" : "Configured"
+        }
     }
 
     func saveCredential() {
@@ -83,15 +112,36 @@ final class MacOpenAISettingsViewModel: ObservableObject {
 
     var modelSummary: String {
         let providerDefaults = OpenAIConfiguration.providerDefaults(for: provider)
-        return "Stet uses \(providerDefaults.transcriptionModel) for transcription and \(providerDefaults.translationModel) for translation and rewrite."
+        switch executionMode {
+        case .automatic:
+            return "Automatic uses Managed Relay for dictation while you are signed in. If you are signed out, Stet falls back to \(providerDefaults.transcriptionModel) for transcription and \(providerDefaults.translationModel) for direct translation and rewrite."
+        case .managed:
+            return "Managed Relay currently covers the dictation pipeline only. Local provider and API key settings are retained for Automatic fallback or BYOK."
+        case .byok:
+            return "BYOK uses \(providerDefaults.transcriptionModel) for transcription and \(providerDefaults.translationModel) for translation and rewrite."
+        }
     }
 
     var providerDescription: String {
-        "Choose between OpenAI and Groq. Stet manages the endpoint and model selection automatically."
+        switch executionMode {
+        case .automatic:
+            return "Automatic uses the provider below only when you are signed out and dictation falls back to the local API path."
+        case .managed:
+            return "Managed Relay ignores the provider below for dictation. Keep it configured for when you switch back to Automatic or BYOK."
+        case .byok:
+            return "BYOK uses the provider below as the active local API path. Stet still manages the endpoint and model selection automatically."
+        }
     }
 
     var rewriteToggleTitle: String {
-        "Rewrite final transcript with \(provider.displayName)"
+        switch executionMode {
+        case .automatic:
+            return "Rewrite final transcript automatically"
+        case .managed:
+            return "Rewrite final transcript with Managed Relay"
+        case .byok:
+            return "Rewrite final transcript with \(provider.displayName)"
+        }
     }
 
     var credentialFieldTitle: String {
@@ -102,11 +152,73 @@ final class MacOpenAISettingsViewModel: ObservableObject {
         provider.apiKeyPlaceholder
     }
 
+    var executionModeDescription: String {
+        executionMode.subtitle
+    }
+
+    var credentialSectionDescription: String {
+        switch executionMode {
+        case .automatic:
+            return "Automatic uses this local API key only when you are signed out and dictation falls back to the direct provider path."
+        case .managed:
+            return "Managed Relay does not use local provider credentials for dictation. Switch to Automatic or BYOK to use this key directly."
+        case .byok:
+            return "BYOK uses this provider and API key directly."
+        }
+    }
+
+    var missingCredentialMessage: String? {
+        switch executionMode {
+        case .automatic:
+            guard !hasRelaySession,
+                  apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return "Add a \(provider.displayName) API key to enable local dictation when you are signed out."
+        case .managed:
+            return hasRelaySession ? nil : "Sign in with your Stet account to use Managed Relay for dictation."
+        case .byok:
+            guard apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return "Add a \(provider.displayName) API key before using direct transcription, translation, or rewrite."
+        }
+    }
+
+    var isCredentialEditingDisabled: Bool {
+        executionMode == .managed
+    }
+
     private func updateCredentialMessage() {
-        credentialMessage = apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? "Add a \(provider.displayName) API key to enable cloud features."
-            : "\(provider.displayName) API key is saved in Keychain."
+        let hasCredential = !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        switch executionMode {
+        case .automatic:
+            if hasCredential {
+                credentialMessage = "\(provider.displayName) API key is saved in Keychain for local fallback."
+            } else if hasRelaySession {
+                credentialMessage = "Managed Relay is active for dictation. No local fallback key is currently saved."
+            } else {
+                credentialMessage = "No \(provider.displayName) API key is saved for local fallback."
+            }
+        case .managed:
+            if hasRelaySession {
+                credentialMessage = hasCredential
+                    ? "A \(provider.displayName) API key is saved in Keychain but ignored by Managed Relay."
+                    : "Managed Relay is active for dictation."
+            } else if hasCredential {
+                credentialMessage = "Sign in to use Managed Relay. A \(provider.displayName) API key is saved for future Automatic fallback or BYOK use."
+            } else {
+                credentialMessage = "Sign in to use Managed Relay. No local provider API key is saved."
+            }
+        case .byok:
+            credentialMessage = hasCredential
+                ? "\(provider.displayName) API key is saved in Keychain."
+                : "No \(provider.displayName) API key is saved in Keychain."
+        }
         credentialMessageIsError = false
+    }
+
+    private var hasRelaySession: Bool {
+        relaySessionProvider()
     }
 }
 #endif

--- a/apps/mac/Stet/Shared/Models/AIExecutionMode.swift
+++ b/apps/mac/Stet/Shared/Models/AIExecutionMode.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum AIExecutionMode: String, CaseIterable, Identifiable, Codable, Sendable {
+    case automatic
+    case managed
+    case byok
+
+    nonisolated var id: Self { self }
+
+    nonisolated var title: String {
+        switch self {
+        case .automatic:
+            return "Automatic"
+        case .managed:
+            return "Managed Relay"
+        case .byok:
+            return "BYOK"
+        }
+    }
+
+    nonisolated var subtitle: String {
+        switch self {
+        case .automatic:
+            return "Use Managed Relay for dictation when signed in. Otherwise fall back to the local provider API key."
+        case .managed:
+            return "Use the authenticated relay for dictation. Current relay coverage is limited to the dictation pipeline and requires a signed-in Supabase session."
+        case .byok:
+            return "Always use the local provider API key and bypass the relay."
+        }
+    }
+
+    nonisolated var requiresAuthenticatedSession: Bool {
+        self == .managed
+    }
+
+    nonisolated var requiresLocalAPIKey: Bool {
+        self == .byok
+    }
+}

--- a/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
+++ b/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
@@ -10,9 +10,10 @@ extension KeychainSecretStore: DictationSecretStore {}
 
 struct DictationSettingsSnapshot: Sendable {
     let provider: DictationProvider
+    let executionMode: AIExecutionMode
     let isRewriteEnabled: Bool
     let shouldPauseMediaDuringDictation: Bool
-    let openAIConfiguration: OpenAIConfiguration?
+    let providerConfiguration: OpenAIConfiguration?
     let translationTargetLanguage: TranslationTargetLanguage
     let translateSelectedTextOnTranslationHotkey: Bool
     let personalDictionary: [String]
@@ -20,8 +21,8 @@ struct DictationSettingsSnapshot: Sendable {
     let interactionSoundPreset: InteractionSoundPreset
     let proxySettings: NetworkProxySettings
 
-    var isOpenAIConfigured: Bool {
-        openAIConfiguration != nil
+    var hasLocalProviderConfiguration: Bool {
+        providerConfiguration != nil
     }
 }
 
@@ -61,6 +62,7 @@ struct DictationSettingsStore: Sendable {
 
     nonisolated func loadSnapshot() -> DictationSettingsSnapshot {
         let provider = loadProvider()
+        let executionMode = loadExecutionMode()
         let isRewriteEnabled = loadRewriteEnabled()
         let shouldPauseMediaDuringDictation =
             defaults.object(forKey: MacPreferences.pauseMediaDuringDictation) as? Bool ?? false
@@ -79,9 +81,10 @@ struct DictationSettingsStore: Sendable {
 
         return DictationSettingsSnapshot(
             provider: provider,
+            executionMode: executionMode,
             isRewriteEnabled: isRewriteEnabled,
             shouldPauseMediaDuringDictation: shouldPauseMediaDuringDictation,
-            openAIConfiguration: configuration,
+            providerConfiguration: configuration,
             translationTargetLanguage: translationTargetLanguage,
             translateSelectedTextOnTranslationHotkey: translateSelectedTextOnTranslationHotkey,
             personalDictionary: personalDictionary,
@@ -122,8 +125,17 @@ struct DictationSettingsStore: Sendable {
         return DictationProvider(rawValue: rawValue) ?? .openAI
     }
 
+    nonisolated func loadExecutionMode() -> AIExecutionMode {
+        let rawValue = defaults.string(forKey: MacPreferences.aiExecutionMode) ?? ""
+        return AIExecutionMode(rawValue: rawValue) ?? .automatic
+    }
+
     nonisolated func saveProvider(_ provider: DictationProvider) {
         defaults.set(provider.rawValue, forKey: MacPreferences.transcriptionProvider)
+    }
+
+    nonisolated func saveExecutionMode(_ mode: AIExecutionMode) {
+        defaults.set(mode.rawValue, forKey: MacPreferences.aiExecutionMode)
     }
 
     nonisolated func saveTranslationTargetLanguage(_ language: TranslationTargetLanguage) {

--- a/apps/mac/Stet/Shared/Utilities/MacConfigurationTransferManager.swift
+++ b/apps/mac/Stet/Shared/Utilities/MacConfigurationTransferManager.swift
@@ -19,6 +19,7 @@ enum MacConfigurationTransferManager {
         var version: Int
         var pauseMediaDuringDictation: Bool
         var transcriptionProvider: String
+        var aiExecutionMode: String?
         var rewriteEnabled: Bool
         var proxyMode: String?
         var customProxyScheme: String?
@@ -91,11 +92,12 @@ enum MacConfigurationTransferManager {
         let proxySettings = store.loadProxySettings()
 
         return ExportedConfiguration(
-            version: 4,
+            version: 5,
             pauseMediaDuringDictation: defaults.bool(forKey: MacPreferences.pauseMediaDuringDictation),
             transcriptionProvider: DictationProvider(
                 rawValue: defaults.string(forKey: MacPreferences.transcriptionProvider) ?? ""
             )?.rawValue ?? DictationProvider.openAI.rawValue,
+            aiExecutionMode: store.loadExecutionMode().rawValue,
             rewriteEnabled: defaults.bool(forKey: MacPreferences.rewriteEnabled),
             proxyMode: proxySettings.mode.rawValue,
             customProxyScheme: proxySettings.customScheme.rawValue,
@@ -134,6 +136,10 @@ enum MacConfigurationTransferManager {
             DictationProvider(rawValue: imported.transcriptionProvider)?.rawValue ?? DictationProvider.openAI.rawValue,
             forKey: MacPreferences.transcriptionProvider
         )
+        defaults.set(
+            AIExecutionMode(rawValue: imported.aiExecutionMode ?? "")?.rawValue ?? AIExecutionMode.automatic.rawValue,
+            forKey: MacPreferences.aiExecutionMode
+        )
         defaults.set(imported.rewriteEnabled, forKey: MacPreferences.rewriteEnabled)
         defaults.set(
             imported.translateSelectedTextOnTranslationHotkey,
@@ -148,6 +154,9 @@ enum MacConfigurationTransferManager {
         defaults.set(imported.hotkeyDistinguishModifierSides, forKey: MacPreferences.hotkeyDistinguishModifierSides)
 
         store.saveHotkeyDistinguishModifierSides(imported.hotkeyDistinguishModifierSides)
+        store.saveExecutionMode(
+            AIExecutionMode(rawValue: imported.aiExecutionMode ?? "") ?? .automatic
+        )
         store.saveTranslationTargetLanguage(
             TranslationTargetLanguage(rawValue: imported.translationTargetLanguage) ?? .english
         )

--- a/apps/mac/Stet/Shared/Utilities/MacPreferences.swift
+++ b/apps/mac/Stet/Shared/Utilities/MacPreferences.swift
@@ -3,6 +3,7 @@ import Foundation
 enum MacPreferences {
     nonisolated static let pauseMediaDuringDictation = "mac.pauseMediaDuringDictation"
     nonisolated static let transcriptionProvider = "mac.transcriptionProvider"
+    nonisolated static let aiExecutionMode = "mac.aiExecutionMode"
     nonisolated static let rewriteEnabled = "mac.rewriteEnabled"
     nonisolated static let proxyMode = "mac.proxyMode"
     nonisolated static let customProxyScheme = "mac.customProxyScheme"

--- a/apps/mac/StetTests/App/MacAppBootstrapperTests.swift
+++ b/apps/mac/StetTests/App/MacAppBootstrapperTests.swift
@@ -22,6 +22,7 @@ struct MacAppBootstrapperTests {
         #expect(launchConfiguration == .init(showInDock: false))
         #expect(!defaults.bool(forKey: MacPreferences.pauseMediaDuringDictation))
         #expect(defaults.string(forKey: MacPreferences.transcriptionProvider) == DictationProvider.openAI.rawValue)
+        #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.automatic.rawValue)
         #expect(defaults.string(forKey: MacPreferences.translationTargetLanguage) == TranslationTargetLanguage.english.rawValue)
         #expect(defaults.bool(forKey: MacPreferences.translateSelectedTextOnTranslationHotkey))
         #expect(!defaults.bool(forKey: MacPreferences.hotkeyDistinguishModifierSides))
@@ -48,6 +49,7 @@ struct MacAppBootstrapperTests {
         defaults.set("https://api.groq.com/openai/v1", forKey: "mac.openAIBaseURL")
         defaults.set("llama-3.3-70b-versatile", forKey: "mac.openAITranslationModel")
         defaults.set(true, forKey: MacPreferences.showInDock)
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
 
         let bootstrapper = MacAppBootstrapper(
             defaults: defaults,
@@ -59,6 +61,7 @@ struct MacAppBootstrapperTests {
         let launchConfiguration = bootstrapper.prepareForLaunch()
 
         #expect(launchConfiguration == .init(showInDock: true))
+        #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.managed.rawValue)
         #expect(defaults.object(forKey: "mac.copyLatestCaptureHotkeyShortcut") == nil)
         #expect(defaults.object(forKey: "mac.historyRetentionPeriod") == nil)
         #expect(defaults.object(forKey: "mac.showPanelOnLaunch") == nil)

--- a/apps/mac/StetTests/Core/ConfigurableSpeechServiceTests.swift
+++ b/apps/mac/StetTests/Core/ConfigurableSpeechServiceTests.swift
@@ -35,6 +35,42 @@ private actor CapturedPromptBox {
 @MainActor
 @Suite("Configurable Speech Service", .serialized)
 struct ConfigurableSpeechServiceTests {
+    private let relayAuthentication = RelayAuthenticationContext(
+        functionsBaseURL: URL(string: "https://example.supabase.co/functions/v1")!,
+        publishableKey: "anon-key",
+        accessToken: "access-token"
+    )
+
+    private func makeDependencies(
+        relayAuthentication: RelayAuthenticationContext? = nil,
+        makeNetworkSession: @escaping @Sendable (NetworkProxySettings) -> URLSession = { _ in
+            TestURLSessionFactory.makeSession()
+        },
+        directSpeech: ControllableSpeechService = ControllableSpeechService(),
+        relaySpeech: ControllableSpeechService = ControllableSpeechService(),
+        directPromptBox: CapturedPromptBox? = nil,
+        relayPromptBox: CapturedPromptBox? = nil,
+        rewriteService: RecordingRewriteService = RecordingRewriteService()
+    ) -> ConfigurableSpeechService.Dependencies {
+        .init(
+            relayAuthenticationContext: { relayAuthentication },
+            makeNetworkSession: makeNetworkSession,
+            makeDirectSpeechService: { _, _, _, promptProvider in
+                if let directPromptBox {
+                    await directPromptBox.set(await promptProvider())
+                }
+                return directSpeech
+            },
+            makeRelaySpeechService: { _, _, _, _, _, promptProvider in
+                if let relayPromptBox {
+                    await relayPromptBox.set(await promptProvider())
+                }
+                return relaySpeech
+            },
+            makeRewriteService: { _, _ in rewriteService }
+        )
+    }
+
     @Test func makeTranscriptionPromptIncludesPreferredSpellings() {
         let prompt = ConfigurableSpeechService.makeTranscriptionPrompt(
             preferredSpellings: ["OpenAI", "Groq"]
@@ -50,11 +86,12 @@ struct ConfigurableSpeechServiceTests {
         )
     }
 
-    @Test func openAIProviderRequiresAPIKey() async {
+    @Test func automaticWithoutSessionRequiresOpenAIAPIKey() async {
         let defaults = TestSupport.makeUserDefaults()
         defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
         let service = ConfigurableSpeechService(
-            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            dependencies: makeDependencies()
         )
 
         await #expect(throws: OpenAIError.missingAPIKey(provider: .openAI)) {
@@ -62,14 +99,29 @@ struct ConfigurableSpeechServiceTests {
         }
     }
 
-    @Test func groqProviderRequiresGroqAPIKey() async {
+    @Test func automaticWithoutSessionRequiresGroqAPIKey() async {
         let defaults = TestSupport.makeUserDefaults()
         defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
         let service = ConfigurableSpeechService(
-            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            dependencies: makeDependencies()
         )
 
         await #expect(throws: OpenAIError.missingAPIKey(provider: .groq)) {
+            try await service.startRecording()
+        }
+    }
+
+    @Test func managedModeRequiresAuthenticatedSession() async {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
+
+        let service = ConfigurableSpeechService(
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            dependencies: makeDependencies(relayAuthentication: nil)
+        )
+
+        await #expect(throws: AIExecutionError.managedRequiresAuthenticatedSession) {
             try await service.startRecording()
         }
     }
@@ -86,16 +138,15 @@ struct ConfigurableSpeechServiceTests {
         try secretStore.saveString("sk-test", forAccount: "openai.api_key")
         let settingsStore = DictationSettingsStore(defaults: defaults, secretStore: secretStore)
         let proxyBox = CapturedProxySettingsBox()
-        let speech = ControllableSpeechService()
+        let directSpeech = ControllableSpeechService()
         let service = ConfigurableSpeechService(
             settingsStore: settingsStore,
-            dependencies: .init(
+            dependencies: makeDependencies(
                 makeNetworkSession: { settings in
                     proxyBox.set(settings)
                     return TestURLSessionFactory.makeSession()
                 },
-                makeOpenAISpeechService: { _, _, _, _ in speech },
-                makeRewriteService: { _, _ in RecordingRewriteService() }
+                directSpeech: directSpeech
             )
         )
 
@@ -106,11 +157,12 @@ struct ConfigurableSpeechServiceTests {
         #expect(proxy.customScheme == .socks5)
         #expect(proxy.customHost == "localhost")
         #expect(proxy.customPort == 1080)
+        #expect(await directSpeech.counts().start == 1)
 
         await service.cancelRecording()
     }
 
-    @Test func openAIProviderSkipsTranscriptionPromptAndUsesRewriteService() async throws {
+    @Test func automaticWithoutSessionUsesDirectPathAndLocalRewrite() async throws {
         let defaults = TestSupport.makeUserDefaults()
         defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
         defaults.set(true, forKey: MacPreferences.rewriteEnabled)
@@ -119,21 +171,21 @@ struct ConfigurableSpeechServiceTests {
         let settingsStore = DictationSettingsStore(defaults: defaults, secretStore: secretStore)
         settingsStore.savePersonalDictionary(["OpenAI", "Groq"])
 
-        let openAISpeech = ControllableSpeechService()
-        await openAISpeech.setStopBehavior(.immediate("source transcript"))
+        let directSpeech = ControllableSpeechService()
+        await directSpeech.setStopBehavior(.immediate("source transcript"))
+        let relaySpeech = ControllableSpeechService()
         let rewriteService = RecordingRewriteService()
         await rewriteService.setResult("rewritten transcript")
-        let promptBox = CapturedPromptBox()
+        let directPromptBox = CapturedPromptBox()
 
         let service = ConfigurableSpeechService(
             settingsStore: settingsStore,
-            dependencies: .init(
-                makeNetworkSession: { _ in TestURLSessionFactory.makeSession() },
-                makeOpenAISpeechService: { _, _, _, promptProvider in
-                    await promptBox.set(await promptProvider())
-                    return openAISpeech
-                },
-                makeRewriteService: { _, _ in rewriteService }
+            dependencies: makeDependencies(
+                relayAuthentication: nil,
+                directSpeech: directSpeech,
+                relaySpeech: relaySpeech,
+                directPromptBox: directPromptBox,
+                rewriteService: rewriteService
             )
         )
 
@@ -144,51 +196,104 @@ struct ConfigurableSpeechServiceTests {
         #expect(result == "rewritten transcript")
         #expect(rewriteRequest.sourceText == "source transcript")
         #expect(rewriteRequest.systemPrompt?.contains("OpenAI, Groq") == true)
-        #expect(await promptBox.get() == nil)
+        #expect(await directPromptBox.get() == nil)
+        #expect(await directSpeech.counts().start == 1)
+        #expect(await relaySpeech.counts().start == 0)
     }
 
-    @Test func groqProviderSkipsTranscriptionPrompt() async throws {
+    @Test func automaticWithSessionPrefersRelayEvenWhenLocalKeyExists() async throws {
         let defaults = TestSupport.makeUserDefaults()
-        defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
+        defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
         let secretStore = TestSecretStore()
-        try secretStore.saveString("gsk-test", forAccount: "groq.api_key")
-        let settingsStore = DictationSettingsStore(defaults: defaults, secretStore: secretStore)
-        settingsStore.savePersonalDictionary(["OpenAI", "Groq"])
+        try secretStore.saveString("sk-test", forAccount: "openai.api_key")
 
-        let groqSpeech = ControllableSpeechService()
-        let promptBox = CapturedPromptBox()
-
+        let directSpeech = ControllableSpeechService()
+        let relaySpeech = ControllableSpeechService()
         let service = ConfigurableSpeechService(
-            settingsStore: settingsStore,
-            dependencies: .init(
-                makeNetworkSession: { _ in TestURLSessionFactory.makeSession() },
-                makeOpenAISpeechService: { _, _, _, promptProvider in
-                    await promptBox.set(await promptProvider())
-                    return groqSpeech
-                },
-                makeRewriteService: { _, _ in RecordingRewriteService() }
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore),
+            dependencies: makeDependencies(
+                relayAuthentication: relayAuthentication,
+                directSpeech: directSpeech,
+                relaySpeech: relaySpeech
             )
         )
 
         try await service.startRecording()
 
-        #expect(await promptBox.get() == nil)
+        #expect(await directSpeech.counts().start == 0)
+        #expect(await relaySpeech.counts().start == 1)
 
         await service.cancelRecording()
     }
 
+    @Test func automaticWithSessionDoesNotFallbackAfterRelayFailure() async throws {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
+        let secretStore = TestSecretStore()
+        try secretStore.saveString("sk-test", forAccount: "openai.api_key")
+
+        let directSpeech = ControllableSpeechService()
+        let relaySpeech = ControllableSpeechService()
+        await relaySpeech.setStopBehavior(.fail(TestError.expected))
+
+        let service = ConfigurableSpeechService(
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore),
+            dependencies: makeDependencies(
+                relayAuthentication: relayAuthentication,
+                directSpeech: directSpeech,
+                relaySpeech: relaySpeech
+            )
+        )
+
+        try await service.startRecording()
+        await #expect(throws: TestError.expected) {
+            try await service.stopRecording()
+        }
+
+        #expect(await directSpeech.counts().start == 0)
+        #expect(await directSpeech.counts().stop == 0)
+        #expect(await relaySpeech.counts().start == 1)
+        #expect(await relaySpeech.counts().stop == 1)
+    }
+
+    @Test func relayPathBuildsTranscriptionPromptAndSkipsLocalRewrite() async throws {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
+        defaults.set(true, forKey: MacPreferences.rewriteEnabled)
+        let settingsStore = DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
+        settingsStore.savePersonalDictionary(["OpenAI", "Groq"])
+
+        let relaySpeech = ControllableSpeechService()
+        await relaySpeech.setStopBehavior(.immediate("relay transcript"))
+        let rewriteService = RecordingRewriteService()
+        let relayPromptBox = CapturedPromptBox()
+
+        let service = ConfigurableSpeechService(
+            settingsStore: settingsStore,
+            dependencies: makeDependencies(
+                relayAuthentication: relayAuthentication,
+                relaySpeech: relaySpeech,
+                relayPromptBox: relayPromptBox,
+                rewriteService: rewriteService
+            )
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result == "relay transcript")
+        #expect(await rewriteService.recordedRequests().isEmpty)
+        #expect(await relayPromptBox.get()?.contains("OpenAI, Groq") == true)
+    }
+
     @Test func emptyTranscriptThrowsEmptyTranscription() async throws {
-        let speech = ControllableSpeechService()
-        await speech.setStopBehavior(.immediate("   "))
+        let directSpeech = ControllableSpeechService()
+        await directSpeech.setStopBehavior(.immediate("   "))
         let secretStore = TestSecretStore()
         try secretStore.saveString("sk-test", forAccount: "openai.api_key")
         let service = ConfigurableSpeechService(
             settingsStore: DictationSettingsStore(defaults: TestSupport.makeUserDefaults(), secretStore: secretStore),
-            dependencies: .init(
-                makeNetworkSession: { _ in TestURLSessionFactory.makeSession() },
-                makeOpenAISpeechService: { _, _, _, _ in speech },
-                makeRewriteService: { _, _ in RecordingRewriteService() }
-            )
+            dependencies: makeDependencies(directSpeech: directSpeech)
         )
 
         try await service.startRecording()

--- a/apps/mac/StetTests/Core/RelayDictationTranscriptionServiceTests.swift
+++ b/apps/mac/StetTests/Core/RelayDictationTranscriptionServiceTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import Stet
+
+@Suite("Relay Dictation Transcription Service", .serialized)
+struct RelayDictationTranscriptionServiceTests {
+    private let authentication = RelayAuthenticationContext(
+        functionsBaseURL: URL(string: "https://example.supabase.co/functions/v1")!,
+        publishableKey: "anon-key",
+        accessToken: "access-token"
+    )
+
+    @Test func transcribeBuildsManagedRelayMultipartRequest() async throws {
+        let fileURL = TestSupport.temporaryFileURL("relay-upload", ext: "wav")
+        try Data("wav-data".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        var capturedRequest: URLRequest?
+        URLProtocolStub.configure { request in
+            capturedRequest = request
+            return (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["x-request-id": "req_success"]
+                )!,
+                Data(#"{"text":"Relay transcript","rewritten":true}"#.utf8)
+            )
+        }
+        defer { URLProtocolStub.reset() }
+
+        let service = RelayDictationTranscriptionService(
+            authentication: authentication,
+            session: TestURLSessionFactory.makeSession(),
+            rewriteEnabled: true,
+            preferredSpellings: ["OpenAI", "Groq"]
+        )
+
+        let result = try await service.transcribe(
+            audioFileAt: fileURL,
+            languageCode: "en",
+            prompt: "Use OpenAI and Groq exactly.",
+            audioDurationSeconds: 4
+        )
+
+        let request = try #require(capturedRequest)
+        let requestBody = try TestSupport.requestBodyData(from: request)
+        let requestBodyText = try #require(String(data: requestBody, encoding: .utf8))
+
+        #expect(result == "Relay transcript")
+        #expect(request.url?.absoluteString == "https://example.supabase.co/functions/v1/relay/v1/audio/transcriptions")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer access-token")
+        #expect(request.value(forHTTPHeaderField: "Apikey") == "anon-key")
+        #expect(request.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data; boundary=") == true)
+        #expect(requestBodyText.contains("name=\"rewrite\""))
+        #expect(requestBodyText.contains("\r\ntrue\r\n"))
+        #expect(requestBodyText.contains("name=\"preferred_spellings\""))
+        #expect(requestBodyText.contains("OpenAI, Groq"))
+        #expect(requestBodyText.contains("name=\"language\""))
+        #expect(requestBodyText.contains("\r\nen\r\n"))
+        #expect(requestBodyText.contains("name=\"prompt\""))
+        #expect(requestBodyText.contains("Use OpenAI and Groq exactly."))
+        #expect(requestBodyText.contains("name=\"file\"; filename=\"speech.wav\""))
+    }
+
+    @Test func transcribeMapsRelayErrors() async {
+        let fileURL = TestSupport.temporaryFileURL("relay-upload-error", ext: "wav")
+        try? Data("wav-data".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        URLProtocolStub.configure { request in
+            (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 429,
+                    httpVersion: nil,
+                    headerFields: ["x-request-id": "req_error"]
+                )!,
+                Data(#"{"code":"quota_error","message":"quota exceeded","request_id":"req_payload"}"#.utf8)
+            )
+        }
+        defer { URLProtocolStub.reset() }
+
+        let service = RelayDictationTranscriptionService(
+            authentication: authentication,
+            session: TestURLSessionFactory.makeSession(),
+            rewriteEnabled: false,
+            preferredSpellings: []
+        )
+
+        await #expect(throws: AIExecutionError.relayInvocationFailed(
+            statusCode: 429,
+            message: "quota exceeded",
+            requestID: "req_payload"
+        )) {
+            try await service.transcribe(
+                audioFileAt: fileURL,
+                languageCode: nil,
+                prompt: nil,
+                audioDurationSeconds: nil
+            )
+        }
+    }
+
+    @Test func transcribeRejectsSuccessfulPayloadWithoutText() async {
+        let fileURL = TestSupport.temporaryFileURL("relay-upload-empty", ext: "wav")
+        try? Data("wav-data".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        URLProtocolStub.configure { request in
+            (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["x-request-id": "req_empty"]
+                )!,
+                Data(#"{"text":"   ","rewritten":false}"#.utf8)
+            )
+        }
+        defer { URLProtocolStub.reset() }
+
+        let service = RelayDictationTranscriptionService(
+            authentication: authentication,
+            session: TestURLSessionFactory.makeSession(),
+            rewriteEnabled: false,
+            preferredSpellings: []
+        )
+
+        await #expect(throws: AIExecutionError.relayInvocationFailed(
+            statusCode: 200,
+            message: "The relay response did not contain any text.",
+            requestID: "req_empty"
+        )) {
+            try await service.transcribe(
+                audioFileAt: fileURL,
+                languageCode: nil,
+                prompt: nil,
+                audioDurationSeconds: nil
+            )
+        }
+    }
+}

--- a/apps/mac/StetTests/Core/TranscriptionHistoryStoreTests.swift
+++ b/apps/mac/StetTests/Core/TranscriptionHistoryStoreTests.swift
@@ -11,6 +11,7 @@ struct MacOpenAISettingsViewModelTests {
         let defaults = TestSupport.makeUserDefaults()
         let secretStore = TestSecretStore()
         try secretStore.saveString("gsk-live", forAccount: "groq.api_key")
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
         defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
         defaults.set(true, forKey: MacPreferences.rewriteEnabled)
         defaults.set(
@@ -20,17 +21,19 @@ struct MacOpenAISettingsViewModelTests {
         defaults.set(false, forKey: MacPreferences.translateSelectedTextOnTranslationHotkey)
 
         let viewModel = MacOpenAISettingsViewModel(
-            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore)
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore),
+            relaySessionProvider: { true }
         )
 
         viewModel.load()
 
+        #expect(viewModel.executionMode == .managed)
         #expect(viewModel.provider == .groq)
         #expect(viewModel.rewriteEnabled)
         #expect(viewModel.translationTargetLanguage == .german)
         #expect(!viewModel.translateSelectedTextOnTranslationHotkey)
         #expect(viewModel.apiKey == "gsk-live")
-        #expect(viewModel.connectionStatusText == "Configured")
+        #expect(viewModel.connectionStatusText == "Relay Only")
     }
 
     @Test func switchingProviderLoadsProviderSpecificCredential() throws {
@@ -40,7 +43,8 @@ struct MacOpenAISettingsViewModelTests {
         try secretStore.saveString("gsk-groq", forAccount: "groq.api_key")
 
         let viewModel = MacOpenAISettingsViewModel(
-            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore)
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: secretStore),
+            relaySessionProvider: { false }
         )
         viewModel.load()
 
@@ -55,18 +59,61 @@ struct MacOpenAISettingsViewModelTests {
         let defaults = TestSupport.makeUserDefaults()
         let secretStore = TestSecretStore()
         let store = DictationSettingsStore(defaults: defaults, secretStore: secretStore)
-        let viewModel = MacOpenAISettingsViewModel(settingsStore: store)
+        let viewModel = MacOpenAISettingsViewModel(settingsStore: store, relaySessionProvider: { false })
 
         viewModel.load()
         viewModel.apiKey = "  sk-live  "
         viewModel.saveCredential()
 
         #expect(store.loadOpenAIAPIKey() == "sk-live")
-        #expect(viewModel.connectionStatusText == "Configured")
+        #expect(viewModel.connectionStatusText == "Direct Fallback")
 
         viewModel.clearCredential()
         #expect(store.loadOpenAIAPIKey().isEmpty)
         #expect(viewModel.connectionStatusText == "Missing Key")
+    }
+
+    @Test func changingExecutionModePersistsSelection() {
+        let defaults = TestSupport.makeUserDefaults()
+        let viewModel = MacOpenAISettingsViewModel(
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            relaySessionProvider: { false }
+        )
+
+        viewModel.load()
+        viewModel.executionMode = .byok
+
+        #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.byok.rawValue)
+    }
+
+    @Test func managedModeWithoutRelaySessionShowsSignInRequired() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
+
+        let viewModel = MacOpenAISettingsViewModel(
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            relaySessionProvider: { false }
+        )
+
+        viewModel.load()
+
+        #expect(viewModel.connectionStatusText == "Sign In Required")
+        #expect(viewModel.connectionNeedsAttention)
+        #expect(viewModel.missingCredentialMessage == "Sign in with your Stet account to use Managed Relay for dictation.")
+    }
+
+    @Test func automaticModeWithRelaySessionShowsRelayActiveWithoutKey() {
+        let defaults = TestSupport.makeUserDefaults()
+        let viewModel = MacOpenAISettingsViewModel(
+            settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+            relaySessionProvider: { true }
+        )
+
+        viewModel.load()
+
+        #expect(viewModel.connectionStatusText == "Relay Active")
+        #expect(!viewModel.connectionNeedsAttention)
+        #expect(viewModel.missingCredentialMessage == nil)
     }
 }
 #endif

--- a/apps/mac/StetTests/Shared/DictationSettingsStoreTests.swift
+++ b/apps/mac/StetTests/Shared/DictationSettingsStoreTests.swift
@@ -36,10 +36,11 @@ struct DictationSettingsStoreTests {
         let snapshot = store.loadSnapshot()
 
         #expect(snapshot.provider == .openAI)
+        #expect(snapshot.executionMode == .automatic)
         #expect(snapshot.isRewriteEnabled == false)
         #expect(snapshot.translationTargetLanguage == .english)
         #expect(snapshot.personalDictionary.isEmpty)
-        #expect(snapshot.openAIConfiguration == nil)
+        #expect(snapshot.providerConfiguration == nil)
         #expect(snapshot.proxySettings.mode == .system)
         #expect(snapshot.proxySettings.customScheme == .http)
     }
@@ -72,10 +73,12 @@ struct DictationSettingsStoreTests {
         let defaults = TestSupport.makeUserDefaults()
         let store = makeStore(defaults: defaults)
 
+        store.saveExecutionMode(.managed)
         store.saveTranslationTargetLanguage(.japanese)
         store.saveTranslateSelectedTextOnTranslationHotkey(false)
         store.savePersonalDictionary([" OpenAI ", "groq", "Groq"])
 
+        #expect(store.loadExecutionMode() == .managed)
         #expect(store.loadTranslationTargetLanguage() == .japanese)
         #expect(store.loadTranslateSelectedTextOnTranslationHotkey() == false)
         #expect(store.loadPersonalDictionary() == ["OpenAI", "groq"])
@@ -110,14 +113,16 @@ struct DictationSettingsStoreTests {
         let secretStore = TestSecretStore()
         try secretStore.saveString("sk-live", forAccount: "openai.api_key")
         defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
+        defaults.set(AIExecutionMode.byok.rawValue, forKey: MacPreferences.aiExecutionMode)
         defaults.set(true, forKey: MacPreferences.rewriteEnabled)
         defaults.set(TranslationTargetLanguage.german.rawValue, forKey: MacPreferences.translationTargetLanguage)
 
         let store = makeStore(defaults: defaults, secretStore: secretStore)
         let snapshot = store.loadSnapshot()
 
-        let configuration = try #require(snapshot.openAIConfiguration)
+        let configuration = try #require(snapshot.providerConfiguration)
         #expect(snapshot.provider == .openAI)
+        #expect(snapshot.executionMode == .byok)
         #expect(snapshot.isRewriteEnabled)
         #expect(snapshot.translationTargetLanguage == .german)
         #expect(configuration.apiKey == "sk-live")
@@ -130,12 +135,14 @@ struct DictationSettingsStoreTests {
         let secretStore = TestSecretStore()
         try secretStore.saveString("gsk-live", forAccount: "groq.api_key")
         defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
+        defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
 
         let store = makeStore(defaults: defaults, secretStore: secretStore)
         let snapshot = store.loadSnapshot()
 
-        let configuration = try #require(snapshot.openAIConfiguration)
+        let configuration = try #require(snapshot.providerConfiguration)
         #expect(snapshot.provider == .groq)
+        #expect(snapshot.executionMode == .managed)
         #expect(configuration.apiKey == "gsk-live")
         #expect(configuration.baseURL.absoluteString == "https://api.groq.com/openai/v1")
         #expect(configuration.transcriptionModel == "whisper-large-v3-turbo")

--- a/apps/mac/StetTests/Shared/MacConfigurationTransferManagerTests.swift
+++ b/apps/mac/StetTests/Shared/MacConfigurationTransferManagerTests.swift
@@ -16,6 +16,7 @@ struct MacConfigurationTransferManagerTests {
         sourceDefaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
         sourceDefaults.set(true, forKey: MacPreferences.showInDock)
         sourceDefaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
+        sourceDefaults.set(AIExecutionMode.byok.rawValue, forKey: MacPreferences.aiExecutionMode)
         sourceStore.saveProxySettings(
             .init(
                 mode: .custom,
@@ -46,6 +47,8 @@ struct MacConfigurationTransferManagerTests {
         #expect(targetDefaults.bool(forKey: MacPreferences.pauseMediaDuringDictation))
         #expect(targetDefaults.bool(forKey: MacPreferences.showInDock))
         #expect(targetDefaults.string(forKey: MacPreferences.transcriptionProvider) == DictationProvider.openAI.rawValue)
+        #expect(targetDefaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.byok.rawValue)
+        #expect(targetStore.loadExecutionMode() == .byok)
         #expect(targetStore.loadTranslationTargetLanguage() == .french)
         #expect(targetStore.loadPersonalDictionary() == ["OpenAI", "Groq"])
         #expect(targetStore.loadProxySettings().mode == .custom)
@@ -80,6 +83,7 @@ struct MacConfigurationTransferManagerTests {
             JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
 
+        #expect(payload["aiExecutionMode"] as? String == AIExecutionMode.automatic.rawValue)
         #expect(payload["proxyMode"] as? String == NetworkProxyMode.disabled.rawValue)
         #expect(payload["customProxyScheme"] as? String == CustomProxyScheme.http.rawValue)
         #expect(payload["customProxyHost"] as? String == "")


### PR DESCRIPTION
## Summary
- add execution mode modeling and persistence for automatic / managed / BYOK routing
- route managed dictation through the relay transcription client instead of the direct provider path
- add focused tests for relay routing, multipart request building, and settings persistence
