### PR TITLE
Fix mac dictation audio lifecycle and playback timing

### DIFF
--- a/apps/mac/Stet/App/Lifecycle/MacAppBehaviorController.swift
+++ b/apps/mac/Stet/App/Lifecycle/MacAppBehaviorController.swift
@@ -5,7 +5,8 @@ import ServiceManagement
 enum MacAppBehaviorController {
     @MainActor
     static func applyDockVisibility(showInDock: Bool) {
-        NSApp.setActivationPolicy(showInDock ? .regular : .accessory)
+        // `NSApp` can still be nil while the SwiftUI `App` type is initializing.
+        NSApplication.shared.setActivationPolicy(showInDock ? .regular : .accessory)
         AppLogger.info("Dock visibility updated: showInDock=\(showInDock)")
     }
 

--- a/apps/mac/Stet/App/Lifecycle/MacAppContracts.swift
+++ b/apps/mac/Stet/App/Lifecycle/MacAppContracts.swift
@@ -22,6 +22,7 @@ protocol MacDictationPanelCoordinating: MacAppStatusObserving {
     var statusText: String { get }
     var recordingLevel: Double { get }
     func hidePanel()
+    func dismissPendingCopy()
     func cancelActiveCapture()
     func performPrimaryAction()
 }

--- a/apps/mac/Stet/App/Lifecycle/MacAppModel.swift
+++ b/apps/mac/Stet/App/Lifecycle/MacAppModel.swift
@@ -85,6 +85,8 @@ final class MacAppModel: ObservableObject, MacDictationCommandsCoordinating, Mac
             return "Stop Recording"
         case .processing:
             return "Processing"
+        case .clipboardPending:
+            return "Copy to Clipboard"
         case .result, .error:
             return "Start Again"
         }
@@ -168,6 +170,8 @@ final class MacAppModel: ObservableObject, MacDictationCommandsCoordinating, Mac
             return "Live"
         case .processing:
             return "Finishing"
+        case .clipboardPending:
+            return "Copy"
         case .result:
             return "Captured"
         case .error:
@@ -213,6 +217,10 @@ final class MacAppModel: ObservableObject, MacDictationCommandsCoordinating, Mac
 
     func hidePanel() {
         sessionController.hidePanel()
+    }
+
+    func dismissPendingCopy() {
+        sessionController.dismissPendingCopy()
     }
 
     func togglePanel() {

--- a/apps/mac/Stet/App/Windowing/MacDictationPanelLayout.swift
+++ b/apps/mac/Stet/App/Windowing/MacDictationPanelLayout.swift
@@ -2,41 +2,41 @@
 import AppKit
 
 struct MacDictationPanelLayout {
-    let panelSize: CGSize
-    let capsuleSize: CGSize
+    let panelWidth: CGFloat
+    let collapsedPanelHeight: CGFloat
+    let expandedPanelHeight: CGFloat
     let bottomInset: CGFloat
-    let horizontalPadding: CGFloat
-    let verticalPadding: CGFloat
-    let controlButtonSize: CGFloat
-    let controlSymbolSize: CGFloat
-    let statusFontSize: CGFloat
-    let secondaryFontSize: CGFloat
-    let voiceBarHeight: CGFloat
+    let scale: CGFloat
+
+    func panelSize(for state: DictationState) -> CGSize {
+        CGSize(
+            width: panelWidth,
+            height: isExpanded(state) ? expandedPanelHeight : collapsedPanelHeight
+        )
+    }
+
+    private func isExpanded(_ state: DictationState) -> Bool {
+        if case .clipboardPending = state {
+            return true
+        }
+
+        return false
+    }
 
     static let standard = MacDictationPanelLayout(
-        panelSize: CGSize(width: 304, height: 76),
-        capsuleSize: CGSize(width: 280, height: 48),
-        bottomInset: 52,
-        horizontalPadding: 10,
-        verticalPadding: 6,
-        controlButtonSize: 34,
-        controlSymbolSize: 15,
-        statusFontSize: 12,
-        secondaryFontSize: 10,
-        voiceBarHeight: 20
+        panelWidth: 460,
+        collapsedPanelHeight: 92,
+        expandedPanelHeight: 140,
+        bottomInset: 18,
+        scale: 1
     )
 
     static let compact = MacDictationPanelLayout(
-        panelSize: CGSize(width: 292, height: 72),
-        capsuleSize: CGSize(width: 268, height: 44),
-        bottomInset: 44,
-        horizontalPadding: 9,
-        verticalPadding: 6,
-        controlButtonSize: 32,
-        controlSymbolSize: 14,
-        statusFontSize: 11,
-        secondaryFontSize: 10,
-        voiceBarHeight: 18
+        panelWidth: 424,
+        collapsedPanelHeight: 86,
+        expandedPanelHeight: 129,
+        bottomInset: 14,
+        scale: 0.92
     )
 
     static func `for`(screen: NSScreen?) -> MacDictationPanelLayout {

--- a/apps/mac/Stet/App/Windowing/MacPanelController.swift
+++ b/apps/mac/Stet/App/Windowing/MacPanelController.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import AppKit
+import Combine
 import SwiftUI
 
 @MainActor
@@ -17,13 +18,18 @@ final class MacPanelController: NSObject, NSWindowDelegate {
     }
 
     private var panel: NSPanel?
+    private weak var observedAppModel: (any MacDictationPanelCoordinating)?
+    private var panelStateCancellable: AnyCancellable?
 
     func show(appModel: any MacDictationPanelCoordinating, mode: PresentationMode) {
         let screen = targetScreen()
         let layout = MacDictationPanelLayout.for(screen: screen)
+        let panelSize = layout.panelSize(for: appModel.dictationState)
+
+        observePanelState(for: appModel)
 
         if panel == nil {
-            panel = makePanel(appModel: appModel, layout: layout)
+            panel = makePanel(appModel: appModel, layout: layout, panelSize: panelSize)
         }
 
         guard let panel else { return }
@@ -32,7 +38,13 @@ final class MacPanelController: NSObject, NSWindowDelegate {
             rootView: MacDictationPanelView(layout: layout, appModel: appModel)
         )
 
-        positionPanel(panel, screen: screen, layout: layout)
+        positionPanel(
+            panel,
+            screen: screen,
+            panelSize: panelSize,
+            bottomInset: layout.bottomInset,
+            animate: false
+        )
         panel.orderFrontRegardless()
 
         if mode == .manual {
@@ -50,9 +62,13 @@ final class MacPanelController: NSObject, NSWindowDelegate {
         return false
     }
 
-    private func makePanel(appModel: any MacDictationPanelCoordinating, layout: MacDictationPanelLayout) -> NSPanel {
+    private func makePanel(
+        appModel: any MacDictationPanelCoordinating,
+        layout: MacDictationPanelLayout,
+        panelSize: CGSize
+    ) -> NSPanel {
         let panel = CapsulePanel(
-            contentRect: NSRect(origin: .zero, size: layout.panelSize),
+            contentRect: NSRect(origin: .zero, size: panelSize),
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -81,22 +97,28 @@ final class MacPanelController: NSObject, NSWindowDelegate {
         return panel
     }
 
-    private func positionPanel(_ panel: NSPanel, screen: NSScreen?, layout: MacDictationPanelLayout) {
+    private func positionPanel(
+        _ panel: NSPanel,
+        screen: NSScreen?,
+        panelSize: CGSize,
+        bottomInset: CGFloat,
+        animate: Bool
+    ) {
         guard let screen else {
-            panel.setContentSize(layout.panelSize)
+            panel.setContentSize(panelSize)
             panel.center()
             return
         }
 
         let visibleFrame = screen.visibleFrame
         let frame = NSRect(
-            x: visibleFrame.midX - (layout.panelSize.width / 2),
-            y: visibleFrame.minY + layout.bottomInset,
-            width: layout.panelSize.width,
-            height: layout.panelSize.height
+            x: visibleFrame.midX - (panelSize.width / 2),
+            y: visibleFrame.minY + bottomInset,
+            width: panelSize.width,
+            height: panelSize.height
         )
 
-        panel.setFrame(frame, display: false)
+        panel.setFrame(frame, display: true, animate: animate)
     }
 
     private func targetScreen() -> NSScreen? {
@@ -107,6 +129,31 @@ final class MacPanelController: NSObject, NSWindowDelegate {
         }
 
         return NSScreen.main ?? NSScreen.screens.first
+    }
+
+    private func observePanelState(for appModel: any MacDictationPanelCoordinating) {
+        guard observedAppModel !== appModel else { return }
+
+        observedAppModel = appModel
+        panelStateCancellable = appModel.updates
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak appModel] _ in
+                DispatchQueue.main.async { [weak self, weak appModel] in
+                    guard let self, let appModel, let panel = self.panel else { return }
+
+                    let screen = panel.screen ?? self.targetScreen()
+                    let layout = MacDictationPanelLayout.for(screen: screen)
+                    let panelSize = layout.panelSize(for: appModel.dictationState)
+
+                    self.positionPanel(
+                        panel,
+                        screen: screen,
+                        panelSize: panelSize,
+                        bottomInset: layout.bottomInset,
+                        animate: panel.isVisible
+                    )
+                }
+            }
     }
 }
 #endif

--- a/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
+++ b/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
@@ -298,9 +298,7 @@ final class MacAppSessionController {
         case .listening, .error:
             showTransientPanel()
         case .clipboardPending:
-            if !isPanelVisible {
-                showTransientPanel()
-            }
+            showTransientPanel()
         case .idle:
             guard workflowController.activeRecordingSource == nil else { return }
             workflowController.resetWorkflowIfNeeded()

--- a/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
+++ b/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
@@ -17,7 +17,7 @@ final class MacAppSessionController {
     private let notificationCenter: NotificationCenter
     private let hotkeyRegistrar: any MacDictationHotkeyRegistering
     private var cancellables = Set<AnyCancellable>()
-    private var stateResetTask: Task<Void, Never>?
+    private var completionHandlingTask: Task<Void, Never>?
     private var hotkeyInteraction = MacDictationHotkeyInteraction()
     private var previousDictationState: DictationState = .idle
     private weak var presentationModel: (any MacAppPresentationModeling)?
@@ -157,6 +157,16 @@ final class MacAppSessionController {
         shellPresentationController.hidePanel()
     }
 
+    func dismissPendingCopy() {
+        guard case .clipboardPending = dictationState else {
+            hidePanel()
+            return
+        }
+
+        hidePanel()
+        workflowController.dictationViewModel.send(.resetTapped)
+    }
+
     func togglePanel() {
         guard hasRequiredPermissions || isPanelVisible else {
             presentRequiredPermissionsGateIfNeeded()
@@ -211,6 +221,8 @@ final class MacAppSessionController {
         switch dictationState {
         case .idle, .result, .error:
             requestDictationCaptureStart(from: source)
+        case .clipboardPending(let text):
+            commitPendingCopy(text)
         case .listening:
             requestDictationCaptureStopIfListening()
         case .processing:
@@ -285,6 +297,10 @@ final class MacAppSessionController {
         switch state {
         case .listening, .error:
             showTransientPanel()
+        case .clipboardPending:
+            if !isPanelVisible {
+                showTransientPanel()
+            }
         case .idle:
             guard workflowController.activeRecordingSource == nil else { return }
             workflowController.resetWorkflowIfNeeded()
@@ -298,31 +314,34 @@ final class MacAppSessionController {
         guard case .result(let text) = state else { return }
 
         let completedWorkflow = workflowController.activeWorkflow
-        Task { @MainActor [weak self] in
+        completionHandlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await workflowController.handleCompletedResult(
+            let outcome = await workflowController.handleCompletedResult(
                 text: text,
                 workflow: completedWorkflow,
                 showTransientPanel: showTransientPanel
             )
-        }
 
-        scheduleStateReset()
+            guard !Task.isCancelled else { return }
+            guard case .result = dictationState else { return }
+
+            switch outcome {
+            case .completed:
+                hidePanel()
+                workflowController.dictationViewModel.send(.resetTapped)
+            case .clipboardPending:
+                if !isPanelVisible {
+                    showTransientPanel()
+                }
+                workflowController.dictationViewModel.send(.clipboardPending(text))
+            }
+        }
     }
 
     private func cancelPendingStateTasks() {
-        stateResetTask?.cancel()
-        stateResetTask = nil
+        completionHandlingTask?.cancel()
+        completionHandlingTask = nil
         shellPresentationController.cancelScheduledPanelHide()
-    }
-
-    private func scheduleStateReset() {
-        stateResetTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(900))
-            guard let self else { return }
-            guard case .result = dictationState else { return }
-            workflowController.dictationViewModel.send(.resetTapped)
-        }
     }
 
     private func scheduleTransientPanelHideIfNeeded() {
@@ -364,7 +383,7 @@ final class MacAppSessionController {
         case .result, .error:
             workflowController.dictationViewModel.send(.resetTapped)
             startDictationCapture(from: source)
-        case .listening, .processing:
+        case .clipboardPending, .listening, .processing:
             break
         }
     }
@@ -379,6 +398,12 @@ final class MacAppSessionController {
     private func requestDictationCaptureStopIfListening() {
         guard case .listening = dictationState else { return }
         workflowController.stopActiveCapture()
+    }
+
+    private func commitPendingCopy(_ text: String) {
+        workflowController.copyPendingResultToClipboard(text)
+        hidePanel()
+        workflowController.dictationViewModel.send(.resetTapped)
     }
 
     private func presentRequiredPermissionsGateIfNeeded() {

--- a/apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -4,6 +4,11 @@ import Foundation
 
 @MainActor
 final class MacDictationCaptureCoordinator {
+    enum CompletionOutcome: Equatable {
+        case completed
+        case clipboardPending
+    }
+
     struct CaptureSettings {
         let shouldCopyToClipboard: Bool
         let shouldAutoPaste: Bool
@@ -26,7 +31,7 @@ final class MacDictationCaptureCoordinator {
         targetApplication: NSRunningApplication?,
         settings: CaptureSettings,
         showPanel: @escaping @MainActor () -> Void
-    ) async {
+    ) async -> CompletionOutcome {
         let shouldRestoreClipboardAfterSuccessfulPaste = settings.shouldAutoPaste && !settings.shouldCopyToClipboard
         let pasteboardSnapshot = shouldRestoreClipboardAfterSuccessfulPaste
             ? PasteboardSnapshot.capture(from: NSPasteboard.general)
@@ -46,7 +51,11 @@ final class MacDictationCaptureCoordinator {
                     }
                 }
                 await DictationLatencyProbe.shared.record(.systemWriteCompleted)
+                return .completed
             } else {
+                if let pasteboardSnapshot {
+                    pasteboardSnapshot.restore(to: NSPasteboard.general)
+                }
                 await DictationLatencyProbe.shared.record(.systemWriteFailed, note: "paste_failed")
             }
 
@@ -57,12 +66,20 @@ final class MacDictationCaptureCoordinator {
             if settings.shouldRevealPanelOnCapture && !didPaste {
                 showPanel()
             }
+
+            return settings.shouldCopyToClipboard ? .completed : .clipboardPending
         } else if settings.shouldRevealPanelOnCapture {
             await DictationLatencyProbe.shared.record(.systemWriteSkipped, note: "auto_paste_disabled")
             showPanel()
         } else {
             await DictationLatencyProbe.shared.record(.systemWriteSkipped, note: "auto_paste_disabled")
         }
+
+        return settings.shouldCopyToClipboard ? .completed : .clipboardPending
+    }
+
+    func copyToClipboard(_ text: String) {
+        clipboardService.copy(text)
     }
 
     private struct PasteboardSnapshot {

--- a/apps/mac/Stet/App/Workflows/MacDictationHotkeyInteraction.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationHotkeyInteraction.swift
@@ -34,6 +34,8 @@ struct MacDictationHotkeyInteraction {
             guard case .idle = state else { return .none }
             state = .pressCandidate(startedAt: now)
             return .startCapture
+        case .clipboardPending:
+            return .none
         case .processing:
             return .none
         }

--- a/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
@@ -25,6 +25,8 @@ final class MacDictationWorkflowController {
         }
     }
 
+    typealias CompletionOutcome = MacDictationCaptureCoordinator.CompletionOutcome
+
     let dictationViewModel: DictationViewModel
 
     private let captureCoordinator: MacDictationCaptureCoordinator
@@ -83,6 +85,15 @@ final class MacDictationWorkflowController {
                 return "Rewrite complete"
             case .dictation:
                 return "Transcription complete"
+            }
+        case .clipboardPending:
+            switch activeWorkflow {
+            case .translationFromSpeech, .translationFromSelection:
+                return "Copy translation"
+            case .rewriteFromSelection:
+                return "Copy rewritten text"
+            case .dictation:
+                return "Copy to clipboard"
             }
         case .error:
             return "Something went wrong"
@@ -146,13 +157,12 @@ final class MacDictationWorkflowController {
         text: String,
         workflow: CaptureWorkflow,
         showTransientPanel: @escaping @MainActor () -> Void
-    ) async {
+    ) async -> CompletionOutcome {
         if workflow.isSelectionReplacement {
-            await handleSelectedTextReplacementResult(text: text, showTransientPanel: showTransientPanel)
-            return
+            return await handleSelectedTextReplacementResult(text: text, showTransientPanel: showTransientPanel)
         }
 
-        await captureCoordinator.handleCompletedCapture(
+        return await captureCoordinator.handleCompletedCapture(
             text: text,
             targetApplication: lastTargetApplication,
             settings: captureSettings,
@@ -160,10 +170,14 @@ final class MacDictationWorkflowController {
         )
     }
 
+    func copyPendingResultToClipboard(_ text: String) {
+        captureCoordinator.copyToClipboard(text)
+    }
+
     private func handleSelectedTextReplacementResult(
         text: String,
         showTransientPanel: @escaping @MainActor () -> Void
-    ) async {
+    ) async -> CompletionOutcome {
         let keepResultInClipboard = captureSettings.shouldCopyToClipboard
         let didReplaceSelection = await textInjectionService.replaceSelectedText(
             text,
@@ -173,6 +187,7 @@ final class MacDictationWorkflowController {
 
         if didReplaceSelection {
             await DictationLatencyProbe.shared.record(.systemWriteCompleted)
+            return .completed
         } else {
             await DictationLatencyProbe.shared.record(.systemWriteFailed, note: "replace_selected_text_failed")
         }
@@ -186,6 +201,8 @@ final class MacDictationWorkflowController {
                 showTransientPanel()
             }
         }
+
+        return keepResultInClipboard ? .completed : .clipboardPending
     }
 
     private func refreshTargetApplication() {
@@ -242,14 +259,14 @@ final class MacDictationWorkflowController {
         switch state {
         case .listening, .processing:
             return true
-        case .idle, .result, .error:
+        case .idle, .result, .clipboardPending, .error:
             return false
         }
     }
 
     private func shouldResumeMedia(after state: DictationState) -> Bool {
         switch state {
-        case .idle, .result, .error:
+        case .idle, .result, .clipboardPending, .error:
             return true
         case .listening, .processing:
             return false

--- a/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
@@ -249,8 +249,8 @@ final class MacDictationWorkflowController {
             return
         }
 
-        if isActiveDictationState(previousState),
-           shouldResumeMedia(after: newState) {
+        if case .listening = previousState,
+           !matchesListeningState(newState) {
             mediaPlaybackController.resumePlaybackIfNeeded()
         }
     }
@@ -271,6 +271,14 @@ final class MacDictationWorkflowController {
         case .listening, .processing:
             return false
         }
+    }
+
+    private func matchesListeningState(_ state: DictationState) -> Bool {
+        if case .listening = state {
+            return true
+        }
+
+        return false
     }
 
     private func matchesErrorState(_ state: DictationState) -> Bool {

--- a/apps/mac/Stet/Core/Speech/ConfigurableSpeechService.swift
+++ b/apps/mac/Stet/Core/Speech/ConfigurableSpeechService.swift
@@ -4,22 +4,35 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     private let settingsStore: DictationSettingsStore
     private let locale: Locale
     private let pipelineFactory: DictationPipelineFactory
-    private let captureService: any AudioCaptureService
+    private let captureServiceFactory: @Sendable () -> any AudioCaptureService
     private let audioLevelBridge = AudioLevelBridge()
 
     private var activePipeline: DictationPipeline?
+    private var activeCaptureService: (any AudioCaptureService)?
     private var audioLevelTask: Task<Void, Never>?
 
     init(
         settingsStore: DictationSettingsStore = DictationSettingsStore(),
         locale: Locale = .autoupdatingCurrent,
         pipelineFactory: DictationPipelineFactory,
-        captureService: (any AudioCaptureService)? = nil
+        captureService: (any AudioCaptureService)? = nil,
+        captureServiceFactory: (@Sendable () -> any AudioCaptureService)? = nil
     ) {
+        precondition(
+            captureService == nil || captureServiceFactory == nil,
+            "Provide either a capture service or a capture service factory."
+        )
+
         self.settingsStore = settingsStore
         self.locale = locale
         self.pipelineFactory = pipelineFactory
-        self.captureService = captureService ?? MacAudioCaptureService()
+        if let captureService {
+            self.captureServiceFactory = { captureService }
+        } else if let captureServiceFactory {
+            self.captureServiceFactory = captureServiceFactory
+        } else {
+            self.captureServiceFactory = { MacAudioCaptureService() }
+        }
     }
 
     func makeAudioLevelStream() async -> AsyncStream<Double> {
@@ -33,24 +46,29 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
         let snapshot = settingsStore.loadSnapshot()
         activePipeline = try await pipelineFactory.makePipeline(from: snapshot)
+        let captureService = captureServiceFactory()
+        activeCaptureService = captureService
 
         do {
             try await captureService.startRecording()
-            startAudioLevelForwarding()
+            startAudioLevelForwarding(using: captureService)
         } catch {
             activePipeline = nil
+            activeCaptureService = nil
             stopAudioLevelForwarding()
             throw error
         }
     }
 
     func stopRecording() async throws -> String {
-        guard let pipeline = activePipeline else {
+        guard let pipeline = activePipeline,
+              let captureService = activeCaptureService else {
             throw SpeechServiceError.notRecording
         }
 
         defer {
             self.activePipeline = nil
+            self.activeCaptureService = nil
             stopAudioLevelForwarding()
         }
 
@@ -114,11 +132,15 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     func cancelRecording() async {
         guard activePipeline != nil else { return }
         self.activePipeline = nil
+        let captureService = activeCaptureService
+        activeCaptureService = nil
         stopAudioLevelForwarding()
-        await captureService.cancelRecording()
+        if let captureService {
+            await captureService.cancelRecording()
+        }
     }
 
-    private func startAudioLevelForwarding() {
+    private func startAudioLevelForwarding(using captureService: any AudioCaptureService) {
         stopAudioLevelForwarding()
 
         guard let streamingService = captureService as? any AudioLevelSource else { return }

--- a/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
+++ b/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
@@ -37,6 +37,27 @@ final class SystemTextInjectionService: TextInjectionService {
         static let paste: CGKeyCode = 9
     }
 
+    private struct SelectionRange: Equatable {
+        let location: Int
+        let length: Int
+    }
+
+    private struct FocusedElementSnapshot: Equatable {
+        let value: String?
+        let selectedText: String?
+        let selectionRange: SelectionRange?
+
+        var canVerifyPaste: Bool {
+            value != nil || selectedText != nil || selectionRange != nil
+        }
+
+        func indicatesMutation(comparedTo previous: Self) -> Bool {
+            value != previous.value
+                || selectedText != previous.selectedText
+                || selectionRange != previous.selectionRange
+        }
+    }
+
     private let clipboardService: any ClipboardService
     private var didPromptForMissingAccessThisSession = false
 
@@ -82,6 +103,8 @@ final class SystemTextInjectionService: TextInjectionService {
             return false
         }
 
+        let snapshotBeforePaste = focusedElementSnapshot()
+
         if let application,
            !application.isTerminated,
            application.bundleIdentifier != Bundle.main.bundleIdentifier {
@@ -90,7 +113,22 @@ final class SystemTextInjectionService: TextInjectionService {
         }
 
         try? await Task.sleep(for: .milliseconds(60))
-        return simulateCommandKey(KeyCode.paste)
+        guard simulateCommandKey(KeyCode.paste) else {
+            return false
+        }
+
+        // Posting Command+V only tells us the event was emitted, not that the target accepted it.
+        guard let snapshotBeforePaste, snapshotBeforePaste.canVerifyPaste else {
+            return false
+        }
+
+        try? await Task.sleep(for: .milliseconds(180))
+
+        guard let snapshotAfterPaste = focusedElementSnapshot() else {
+            return false
+        }
+
+        return snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste)
     }
 
     func selectedText() -> String? {
@@ -210,6 +248,84 @@ final class SystemTextInjectionService: TextInjectionService {
         keyDown.post(tap: .cghidEventTap)
         keyUp.post(tap: .cghidEventTap)
         return true
+    }
+
+    private func focusedElementSnapshot() -> FocusedElementSnapshot? {
+        guard accessState.hasAccessibilityAccess,
+              let focusedElement = focusedAXElement() else {
+            return nil
+        }
+
+        return FocusedElementSnapshot(
+            value: stringAttribute(kAXValueAttribute as CFString, from: focusedElement),
+            selectedText: stringAttribute(kAXSelectedTextAttribute as CFString, from: focusedElement),
+            selectionRange: selectedRange(from: focusedElement)
+        )
+    }
+
+    private func focusedAXElement() -> AXUIElement? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedElementRef: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElementRef
+        )
+
+        guard status == .success,
+              let focusedElementRef,
+              CFGetTypeID(focusedElementRef) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        return unsafeBitCast(focusedElementRef, to: AXUIElement.self)
+    }
+
+    private func stringAttribute(_ attribute: CFString, from element: AXUIElement) -> String? {
+        var valueRef: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(element, attribute, &valueRef)
+
+        guard status == .success,
+              let valueRef else {
+            return nil
+        }
+
+        if let value = valueRef as? String, !value.isEmpty {
+            return value
+        }
+
+        if let value = valueRef as? NSAttributedString, !value.string.isEmpty {
+            return value.string
+        }
+
+        return nil
+    }
+
+    private func selectedRange(from element: AXUIElement) -> SelectionRange? {
+        var rangeRef: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &rangeRef
+        )
+
+        guard status == .success,
+              let rangeRef,
+              CFGetTypeID(rangeRef) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let axValue = unsafeBitCast(rangeRef, to: AXValue.self)
+        guard AXValueGetType(axValue) == .cfRange else {
+            return nil
+        }
+
+        var range = CFRange()
+        guard AXValueGetValue(axValue, .cfRange, &range) else {
+            return nil
+        }
+
+        return SelectionRange(location: range.location, length: range.length)
     }
 
     private func requestMissingAccesses(trigger: String) {

--- a/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
+++ b/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
@@ -115,7 +115,14 @@ final class SystemTextInjectionService: TextInjectionService {
         clipboardService.copy(text)
         let didPaste = await pasteClipboard(into: application)
 
-        guard didPaste, !keepResultInClipboard else {
+        guard didPaste else {
+            if !keepResultInClipboard {
+                snapshot.restore(to: pasteboard)
+            }
+            return false
+        }
+
+        guard !keepResultInClipboard else {
             return didPaste
         }
 

--- a/apps/mac/Stet/Features/Dictation/DictationAction.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationAction.swift
@@ -5,5 +5,6 @@ enum DictationAction: Equatable {
     case stopTapped
     case resetTapped
     case transcriptionSucceeded(String)
+    case clipboardPending(String)
     case transcriptionFailed(String)
 }

--- a/apps/mac/Stet/Features/Dictation/DictationState.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationState.swift
@@ -5,6 +5,7 @@ enum DictationState: Equatable {
     case listening
     case processing
     case result(String)
+    case clipboardPending(String)
     case error(String)
 
     var statusText: String {
@@ -17,12 +18,10 @@ enum DictationState: Equatable {
             return "Processing..."
         case .result:
             return "Transcription complete"
+        case .clipboardPending:
+            return "Copy to clipboard"
         case .error:
             return "Something went wrong"
         }
     }
 }
-
-
-
-

--- a/apps/mac/Stet/Features/Dictation/DictationView.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationView.swift
@@ -70,6 +70,8 @@ struct DictationView: View {
             return .resetTapped
         case .result, .error:
             return .startTapped
+        case .clipboardPending:
+            return .resetTapped
         }
     }
 
@@ -83,6 +85,8 @@ struct DictationView: View {
             return "Wait"
         case .result, .error:
             return "Again"
+        case .clipboardPending:
+            return "Dismiss"
         }
     }
 
@@ -96,6 +100,8 @@ struct DictationView: View {
             return .orange
         case .result:
             return .green
+        case .clipboardPending:
+            return .mint
         case .error:
             return .gray
         }
@@ -103,7 +109,7 @@ struct DictationView: View {
 
     private var showsReset: Bool {
         switch viewModel.state {
-        case .idle, .listening, .processing, .result, .error:
+        case .idle, .listening, .processing, .result, .clipboardPending, .error:
             return false
         }
     }
@@ -123,6 +129,10 @@ struct DictationView: View {
             ProgressView("Finalizing transcription...")
 
         case .result(let text):
+            Text(text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+        case .clipboardPending(let text):
             Text(text)
                 .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/apps/mac/Stet/Features/Dictation/DictationViewModel.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationViewModel.swift
@@ -36,6 +36,9 @@ final class DictationViewModel: ObservableObject {
         case .transcriptionSucceeded(let text):
             state = .result(text)
 
+        case .clipboardPending(let text):
+            state = .clipboardPending(text)
+
         case .transcriptionFailed(let message):
             state = .error(message)
         }

--- a/apps/mac/Stet/Features/MacShell/CapsuleOrbShaders.metal
+++ b/apps/mac/Stet/Features/MacShell/CapsuleOrbShaders.metal
@@ -1,0 +1,98 @@
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+
+using namespace metal;
+
+static float hash21(float2 p) {
+    p = fract(p * float2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+static float noise2D(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    float2 u = f * f * (3.0 - 2.0 * f);
+
+    float a = hash21(i);
+    float b = hash21(i + float2(1.0, 0.0));
+    float c = hash21(i + float2(0.0, 1.0));
+    float d = hash21(i + float2(1.0, 1.0));
+
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+static float fbm(float2 p) {
+    float v = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 5; i++) {
+        v += a * noise2D(p);
+        float2 rp = float2(
+            p.x * 0.80 + p.y * 0.60,
+           -p.x * 0.60 + p.y * 0.80
+        );
+        p = rp * 2.0 + float2(10.0);
+        a *= 0.5;
+    }
+    return v;
+}
+
+static float2 domainWarp(float2 p, float t) {
+    float2 q = float2(
+        fbm(p + float2(0.0, 0.0) + t * 0.05),
+        fbm(p + float2(5.2, 1.3) - t * 0.04)
+    );
+    float2 r = float2(
+        fbm(p + 3.0 * q + float2(1.7, 9.2) + t * 0.02),
+        fbm(p + 3.0 * q + float2(8.3, 2.8) - t * 0.02)
+    );
+    return r;
+}
+
+// Capsule shader for the floating voice pill.
+[[ stitchable ]] half4 cloudOrbGlassWide(
+    float2 position,
+    half4 currentColor,
+    float2 size,
+    float time,
+    float audio
+) {
+    float2 safeSize = float2(max(size.x, 1.0), max(size.y, 1.0));
+    float2 uv = position / safeSize;
+    float aspect = safeSize.x / safeSize.y;
+
+    float2 p = float2((uv.x - 0.5) * 2.0 * aspect,
+                      (uv.y - 0.5) * 2.0);
+
+    p.y += (0.015 + audio * 0.025) * sin(time * 6.28318 / 4.0);
+
+    float warpSpeed = 1.0 + audio * 0.4;
+    float warpStrength = 1.2 + audio * 0.5;
+    float2 w = domainWarp(p * 0.5, time * warpSpeed);
+    float n = fbm(p * 0.8 + w * warpStrength + float2(0.0, time * 0.06));
+    n = smoothstep(0.15, 0.95, n);
+
+    float h = smoothstep(-1.0, 1.0, p.y + (n - 0.5) * 0.55);
+
+    float3 top = float3(0.929, 0.549, 0.325);
+    float3 mid = float3(0.855, 0.596, 0.855);
+    float3 low = float3(0.702, 0.745, 0.980);
+
+    float3 base = mix(low, top, h);
+    base = mix(base, mid, 0.38 * (1.0 - h));
+
+    float cloud = smoothstep(0.55, 0.90, n) * (0.55 + 0.45 * h);
+    base = mix(base, float3(1.0), cloud * (0.55 + audio * 0.15));
+
+    float2 sunPos = float2(aspect * 0.3, 0.4);
+    float sun = exp(-dot(p - sunPos, p - sunPos) * 0.8);
+    base = mix(base, float3(1.0, 0.98, 0.92), sun * 0.10);
+
+    float vignette = smoothstep(0.3, 1.3, length(p / float2(aspect, 1.0)));
+    base *= 1.0 - vignette * 0.10;
+
+    base += float3(0.08, 0.06, 0.03) * audio;
+    base = clamp(base, 0.0, 1.0);
+
+    return half4(half3(base), half(float(currentColor.a)));
+}

--- a/apps/mac/Stet/Features/MacShell/MacDictationPanelView.swift
+++ b/apps/mac/Stet/Features/MacShell/MacDictationPanelView.swift
@@ -12,515 +12,511 @@ struct MacDictationPanelView: View {
     }
 
     var body: some View {
-        Group {
-            switch viewModel.state {
-            case .idle:
-                idleCapsule
-            case .listening:
-                recordingCapsule
-            case .processing:
-                thinkingCapsule
-            case .result:
-                insertedCapsule
-            case .clipboardPending:
-                clipboardPendingCapsule
-            case .error(let message):
-                errorCapsule(message: message)
-            }
-        }
-        .frame(width: layout.panelSize.width, height: layout.panelSize.height)
+        let panelSize = layout.panelSize(for: viewModel.state)
+
+        MacDictationCapsuleSurface(
+            layout: layout,
+            panelSize: panelSize,
+            state: viewModel.state,
+            statusText: viewModel.statusText,
+            recordingLevel: viewModel.recordingLevel,
+            leadingOrb: leadingOrb,
+            trailingOrb: trailingOrb
+        )
+        .frame(width: panelSize.width, height: panelSize.height)
     }
 
-    private var idleCapsule: some View {
-        shell(style: .idle) {
-            HStack(spacing: 10) {
-                controlButton(
-                    systemName: "xmark",
-                    isEmphasized: false,
-                    action: viewModel.hidePanel
-                )
-
-                Text("Ready")
-                    .font(statusFont(weight: .semibold))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.9)
-                    .frame(maxWidth: .infinity)
-
-                controlButton(
-                    systemName: "mic.fill",
-                    isEmphasized: true,
-                    action: viewModel.performPrimaryAction
-                )
-            }
-        }
-    }
-
-    private var recordingCapsule: some View {
-        shell(style: .listening(level: emphasizedRecordingLevel)) {
-            HStack(spacing: 12) {
-                controlButton(
-                    systemName: "xmark",
-                    isEmphasized: false,
-                    action: viewModel.cancelActiveCapture
-                )
-
-                VoiceLevelBarsView(level: emphasizedRecordingLevel, layout: layout)
-                    .frame(maxWidth: .infinity)
-
-                controlButton(
-                    systemName: "checkmark",
-                    isEmphasized: true,
-                    action: viewModel.performPrimaryAction
-                )
-            }
-        }
-    }
-
-    private var thinkingCapsule: some View {
-        shell(style: .processing) {
-            HStack(spacing: 8) {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(.white)
-
-                Text(viewModel.statusText)
-                    .font(statusFont(weight: .semibold))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.9)
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-        }
-    }
-
-    private var insertedCapsule: some View {
-        shell(style: .result) {
-            HStack(spacing: 8) {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.white)
-
-                Text(viewModel.statusText)
-                    .font(statusFont(weight: .semibold))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.9)
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-        }
-    }
-
-    private var clipboardPendingCapsule: some View {
-        shell(style: .clipboardPending) {
-            HStack(spacing: 10) {
-                controlButton(
-                    systemName: "xmark",
-                    isEmphasized: false,
-                    action: viewModel.dismissPendingCopy
-                )
-
-                Text(viewModel.statusText)
-                    .font(statusFont(weight: .semibold))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.9)
-                    .frame(maxWidth: .infinity, alignment: .center)
-
-                actionButton(
-                    title: "Copy",
-                    action: viewModel.performPrimaryAction
-                )
-            }
-        }
-    }
-
-    private func errorCapsule(message: String) -> some View {
-        shell(style: .error) {
-            HStack(spacing: 10) {
-                controlButton(
-                    systemName: "xmark",
-                    isEmphasized: false,
-                    action: viewModel.hidePanel
-                )
-
-                Text(message)
-                    .font(.system(size: layout.secondaryFontSize, weight: .medium, design: .rounded))
-                    .foregroundStyle(.white.opacity(0.88))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                controlButton(
-                    systemName: "arrow.clockwise",
-                    isEmphasized: true,
-                    action: viewModel.performPrimaryAction
-                )
-            }
-        }
-    }
-
-    private func shell<Content: View>(
-        style: BlendCapsuleStyle,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        content()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, layout.horizontalPadding)
-            .padding(.vertical, layout.verticalPadding)
-            .frame(width: layout.capsuleSize.width, height: layout.capsuleSize.height)
-            .background(
-                ReactiveBlendCapsuleBackground(
-                    level: style.level,
-                    isActive: style.isActive,
-                    palette: style.palette
-                )
+    private var leadingOrb: CapsuleOrbConfiguration? {
+        switch viewModel.state {
+        case .idle:
+            CapsuleOrbConfiguration(
+                systemName: "xmark",
+                tint: .cancel,
+                action: viewModel.hidePanel
             )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .listening:
+            CapsuleOrbConfiguration(
+                systemName: "xmark",
+                tint: .cancel,
+                action: viewModel.cancelActiveCapture
+            )
+        case .processing:
+            nil
+        case .result:
+            nil
+        case .clipboardPending:
+            CapsuleOrbConfiguration(
+                systemName: "xmark",
+                tint: .cancel,
+                action: viewModel.dismissPendingCopy
+            )
+        case .error:
+            CapsuleOrbConfiguration(
+                systemName: "xmark",
+                tint: .cancel,
+                action: viewModel.hidePanel
+            )
+        }
+    }
+
+    private var trailingOrb: CapsuleOrbConfiguration? {
+        switch viewModel.state {
+        case .idle:
+            CapsuleOrbConfiguration(
+                systemName: "mic.fill",
+                tint: .primaryAction,
+                action: viewModel.performPrimaryAction
+            )
+        case .listening:
+            CapsuleOrbConfiguration(
+                systemName: "checkmark",
+                tint: .primaryAction,
+                action: viewModel.performPrimaryAction
+            )
+        case .processing:
+            nil
+        case .result:
+            nil
+        case .clipboardPending:
+            CapsuleOrbConfiguration(
+                systemName: "doc.on.doc",
+                tint: .copyAction,
+                action: viewModel.performPrimaryAction
+            )
+        case .error:
+            CapsuleOrbConfiguration(
+                systemName: "arrow.clockwise",
+                tint: .retryAction,
+                action: viewModel.performPrimaryAction
+            )
+        }
+    }
+}
+
+private struct MacDictationCapsuleSurface: View {
+    let layout: MacDictationPanelLayout
+    let panelSize: CGSize
+    let state: DictationState
+    let statusText: String
+    let recordingLevel: Double
+    let leadingOrb: CapsuleOrbConfiguration?
+    let trailingOrb: CapsuleOrbConfiguration?
+
+    @State private var appeared = false
+    @State private var startDate = Date()
+
+    private var scale: CGFloat {
+        layout.scale
+    }
+
+    private var canvasSize: CGSize {
+        panelSize
+    }
+
+    private var isClipboardPending: Bool {
+        if case .clipboardPending = state {
+            return true
+        }
+
+        return false
+    }
+
+    private var isProcessing: Bool {
+        if case .processing = state {
+            return true
+        }
+
+        return false
+    }
+
+    private var isError: Bool {
+        if case .error = state {
+            return true
+        }
+
+        return false
     }
 
     private var normalizedRecordingLevel: Double {
-        min(max(viewModel.recordingLevel, 0), 1)
+        min(max(recordingLevel, 0), 1)
     }
 
-    private var emphasizedRecordingLevel: Double {
-        let silenceFloor = 0.08
-        let normalized = normalizedRecordingLevel
-        let lifted = max(normalized - silenceFloor, 0) / (1 - silenceFloor)
-        let emphasized = pow(lifted, 0.58)
-        return min(max(0.1 + emphasized * 0.9, 0.1), 1)
-    }
-
-    private func controlButton(
-        systemName: String,
-        isEmphasized: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: layout.controlSymbolSize, weight: .bold))
-                .foregroundStyle(isEmphasized ? .black : .white)
-                .frame(width: layout.controlButtonSize, height: layout.controlButtonSize)
-                .background(
-                    Circle()
-                        .fill(isEmphasized ? Color.white : Color.white.opacity(0.12))
-                )
+    private var displayLevel: Double {
+        switch state {
+        case .idle:
+            return 0.14
+        case .listening:
+            return min(max(0.12 + normalizedRecordingLevel * 0.88, 0), 1)
+        case .processing:
+            return 0.08
+        case .result:
+            return 0.12
+        case .clipboardPending, .error:
+            return 0
         }
-        .buttonStyle(.plain)
     }
 
-    private func actionButton(
-        title: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: layout.secondaryFontSize + 1, weight: .bold, design: .rounded))
-                .foregroundStyle(.black)
-                .frame(minWidth: layout.controlButtonSize + 18, minHeight: layout.controlButtonSize)
-                .padding(.horizontal, 8)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(Color.white)
-                )
+    private var mainWidth: CGFloat {
+        switch state {
+        case .idle:
+            scaled(250)
+        case .listening:
+            scaled(250)
+        case .processing:
+            scaled(228)
+        case .result:
+            scaled(270)
+        case .clipboardPending:
+            scaled(320)
+        case .error:
+            scaled(300)
         }
-        .buttonStyle(.plain)
     }
 
-    private func statusFont(weight: Font.Weight) -> Font {
-        .system(size: layout.statusFontSize, weight: weight, design: .rounded)
+    private var mainHeight: CGFloat {
+        isClipboardPending ? scaled(118) : scaled(52)
     }
-}
 
-private struct ReactiveBlendCapsuleBackground: View {
-    let level: Double
-    let isActive: Bool
-    let palette: [Color]
+    private var mainCornerRadius: CGFloat {
+        isClipboardPending ? scaled(30) : mainHeight / 2
+    }
 
-    private var energy: Double {
-        min(max(level, 0), 1)
+    private var mainOffsetX: CGFloat {
+        switch state {
+        case .idle, .listening:
+            scaled(12)
+        case .clipboardPending:
+            0
+        case .processing, .result, .error:
+            scaled(24)
+        }
+    }
+
+    private var mainOffsetY: CGFloat {
+        isClipboardPending ? scaled(-2) : scaled(-4)
+    }
+
+    private var leadingOrbProgress: CGFloat {
+        leadingOrb == nil ? 0 : 1
+    }
+
+    private var trailingOrbProgress: CGFloat {
+        trailingOrb == nil ? 0 : 1
+    }
+
+    private var leadingOrbX: CGFloat {
+        let startX = mainOffsetX - (mainWidth / 2) + scaled(18)
+        let targetX = mainOffsetX - (mainWidth / 2) - scaled(isClipboardPending ? 46 : 55)
+        return startX + (targetX - startX) * leadingOrbProgress
+    }
+
+    private var trailingOrbX: CGFloat {
+        let startX = mainOffsetX + (mainWidth / 2) - scaled(18)
+        let targetX = mainOffsetX + (mainWidth / 2) + scaled(isClipboardPending ? 46 : 55)
+        return startX + (targetX - startX) * trailingOrbProgress
+    }
+
+    private var orbSize: CGFloat {
+        scaled(52)
     }
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: !isActive)) { timeline in
-            let time = timeline.date.timeIntervalSinceReferenceDate
-            let pulseScale = isActive ? (0.985 + 0.05 * energy) : 1
-            let shadowRadius = 14 + 12 * energy
-            let shadowYOffset = 6 + 5 * energy
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: false)) { timeline in
+            let elapsed = timeline.date.timeIntervalSince(startDate)
 
             ZStack {
-                Capsule(style: .continuous)
-                    .fill(BlendPalette.surface)
+                GlassEffectContainer(spacing: scaled(28)) {
+                    ZStack {
+                        if let leadingOrb {
+                            capsuleOrbButton(leadingOrb, elapsed: elapsed)
+                                .offset(x: leadingOrbX, y: mainOffsetY)
+                                .scaleEffect(0.24 + 0.76 * leadingOrbProgress)
+                                .opacity(leadingOrbProgress)
+                                .allowsHitTesting(leadingOrbProgress > 0.01)
+                        }
 
-                ColorCloudField(
-                    time: time,
-                    level: energy,
-                    palette: palette,
-                    isActive: isActive
-                )
-                .clipShape(Capsule(style: .continuous))
+                        mainCapsule(elapsed: elapsed)
+                            .offset(x: mainOffsetX, y: mainOffsetY)
 
-                Capsule(style: .continuous)
+                        if let trailingOrb {
+                            capsuleOrbButton(trailingOrb, elapsed: elapsed)
+                                .offset(x: trailingOrbX, y: mainOffsetY)
+                                .scaleEffect(0.24 + 0.76 * trailingOrbProgress)
+                                .opacity(trailingOrbProgress)
+                                .allowsHitTesting(trailingOrbProgress > 0.01)
+                        }
+                    }
+                    .frame(width: canvasSize.width, height: canvasSize.height)
+                }
+
+                mainContent(elapsed: elapsed)
+                    .frame(width: mainWidth, height: mainHeight)
+                    .offset(x: mainOffsetX, y: mainOffsetY)
+            }
+            .frame(width: canvasSize.width, height: canvasSize.height)
+        }
+        .scaleEffect(appeared ? 1.0 : 0.94)
+        .opacity(appeared ? 1.0 : 0.0)
+        .onAppear {
+            if !appeared {
+                withAnimation(.spring(response: 0.46, dampingFraction: 0.78)) {
+                    appeared = true
+                }
+            }
+        }
+        .animation(.spring(response: 0.56, dampingFraction: 0.82), value: state)
+    }
+
+    @ViewBuilder
+    private func mainCapsule(elapsed: Double) -> some View {
+        GeometryReader { proxy in
+            if isClipboardPending {
+                Rectangle()
                     .fill(
                         LinearGradient(
                             colors: [
-                                Color.white.opacity(0.16),
-                                Color.white.opacity(0.05),
-                                Color.clear
+                                .white.opacity(0.18),
+                                .white.opacity(0.10)
                             ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-
-                Capsule(style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color.clear,
-                                Color.black.opacity(0.05)
-                            ],
-                            startPoint: .center,
+                            startPoint: .top,
                             endPoint: .bottom
                         )
                     )
-
-                Capsule(style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
-            }
-            .scaleEffect(x: 1, y: pulseScale, anchor: .center)
-            .clipShape(Capsule(style: .continuous))
-            .shadow(color: Color.black.opacity(0.1 + 0.08 * energy), radius: shadowRadius, y: shadowYOffset)
-            .animation(.interactiveSpring(response: 0.18, dampingFraction: 0.72), value: energy)
-        }
-    }
-}
-
-private struct ColorCloudField: View {
-    let time: TimeInterval
-    let level: Double
-    let palette: [Color]
-    let isActive: Bool
-
-    var body: some View {
-        GeometryReader { proxy in
-            let blobs = BlendBlob.makeBlobs(
-                in: proxy.size,
-                time: time,
-                level: level,
-                palette: palette,
-                isActive: isActive
-            )
-
-            ZStack {
-                Rectangle()
-                    .fill(BlendPalette.base)
-
-                ForEach(blobs) { blob in
-                    Ellipse()
-                        .fill(blob.color.opacity(blob.opacity))
-                        .frame(width: blob.size.width, height: blob.size.height)
-                        .position(x: blob.center.x, y: blob.center.y)
-                        .blur(radius: blob.blur)
-                }
-
+            } else if isError {
                 Rectangle()
                     .fill(
                         LinearGradient(
                             colors: [
-                                Color.white.opacity(0.04 + 0.06 * level),
-                                Color.clear,
-                                Color.black.opacity(0.04)
+                                Color(red: 0.78, green: 0.42, blue: 0.52).opacity(0.42),
+                                Color(red: 0.93, green: 0.48, blue: 0.34).opacity(0.24)
                             ],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         )
                     )
+            } else {
+                Rectangle()
+                    .fill(.white)
+                    .colorEffect(
+                        ShaderLibrary.cloudOrbGlassWide(
+                            .float2(proxy.size),
+                            .float(elapsed),
+                            .float(displayLevel)
+                        )
+                    )
             }
-            .drawingGroup(opaque: true, colorMode: .linear)
-            .saturation(1.08 + 0.2 * level)
-            .brightness(0.012 + 0.04 * level)
         }
-    }
-}
-
-private struct BlendBlob: Identifiable {
-    let id: Int
-    let center: CGPoint
-    let size: CGSize
-    let color: Color
-    let blur: CGFloat
-    let opacity: Double
-
-    static func makeBlobs(
-        in size: CGSize,
-        time: TimeInterval,
-        level: Double,
-        palette: [Color],
-        isActive: Bool
-    ) -> [BlendBlob] {
-        let energy = CGFloat(min(max(level, 0), 1))
-        let motion = isActive ? (0.55 + 0.95 * energy) : 0.16
-        let width = size.width
-        let height = size.height
-
-        let anchors: [(CGFloat, CGFloat, CGFloat, CGFloat)] = [
-            (0.08, 0.22, 0.68, 1.28),
-            (0.28, 0.74, 0.62, 1.12),
-            (0.50, 0.34, 0.70, 1.30),
-            (0.72, 0.68, 0.62, 1.08),
-            (0.93, 0.28, 0.60, 1.02)
-        ]
-
-        return anchors.enumerated().map { index, anchor in
-            let seed = Double(index) * 11.73 + 0.91
-
-            let smoothX = width * (0.04 + 0.075 * motion) * smoothNoise(time, seed: seed)
-            let smoothY = height * (0.06 + 0.1 * motion) * smoothNoise(time * 1.17, seed: seed + 3.2)
-
-            let jumpX = width * (0.01 + 0.024 * motion) * steppedNoise(time * (4.4 + Double(level) * 10.0), seed: seed + 8.4)
-            let jumpY = height * (0.012 + 0.03 * motion) * steppedNoise(time * (5.6 + Double(level) * 13.0), seed: seed + 14.7)
-
-            let widthPulse = 1 + (0.06 + 0.18 * motion) * smoothNoise(time * (1.05 + Double(index) * 0.08), seed: seed + 1.6)
-            let heightPulse = 1 + (0.05 + 0.16 * motion) * smoothNoise(time * (0.92 + Double(index) * 0.07), seed: seed + 4.9)
-
-            return BlendBlob(
-                id: index,
-                center: CGPoint(
-                    x: width * anchor.0 + smoothX + jumpX,
-                    y: height * anchor.1 + smoothY + jumpY
-                ),
-                size: CGSize(
-                    width: width * anchor.2 * widthPulse,
-                    height: height * anchor.3 * heightPulse
-                ),
-                color: palette[index % palette.count],
-                blur: height * (0.24 + 0.06 * motion),
-                opacity: Double(0.48 + 0.24 * motion + 0.05 * CGFloat(index % 2))
-            )
+        .frame(width: mainWidth, height: mainHeight)
+        .clipShape(RoundedRectangle(cornerRadius: mainCornerRadius, style: .continuous))
+        .glassEffect(.clear, in: RoundedRectangle(cornerRadius: mainCornerRadius, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: mainCornerRadius, style: .continuous)
+                .strokeBorder(.white.opacity(isClipboardPending ? 0.18 : 0.08), lineWidth: scaled(0.9))
         }
-    }
-
-    private static func smoothNoise(_ t: TimeInterval, seed: Double) -> CGFloat {
-        let value =
-            0.62 * sin(t * 0.82 + seed) +
-            0.26 * sin(t * 1.47 + seed * 1.31) +
-            0.12 * cos(t * 2.21 + seed * 0.73)
-        return CGFloat(value)
-    }
-
-    private static func steppedNoise(_ t: TimeInterval, seed: Double) -> CGFloat {
-        let step = floor(t)
-        let raw = sin((step + seed) * 12.9898) * 43758.5453
-        let fractional = raw - floor(raw)
-        return CGFloat(fractional * 2 - 1)
-    }
-}
-
-private struct BlendCapsuleStyle {
-    let level: Double
-    let isActive: Bool
-    let palette: [Color]
-
-    static let idle = BlendCapsuleStyle(
-        level: 0.10,
-        isActive: false,
-        palette: BlendPalette.sunsetPastel
-    )
-
-    static func listening(level: Double) -> BlendCapsuleStyle {
-        BlendCapsuleStyle(
-            level: max(0.12, min(max(level, 0), 1)),
-            isActive: true,
-            palette: BlendPalette.sunsetPastel
+        .shadow(
+            color: .black.opacity(isClipboardPending ? 0.22 : 0.12),
+            radius: isClipboardPending ? scaled(18) : scaled(8),
+            y: isClipboardPending ? scaled(10) : scaled(4)
         )
     }
 
-    static let processing = BlendCapsuleStyle(
-        level: 0.28,
-        isActive: true,
-        palette: BlendPalette.sunsetPastel
-    )
+    @ViewBuilder
+    private func mainContent(elapsed: Double) -> some View {
+        switch state {
+        case .processing:
+            processingContent(elapsed: elapsed)
+        case .clipboardPending(let text):
+            clipboardContent(text: text)
+        case .error(let message):
+            messageText(
+                message,
+                fontSize: 13,
+                lineLimit: 3,
+                minimumScaleFactor: 0.9
+            )
+            .padding(.horizontal, scaled(24))
+        case .result:
+            HStack(spacing: scaled(8)) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: scaled(16), weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.96))
 
-    static let result = BlendCapsuleStyle(
-        level: 0.16,
-        isActive: false,
-        palette: BlendPalette.sunsetPastel
-    )
+                messageText(statusText, fontSize: 13, lineLimit: 1, minimumScaleFactor: 0.92)
+            }
+            .padding(.horizontal, scaled(20))
+        case .idle, .listening:
+            messageText(statusText, fontSize: 13, lineLimit: 1, minimumScaleFactor: 0.86)
+                .padding(.horizontal, scaled(22))
+        }
+    }
 
-    static let clipboardPending = BlendCapsuleStyle(
-        level: 0.18,
-        isActive: false,
-        palette: BlendPalette.sunsetPastel
-    )
+    @ViewBuilder
+    private func processingContent(elapsed: Double) -> some View {
+        VStack(spacing: scaled(8)) {
+            processingDots(elapsed: elapsed)
 
-    static let error = BlendCapsuleStyle(
-        level: 0.18,
-        isActive: false,
-        palette: BlendPalette.error
-    )
-}
-
-private enum BlendPalette {
-    static let surface = LinearGradient(
-        colors: [
-            Color(red: 0.86, green: 0.84, blue: 0.93),
-            Color(red: 0.93, green: 0.77, blue: 0.73)
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
-
-    static let base = LinearGradient(
-        colors: [
-            Color(red: 0.82, green: 0.83, blue: 0.96),
-            Color(red: 0.90, green: 0.68, blue: 0.76),
-            Color(red: 0.93, green: 0.62, blue: 0.50)
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-    )
-
-    static let sunsetPastel: [Color] = [
-        Color(red: 0.74, green: 0.78, blue: 0.98),
-        Color(red: 0.88, green: 0.67, blue: 0.84),
-        Color(red: 0.92, green: 0.64, blue: 0.62),
-        Color(red: 0.93, green: 0.61, blue: 0.39),
-        Color(red: 0.95, green: 0.78, blue: 0.44)
-    ]
-
-    static let error: [Color] = [
-        Color(red: 0.96, green: 0.66, blue: 0.72),
-        Color(red: 0.95, green: 0.56, blue: 0.56),
-        Color(red: 0.96, green: 0.66, blue: 0.46),
-        Color(red: 0.82, green: 0.62, blue: 0.96),
-        Color(red: 0.93, green: 0.78, blue: 0.50)
-    ]
-}
-
-private struct VoiceLevelBarsView: View {
-    let level: Double
-    let layout: MacDictationPanelLayout
-
-    private let multipliers: [CGFloat] = [0.18, 0.34, 0.56, 0.82, 1, 0.82, 0.56, 0.34, 0.18]
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 3) {
-            ForEach(Array(multipliers.enumerated()), id: \.offset) { _, multiplier in
-                Capsule()
-                    .fill(Color.white)
-                    .frame(width: 5, height: barHeight(multiplier: multiplier))
-                    .opacity(0.68 + 0.32 * level)
+            if statusText != DictationState.processing.statusText {
+                messageText(statusText, fontSize: 11, lineLimit: 1, minimumScaleFactor: 0.85)
+                    .opacity(0.82)
             }
         }
-        .frame(height: layout.voiceBarHeight)
-        .animation(.interactiveSpring(response: 0.16, dampingFraction: 0.68), value: level)
+        .padding(.horizontal, scaled(16))
     }
 
-    private func barHeight(multiplier: CGFloat) -> CGFloat {
-        let baseHeight: CGFloat = 3
-        let responsiveLevel = CGFloat(pow(max(level, 0.02), 0.82))
-        let variableHeight = responsiveLevel * (layout.voiceBarHeight - baseHeight) * multiplier
-        return baseHeight + variableHeight
+    @ViewBuilder
+    private func clipboardContent(text: String) -> some View {
+        Text(text)
+            .font(.system(size: scaled(15), weight: .medium, design: .rounded))
+            .foregroundStyle(.white.opacity(0.96))
+            .multilineTextAlignment(.center)
+            .lineSpacing(scaled(4))
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, scaled(24))
+            .padding(.vertical, scaled(18))
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
+
+    @ViewBuilder
+    private func messageText(
+        _ text: String,
+        fontSize: CGFloat,
+        lineLimit: Int,
+        minimumScaleFactor: CGFloat
+    ) -> some View {
+        Text(text)
+            .font(.system(size: scaled(fontSize), weight: .semibold, design: .rounded))
+            .foregroundStyle(.white.opacity(0.96))
+            .lineLimit(lineLimit)
+            .minimumScaleFactor(minimumScaleFactor)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .multilineTextAlignment(.center)
+            .shadow(color: .black.opacity(0.16), radius: scaled(10), y: scaled(4))
+    }
+
+    @ViewBuilder
+    private func processingDots(elapsed: Double) -> some View {
+        HStack(spacing: scaled(5)) {
+            let cadence = elapsed * 3.2
+            let head = Int(floor(cadence)).quotientAndRemainder(dividingBy: 3).remainder
+            let progress = cadence - floor(cadence)
+
+            ForEach(0..<3, id: \.self) { index in
+                let isHead = index == head
+                let isTrailing = index == (head + 2) % 3
+                let headGlow = isHead ? (0.72 + 0.28 * progress) : 0.0
+                let trailingGlow = isTrailing ? (0.42 * (1.0 - progress)) : 0.0
+                let intensity = max(headGlow, trailingGlow)
+                let opacity = 0.36 + intensity * 0.64
+                let scale = 0.82 + intensity * 0.34
+                let yOffset = -1.2 * intensity
+
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [
+                                .white.opacity(min(1.0, opacity + 0.18)),
+                                Color.primaryAction.opacity(opacity)
+                            ],
+                            center: .center,
+                            startRadius: scaled(0.5),
+                            endRadius: scaled(4)
+                        )
+                    )
+                    .frame(width: scaled(6.5), height: scaled(6.5))
+                    .scaleEffect(scale)
+                    .offset(y: scaled(yOffset))
+                    .shadow(color: Color.primaryAction.opacity(0.26 + intensity * 0.34), radius: scaled(6))
+            }
+        }
+        .frame(height: scaled(18))
+    }
+
+    @ViewBuilder
+    private func capsuleOrbButton(
+        _ configuration: CapsuleOrbConfiguration,
+        elapsed: Double
+    ) -> some View {
+        Button(action: configuration.action) {
+            Color.clear
+                .frame(width: orbSize, height: orbSize)
+                .glassEffect(.clear, in: Circle())
+                .overlay {
+                    ZStack {
+                        Circle()
+                            .fill(
+                                RadialGradient(
+                                    colors: [
+                                        configuration.tint.opacity(0.38 + displayLevel * 0.10),
+                                        configuration.tint.opacity(0.18 + displayLevel * 0.06),
+                                        configuration.tint.opacity(0.04),
+                                        .clear
+                                    ],
+                                    center: .center,
+                                    startRadius: scaled(2),
+                                    endRadius: orbSize * 0.48
+                                )
+                            )
+                            .frame(width: orbSize - scaled(6), height: orbSize - scaled(6))
+                            .scaleEffect(1.0 + displayLevel * 0.07)
+
+                        Circle()
+                            .fill(.white.opacity(0.06))
+                            .frame(width: orbSize - scaled(20), height: orbSize - scaled(20))
+
+                        Circle()
+                            .strokeBorder(configuration.tint.opacity(0.36), lineWidth: scaled(1.2))
+                            .frame(width: orbSize - scaled(16), height: orbSize - scaled(16))
+
+                        Circle()
+                            .strokeBorder(.white.opacity(0.14), lineWidth: scaled(0.8))
+                            .frame(width: orbSize - scaled(8), height: orbSize - scaled(8))
+
+                        Image(systemName: configuration.systemName)
+                            .font(.system(size: scaled(16), weight: .bold))
+                            .foregroundStyle(.white.opacity(0.96))
+                            .shadow(color: configuration.tint.opacity(0.45), radius: scaled(6))
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .shadow(color: configuration.tint.opacity(0.16), radius: scaled(10))
+        .accessibilityLabel(configuration.systemName)
+    }
+
+    private func scaled(_ value: CGFloat) -> CGFloat {
+        value * scale
+    }
+}
+
+private struct CapsuleOrbConfiguration {
+    let systemName: String
+    let tint: Color
+    let action: () -> Void
+}
+
+private extension Color {
+    static let cancel = Color(
+        red: 218.0 / 255.0,
+        green: 152.0 / 255.0,
+        blue: 218.0 / 255.0
+    )
+
+    static let primaryAction = Color(
+        red: 179.0 / 255.0,
+        green: 190.0 / 255.0,
+        blue: 250.0 / 255.0
+    )
+
+    static let copyAction = Color(
+        red: 192.0 / 255.0,
+        green: 218.0 / 255.0,
+        blue: 1.0
+    )
+
+    static let retryAction = Color(
+        red: 1.0,
+        green: 180.0 / 255.0,
+        blue: 124.0 / 255.0
+    )
 }
 #endif

--- a/apps/mac/Stet/Features/MacShell/MacDictationPanelView.swift
+++ b/apps/mac/Stet/Features/MacShell/MacDictationPanelView.swift
@@ -22,6 +22,8 @@ struct MacDictationPanelView: View {
                 thinkingCapsule
             case .result:
                 insertedCapsule
+            case .clipboardPending:
+                clipboardPendingCapsule
             case .error(let message):
                 errorCapsule(message: message)
             }
@@ -108,6 +110,30 @@ struct MacDictationPanelView: View {
         }
     }
 
+    private var clipboardPendingCapsule: some View {
+        shell(style: .clipboardPending) {
+            HStack(spacing: 10) {
+                controlButton(
+                    systemName: "xmark",
+                    isEmphasized: false,
+                    action: viewModel.dismissPendingCopy
+                )
+
+                Text(viewModel.statusText)
+                    .font(statusFont(weight: .semibold))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.9)
+                    .frame(maxWidth: .infinity, alignment: .center)
+
+                actionButton(
+                    title: "Copy",
+                    action: viewModel.performPrimaryAction
+                )
+            }
+        }
+    }
+
     private func errorCapsule(message: String) -> some View {
         shell(style: .error) {
             HStack(spacing: 10) {
@@ -177,6 +203,24 @@ struct MacDictationPanelView: View {
                 .background(
                     Circle()
                         .fill(isEmphasized ? Color.white : Color.white.opacity(0.12))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func actionButton(
+        title: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: layout.secondaryFontSize + 1, weight: .bold, design: .rounded))
+                .foregroundStyle(.black)
+                .frame(minWidth: layout.controlButtonSize + 18, minHeight: layout.controlButtonSize)
+                .padding(.horizontal, 8)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.white)
                 )
         }
         .buttonStyle(.plain)
@@ -399,6 +443,12 @@ private struct BlendCapsuleStyle {
 
     static let result = BlendCapsuleStyle(
         level: 0.16,
+        isActive: false,
+        palette: BlendPalette.sunsetPastel
+    )
+
+    static let clipboardPending = BlendCapsuleStyle(
+        level: 0.18,
         isActive: false,
         palette: BlendPalette.sunsetPastel
     )

--- a/apps/mac/Stet/Features/MacShell/MacDictationPanelViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/MacDictationPanelViewModel.swift
@@ -7,27 +7,30 @@ final class MacDictationPanelViewModel: ObservableObject {
     private let appModel: any MacDictationPanelCoordinating
     private var cancellables = Set<AnyCancellable>()
 
+    @Published private(set) var state: DictationState
+    @Published private(set) var statusText: String
+    @Published private(set) var recordingLevel: Double
+
     init(appModel: any MacDictationPanelCoordinating) {
         self.appModel = appModel
+        self.state = appModel.dictationState
+        self.statusText = appModel.statusText
+        self.recordingLevel = appModel.recordingLevel
 
         appModel.updates
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.objectWillChange.send()
+                DispatchQueue.main.async { [weak self] in
+                    self?.syncFromAppModel()
+                }
             }
             .store(in: &cancellables)
     }
 
-    var state: DictationState {
-        appModel.dictationState
-    }
-
-    var statusText: String {
-        appModel.statusText
-    }
-
-    var recordingLevel: Double {
-        appModel.recordingLevel
+    private func syncFromAppModel() {
+        state = appModel.dictationState
+        statusText = appModel.statusText
+        recordingLevel = appModel.recordingLevel
     }
 
     func hidePanel() {

--- a/apps/mac/Stet/Features/MacShell/MacDictationPanelViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/MacDictationPanelViewModel.swift
@@ -34,6 +34,10 @@ final class MacDictationPanelViewModel: ObservableObject {
         appModel.hidePanel()
     }
 
+    func dismissPendingCopy() {
+        appModel.dismissPendingCopy()
+    }
+
     func cancelActiveCapture() {
         appModel.cancelActiveCapture()
     }

--- a/apps/mac/StetTests/App/MacAppBootstrapperTests.swift
+++ b/apps/mac/StetTests/App/MacAppBootstrapperTests.swift
@@ -13,8 +13,7 @@ struct MacAppBootstrapperTests {
         let bootstrapper = MacAppBootstrapper(
             defaults: defaults,
             settingsStore: settingsStore,
-            launchAtLoginStatusProvider: { true },
-            legacyHistoryURLs: []
+            launchAtLoginStatusProvider: { true }
         )
 
         let launchConfiguration = bootstrapper.prepareForLaunch()
@@ -32,12 +31,9 @@ struct MacAppBootstrapperTests {
         #expect(!defaults.bool(forKey: MacPreferences.showInDock))
     }
 
-    @Test func prepareForLaunchRemovesLegacyArtifactsAndKeepsExplicitPreferences() throws {
+    @Test func prepareForLaunchKeepsExplicitPreferencesAndAppliesMissingDefaults() throws {
         let defaults = TestSupport.makeUserDefaults()
         let settingsStore = DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
-        let legacyHistoryURL = TestSupport.temporaryFileURL("airtype-legacy-history", ext: "json")
-        try Data("[]".utf8).write(to: legacyHistoryURL)
-
         defaults.set("legacy", forKey: "mac.copyLatestCaptureHotkeyShortcut")
         defaults.set("forever", forKey: "mac.historyRetentionPeriod")
         defaults.set(true, forKey: "mac.showPanelOnLaunch")
@@ -52,23 +48,25 @@ struct MacAppBootstrapperTests {
         let bootstrapper = MacAppBootstrapper(
             defaults: defaults,
             settingsStore: settingsStore,
-            launchAtLoginStatusProvider: { false },
-            legacyHistoryURLs: [legacyHistoryURL]
+            launchAtLoginStatusProvider: { false }
         )
 
         let launchConfiguration = bootstrapper.prepareForLaunch()
 
         #expect(launchConfiguration == .init(showInDock: true))
         #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.managed.rawValue)
-        #expect(defaults.object(forKey: "mac.copyLatestCaptureHotkeyShortcut") == nil)
-        #expect(defaults.object(forKey: "mac.historyRetentionPeriod") == nil)
-        #expect(defaults.object(forKey: "mac.showPanelOnLaunch") == nil)
-        #expect(defaults.object(forKey: "mac.copyToClipboardOnCapture") == nil)
-        #expect(defaults.object(forKey: "mac.autoPasteOnCapture") == nil)
-        #expect(defaults.object(forKey: "mac.revealPanelOnCapture") == nil)
-        #expect(defaults.object(forKey: "mac.openAIBaseURL") == nil)
-        #expect(defaults.object(forKey: "mac.openAITranslationModel") == nil)
-        #expect(!FileManager.default.fileExists(atPath: legacyHistoryURL.path))
+        #expect(defaults.object(forKey: "mac.copyLatestCaptureHotkeyShortcut") as? String == "legacy")
+        #expect(defaults.object(forKey: "mac.historyRetentionPeriod") as? String == "forever")
+        #expect(defaults.object(forKey: "mac.showPanelOnLaunch") as? Bool == true)
+        #expect(defaults.object(forKey: "mac.copyToClipboardOnCapture") as? Bool == true)
+        #expect(defaults.object(forKey: "mac.autoPasteOnCapture") as? Bool == true)
+        #expect(defaults.object(forKey: "mac.revealPanelOnCapture") as? Bool == true)
+        #expect(defaults.object(forKey: "mac.openAIBaseURL") as? String == "https://api.groq.com/openai/v1")
+        #expect(defaults.object(forKey: "mac.openAITranslationModel") as? String == "llama-3.3-70b-versatile")
+        #expect(defaults.string(forKey: MacPreferences.translationTargetLanguage) == TranslationTargetLanguage.english.rawValue)
+        #expect(defaults.object(forKey: MacPreferences.translateSelectedTextOnTranslationHotkey) as? Bool == true)
+        #expect(defaults.object(forKey: MacPreferences.hotkeyDistinguishModifierSides) as? Bool == false)
+        #expect(defaults.bool(forKey: MacPreferences.launchAtLogin) == false)
     }
 }
 #endif

--- a/apps/mac/StetTests/App/MacDictationCaptureCoordinatorTests.swift
+++ b/apps/mac/StetTests/App/MacDictationCaptureCoordinatorTests.swift
@@ -7,6 +7,57 @@ import Testing
 @MainActor
 @Suite("Mac Dictation Capture Coordinator", .serialized)
 struct MacDictationCaptureCoordinatorTests {
+    @Test func completedCaptureCopiesTextWithoutAutoPaste() async {
+        let clipboard = TestClipboardService()
+        let textInjection = TestTextInjectionService()
+        let coordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboard,
+            textInjectionService: textInjection
+        )
+
+        let outcome = await coordinator.handleCompletedCapture(
+            text: "hello",
+            targetApplication: nil,
+            settings: .init(
+                shouldCopyToClipboard: true,
+                shouldAutoPaste: false,
+                shouldRevealPanelOnCapture: false
+            ),
+            showPanel: {}
+        )
+
+        #expect(outcome == .completed)
+        #expect(clipboard.copiedTexts == ["hello"])
+        #expect(textInjection.pasteTargets.isEmpty)
+    }
+
+    @Test func completedCaptureAutoPasteSucceedsAndCopiesInSamePath() async {
+        let clipboard = TestClipboardService()
+        let textInjection = TestTextInjectionService()
+        textInjection.pasteResult = true
+        let coordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboard,
+            textInjectionService: textInjection
+        )
+        var revealCount = 0
+
+        let outcome = await coordinator.handleCompletedCapture(
+            text: "hello",
+            targetApplication: nil,
+            settings: .init(
+                shouldCopyToClipboard: false,
+                shouldAutoPaste: true,
+                shouldRevealPanelOnCapture: false
+            ),
+            showPanel: { revealCount += 1 }
+        )
+
+        #expect(outcome == .completed)
+        #expect(clipboard.copiedTexts == ["hello"])
+        #expect(textInjection.pasteTargets.count == 1)
+        #expect(revealCount == 0)
+    }
+
     @Test func completedCaptureCopiesAndPastesWhenEnabled() async {
         let clipboard = TestClipboardService()
         let textInjection = TestTextInjectionService()
@@ -32,6 +83,34 @@ struct MacDictationCaptureCoordinatorTests {
         #expect(clipboard.copiedTexts == ["hello"])
         #expect(textInjection.pasteTargets.count == 1)
         #expect(revealCount == 0)
+    }
+
+    @Test func completedCaptureAutoPasteFailureWhenCopyIsEnabledRevealsPanelAndReturnsCompleted() async {
+        let clipboard = TestClipboardService()
+        let textInjection = TestTextInjectionService()
+        textInjection.isAvailable = false
+        textInjection.pasteResult = false
+        let coordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboard,
+            textInjectionService: textInjection
+        )
+        var revealCount = 0
+
+        let outcome = await coordinator.handleCompletedCapture(
+            text: "hello",
+            targetApplication: nil,
+            settings: .init(
+                shouldCopyToClipboard: true,
+                shouldAutoPaste: true,
+                shouldRevealPanelOnCapture: true
+            ),
+            showPanel: { revealCount += 1 }
+        )
+
+        #expect(outcome == .completed)
+        #expect(clipboard.copiedTexts == ["hello"])
+        #expect(textInjection.didRequestAccessIfNeeded)
+        #expect(revealCount == 1)
     }
 
     @Test func completedCaptureRequestsAccessibilityWhenPasteUnavailable() async {
@@ -89,6 +168,19 @@ struct MacDictationCaptureCoordinatorTests {
         #expect(clipboard.copiedTexts.isEmpty)
         #expect(textInjection.pasteTargets.isEmpty)
         #expect(revealCount == 1)
+    }
+
+    @Test func copyToClipboardCopiesText() {
+        let clipboard = TestClipboardService()
+        let textInjection = TestTextInjectionService()
+        let coordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboard,
+            textInjectionService: textInjection
+        )
+
+        coordinator.copyToClipboard("snippet")
+
+        #expect(clipboard.copiedTexts == ["snippet"])
     }
 
     @Test func completedCaptureSkipsClipboardWhenCopyAndPasteAreDisabled() async {

--- a/apps/mac/StetTests/App/MacDictationCaptureCoordinatorTests.swift
+++ b/apps/mac/StetTests/App/MacDictationCaptureCoordinatorTests.swift
@@ -17,7 +17,7 @@ struct MacDictationCaptureCoordinatorTests {
         )
         var revealCount = 0
 
-        await coordinator.handleCompletedCapture(
+        let outcome = await coordinator.handleCompletedCapture(
             text: "hello",
             targetApplication: nil,
             settings: .init(
@@ -28,6 +28,7 @@ struct MacDictationCaptureCoordinatorTests {
             showPanel: { revealCount += 1 }
         )
 
+        #expect(outcome == .completed)
         #expect(clipboard.copiedTexts == ["hello"])
         #expect(textInjection.pasteTargets.count == 1)
         #expect(revealCount == 0)
@@ -48,7 +49,7 @@ struct MacDictationCaptureCoordinatorTests {
         )
         var revealCount = 0
 
-        _ = await coordinator.handleCompletedCapture(
+        let outcome = await coordinator.handleCompletedCapture(
             text: "hello",
             targetApplication: nil,
             settings: .init(
@@ -59,6 +60,7 @@ struct MacDictationCaptureCoordinatorTests {
             showPanel: { revealCount += 1 }
         )
 
+        #expect(outcome == .clipboardPending)
         #expect(textInjection.didRequestAccessIfNeeded)
         #expect(revealCount == 1)
     }
@@ -72,7 +74,7 @@ struct MacDictationCaptureCoordinatorTests {
         )
         var revealCount = 0
 
-        await coordinator.handleCompletedCapture(
+        let outcome = await coordinator.handleCompletedCapture(
             text: "hello",
             targetApplication: nil,
             settings: .init(
@@ -83,6 +85,7 @@ struct MacDictationCaptureCoordinatorTests {
             showPanel: { revealCount += 1 }
         )
 
+        #expect(outcome == .clipboardPending)
         #expect(clipboard.copiedTexts.isEmpty)
         #expect(textInjection.pasteTargets.isEmpty)
         #expect(revealCount == 1)
@@ -96,7 +99,7 @@ struct MacDictationCaptureCoordinatorTests {
             textInjectionService: textInjection
         )
 
-        await coordinator.handleCompletedCapture(
+        let outcome = await coordinator.handleCompletedCapture(
             text: "hello",
             targetApplication: nil,
             settings: .init(
@@ -107,6 +110,7 @@ struct MacDictationCaptureCoordinatorTests {
             showPanel: {}
         )
 
+        #expect(outcome == .clipboardPending)
         #expect(clipboard.copiedTexts.isEmpty)
         #expect(textInjection.pasteTargets.isEmpty)
     }

--- a/apps/mac/StetTests/App/MacDictationWorkflowControllerTests.swift
+++ b/apps/mac/StetTests/App/MacDictationWorkflowControllerTests.swift
@@ -110,7 +110,7 @@ struct MacDictationWorkflowControllerTests {
 
         #expect(subject.mediaPlaybackController.pauseCallCount == 1)
 
-        subject.controller.handleStateTransition(from: .listening, to: .result("done"))
+        subject.controller.handleStateTransition(from: .listening, to: .processing)
 
         #expect(subject.mediaPlaybackController.resumeCallCount == 1)
         #expect(subject.controller.activeRecordingSource == nil)
@@ -159,6 +159,89 @@ struct MacDictationWorkflowControllerTests {
         #expect(subject.textInjectionService.replacementTexts == ["rewritten"])
         #expect(subject.textInjectionService.didRequestAccessIfNeeded)
         #expect(showPanelCount == 0)
+    }
+
+    @Test func resetWorkflowIfNeededNoopWhenSourceIsActive() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
+        let subject = makeController(defaults: defaults)
+
+        subject.controller.startDictationCapture(source: .hotkey) {}
+
+        subject.controller.resetWorkflowIfNeeded()
+
+        #expect(subject.controller.activeWorkflow == .dictation)
+        #expect(subject.controller.activeRecordingSource == .hotkey)
+    }
+
+    @Test func resetWorkflowIfNeededResetsWhenNoSource() {
+        let subject = makeController()
+        subject.controller.startDictationCapture(source: .hotkey) {}
+        subject.controller.stopActiveCapture()
+
+        subject.controller.resetWorkflowIfNeeded()
+
+        #expect(subject.controller.activeWorkflow == .dictation)
+        #expect(subject.controller.activeRecordingSource == nil)
+    }
+
+    @Test func copyPendingResultToClipboardForwardsText() {
+        let subject = makeController()
+
+        subject.controller.copyPendingResultToClipboard("needs-review")
+
+        #expect(subject.clipboard.copiedTexts == ["needs-review"])
+    }
+
+    @Test func statusTextReflectsDictationStateTransitions() {
+        let subject = makeController()
+
+        #expect(subject.controller.statusText == "Ready")
+
+        subject.controller.startDictationCapture(source: .interface) {}
+        #expect(subject.controller.statusText == "Listening...")
+
+        subject.viewModel.send(.stopTapped)
+        #expect(subject.controller.statusText == "Processing...")
+
+        subject.viewModel.send(.transcriptionSucceeded("hello"))
+        #expect(subject.controller.statusText == "Transcription complete")
+
+        subject.viewModel.send(.clipboardPending("hello"))
+        #expect(subject.controller.statusText == "Copy to clipboard")
+
+        subject.viewModel.send(.transcriptionFailed("failure"))
+        #expect(subject.controller.statusText == "Something went wrong")
+    }
+
+    @Test func listeningToProcessingTransitionResumesPlaybackImmediately() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
+        let subject = makeController(defaults: defaults)
+
+        subject.controller.startDictationCapture(source: .interface) {}
+        subject.controller.handleStateTransition(from: .idle, to: .listening)
+
+        #expect(subject.mediaPlaybackController.pauseCallCount == 1)
+
+        subject.controller.handleStateTransition(from: .listening, to: .processing)
+
+        #expect(subject.mediaPlaybackController.pauseCallCount == 1)
+        #expect(subject.mediaPlaybackController.resumeCallCount == 1)
+    }
+
+    @Test func processingToResultTransitionDoesNotResumePlaybackAgain() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
+        let subject = makeController(defaults: defaults)
+
+        subject.controller.startDictationCapture(source: .interface) {}
+        subject.controller.handleStateTransition(from: .idle, to: .listening)
+        subject.controller.handleStateTransition(from: .listening, to: .processing)
+        subject.controller.handleStateTransition(from: .processing, to: .result("done"))
+
+        #expect(subject.mediaPlaybackController.pauseCallCount == 1)
+        #expect(subject.mediaPlaybackController.resumeCallCount == 1)
     }
 }
 #endif

--- a/apps/mac/StetTests/App/MacDictationWorkflowControllerTests.swift
+++ b/apps/mac/StetTests/App/MacDictationWorkflowControllerTests.swift
@@ -124,13 +124,14 @@ struct MacDictationWorkflowControllerTests {
         let subject = makeController(textInjectionService: textInjectionService)
         var showPanelCount = 0
 
-        await subject.controller.handleCompletedResult(
+        let outcome = await subject.controller.handleCompletedResult(
             text: "hello",
             workflow: .dictation
         ) {
             showPanelCount += 1
         }
 
+        #expect(outcome == .completed)
         #expect(subject.clipboard.copiedTexts == ["hello"])
         #expect(subject.textInjectionService.pasteTargets.count == 1)
         #expect(showPanelCount == 0)
@@ -147,13 +148,14 @@ struct MacDictationWorkflowControllerTests {
         let subject = makeController(textInjectionService: textInjectionService)
         var showPanelCount = 0
 
-        await subject.controller.handleCompletedResult(
+        let outcome = await subject.controller.handleCompletedResult(
             text: "rewritten",
             workflow: .rewriteFromSelection(sourceText: "hello")
         ) {
             showPanelCount += 1
         }
 
+        #expect(outcome == .clipboardPending)
         #expect(subject.textInjectionService.replacementTexts == ["rewritten"])
         #expect(subject.textInjectionService.didRequestAccessIfNeeded)
         #expect(showPanelCount == 0)

--- a/apps/mac/StetTests/App/Windowing/MacDictationPanelLayoutTests.swift
+++ b/apps/mac/StetTests/App/Windowing/MacDictationPanelLayoutTests.swift
@@ -1,0 +1,63 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import Testing
+
+@testable import Stet
+
+@MainActor
+@Suite("Mac Dictation Panel Layout", .serialized)
+struct MacDictationPanelLayoutTests {
+    @Test func panelSizeUsesExpandedHeightOnlyForClipboardPendingState() {
+        let standard = MacDictationPanelLayout.standard
+
+        let nonClipboardStates: [DictationState] = [
+            .idle,
+            .listening,
+            .processing,
+            .result("result"),
+            .error("error")
+        ]
+
+        for state in nonClipboardStates {
+            let size = standard.panelSize(for: state)
+            #expect(size.width == standard.panelWidth)
+            #expect(size.height == standard.collapsedPanelHeight)
+        }
+
+        let clipboardSize = standard.panelSize(for: .clipboardPending("copied text"))
+        #expect(clipboardSize.width == standard.panelWidth)
+        #expect(clipboardSize.height == standard.expandedPanelHeight)
+    }
+
+    @Test func panelLayoutForNilScreenReturnsStandard() {
+        let layout = MacDictationPanelLayout.for(screen: nil)
+        #expect(layout.panelWidth == MacDictationPanelLayout.standard.panelWidth)
+        #expect(layout.collapsedPanelHeight == MacDictationPanelLayout.standard.collapsedPanelHeight)
+        #expect(layout.expandedPanelHeight == MacDictationPanelLayout.standard.expandedPanelHeight)
+        #expect(layout.bottomInset == MacDictationPanelLayout.standard.bottomInset)
+        #expect(layout.scale == MacDictationPanelLayout.standard.scale)
+    }
+
+    @Test func panelLayoutForScreenRespectsCompactOrStandardThresholds() {
+        guard let screen = NSScreen.main else {
+            return
+        }
+
+        let layout = MacDictationPanelLayout.for(screen: screen)
+        let expected: MacDictationPanelLayout = {
+            let visibleFrame = screen.visibleFrame
+            if visibleFrame.width < 1400 || visibleFrame.height < 900 {
+                return .compact
+            }
+            return .standard
+        }()
+
+        #expect(layout.panelWidth == expected.panelWidth)
+        #expect(layout.collapsedPanelHeight == expected.collapsedPanelHeight)
+        #expect(layout.expandedPanelHeight == expected.expandedPanelHeight)
+        #expect(layout.bottomInset == expected.bottomInset)
+        #expect(layout.scale == expected.scale)
+    }
+}
+#endif

--- a/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -1,0 +1,202 @@
+#if os(macOS)
+import Foundation
+import Testing
+
+@testable import Stet
+
+@MainActor
+private final class FakeShellPresenter: MacShellPresenting {
+    var onVisibilityChange: (() -> Void)?
+
+    private(set) var isPanelVisible = false
+
+    private(set) var showPanelCallCount = 0
+    private(set) var showTransientPanelCallCount = 0
+    private(set) var hidePanelCallCount = 0
+    private(set) var togglePanelCallCount = 0
+    private(set) var panelDidHideCallCount = 0
+    private(set) var cancelScheduledPanelHideCallCount = 0
+    private(set) var scheduleTransientPanelHideCallCount = 0
+    private(set) var applyDockVisibilityCallCount = 0
+    private(set) var lastShowInDockValue: Bool?
+
+    func showPanel(appModel: any MacDictationPanelCoordinating) {
+        showPanelCallCount += 1
+        isPanelVisible = true
+        onVisibilityChange?()
+    }
+
+    func showTransientPanel(appModel: any MacDictationPanelCoordinating) {
+        showTransientPanelCallCount += 1
+        isPanelVisible = true
+        onVisibilityChange?()
+    }
+
+    func hidePanel() {
+        hidePanelCallCount += 1
+        isPanelVisible = false
+        onVisibilityChange?()
+    }
+
+    func togglePanel(appModel: any MacDictationPanelCoordinating) {
+        togglePanelCallCount += 1
+        isPanelVisible.toggle()
+        onVisibilityChange?()
+    }
+
+    func panelDidHide() {
+        panelDidHideCallCount += 1
+        isPanelVisible = false
+    }
+
+    func cancelScheduledPanelHide() {
+        cancelScheduledPanelHideCallCount += 1
+    }
+
+    func scheduleTransientPanelHideIfNeeded(currentState: @escaping @MainActor () -> DictationState) {
+        scheduleTransientPanelHideCallCount += 1
+        _ = currentState()
+    }
+
+    func applyDockVisibility(showInDock: Bool) {
+        applyDockVisibilityCallCount += 1
+        lastShowInDockValue = showInDock
+    }
+
+    func openSettings(currentShowInDockPreference: Bool, using action: () -> Void) {
+        action()
+    }
+
+    func settingsDidAppear(currentShowInDockPreference: Bool) {}
+
+    func settingsDidDisappear(currentShowInDockPreference: Bool) {}
+}
+
+@MainActor
+private final class FakePermissionGatePresenter: MacPermissionGatePresenting {
+    private(set) var showCallCount = 0
+    private(set) var hideCallCount = 0
+
+    func show(appModel: any MacPermissionsCoordinating) {
+        showCallCount += 1
+    }
+
+    func hide() {
+        hideCallCount += 1
+    }
+}
+
+@MainActor
+private final class FakeHotkeyRegistrar: MacDictationHotkeyRegistering {
+    private(set) var clearDictationHandlersCallCount = 0
+    private(set) var registerKeyDownCallCount = 0
+    private(set) var registerKeyUpCallCount = 0
+
+    func clearDictationHandlers() {
+        clearDictationHandlersCallCount += 1
+    }
+
+    func registerDictationKeyDown(_ handler: @escaping () -> Void) {
+        registerKeyDownCallCount += 1
+    }
+
+    func registerDictationKeyUp(_ handler: @escaping () -> Void) {
+        registerKeyUpCallCount += 1
+    }
+}
+
+@MainActor
+private final class FakeMediaPlaybackController: MediaPlaybackControlling {
+    private(set) var pausePlaybackIfNeededCallCount = 0
+    private(set) var resumePlaybackIfNeededCallCount = 0
+
+    func pausePlaybackIfNeeded() {
+        pausePlaybackIfNeededCallCount += 1
+    }
+
+    func resumePlaybackIfNeeded() {
+        resumePlaybackIfNeededCallCount += 1
+    }
+}
+
+@MainActor
+@Suite("Mac App Session Controller Action Behavior", .serialized)
+struct MacAppSessionControllerActionTests {
+    private func makeSubject() -> (
+        session: MacAppSessionController,
+        workflow: MacDictationWorkflowController,
+        shell: FakeShellPresenter,
+        permissionGate: FakePermissionGatePresenter
+    ) {
+        let defaults = TestSupport.makeUserDefaults()
+        let speechService = ControllableSpeechService()
+        let textInjectionService = TestTextInjectionService()
+        let clipboardService = TestClipboardService()
+        let mediaPlaybackController = FakeMediaPlaybackController()
+        let settingsStore = DictationSettingsStore(
+            defaults: defaults,
+            secretStore: TestSecretStore()
+        )
+        let dictationViewModel = DictationViewModel(speechService: speechService)
+        let captureCoordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboardService,
+            textInjectionService: textInjectionService
+        )
+        let workflow = MacDictationWorkflowController(
+            dictationViewModel: dictationViewModel,
+            captureCoordinator: captureCoordinator,
+            textInjectionService: textInjectionService,
+            mediaPlaybackController: mediaPlaybackController,
+            settingsStore: settingsStore,
+            interactionSoundPlayer: InteractionSoundPlayer()
+        )
+        let permissionManager = MacPermissionManager(textInjectionService: textInjectionService)
+        let shell = FakeShellPresenter()
+        let permissionGate = FakePermissionGatePresenter()
+        let hotkeyRegistrar = FakeHotkeyRegistrar()
+
+        let session = MacAppSessionController(
+            workflowController: workflow,
+            shellPresentationController: shell,
+            permissionGateController: permissionGate,
+            permissionManager: permissionManager,
+            hotkeyRegistrar: hotkeyRegistrar
+        )
+
+        return (session: session, workflow: workflow, shell: shell, permissionGate: permissionGate)
+    }
+
+    @Test func cancelActiveCaptureHidesPanelAndResetsWorkflowState() {
+        let subject = makeSubject()
+
+        subject.workflow.startDictationCapture(source: .interface) {}
+
+        #expect(subject.workflow.dictationViewModel.state == .listening)
+        #expect(subject.workflow.activeRecordingSource == .interface)
+        #expect(subject.shell.hidePanelCallCount == 0)
+
+        subject.session.cancelActiveCapture()
+
+        #expect(subject.workflow.activeRecordingSource == nil)
+        #expect(subject.workflow.dictationViewModel.state == .idle)
+        #expect(subject.shell.hidePanelCallCount == 1)
+        #expect(subject.shell.isPanelVisible == false)
+    }
+
+    @Test func dismissPendingCopyHidesPanelAndResetsClipboardPendingState() async {
+        let subject = makeSubject()
+
+        subject.workflow.dictationViewModel.send(.clipboardPending("needs copy"))
+
+        #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .clipboardPending("needs copy") })
+        #expect(subject.shell.hidePanelCallCount == 0)
+
+        subject.session.dismissPendingCopy()
+
+        #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .idle })
+        #expect(subject.shell.hidePanelCallCount == 1)
+        #expect(subject.shell.isPanelVisible == false)
+    }
+}
+
+#endif

--- a/apps/mac/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
@@ -1,0 +1,254 @@
+#if os(macOS)
+import Combine
+import Foundation
+import Testing
+
+@testable import Stet
+
+@MainActor
+private final class TestShellPresenter: MacShellPresenting {
+    var onVisibilityChange: (() -> Void)?
+    private(set) var isPanelVisible = false
+    private(set) var applyDockVisibilityCalls: [Bool] = []
+    private(set) var openSettingsCalls: [Bool] = []
+    private(set) var settingsDidAppearCalls: [Bool] = []
+    private(set) var settingsDidDisappearCalls: [Bool] = []
+    private(set) var cancelScheduledPanelHideCount = 0
+    private(set) var schedulePanelHideCallCount = 0
+    private(set) var showPanelCallCount = 0
+    private(set) var showTransientPanelCallCount = 0
+    private(set) var hidePanelCallCount = 0
+    private(set) var togglePanelCallCount = 0
+
+    func showPanel(appModel: any MacDictationPanelCoordinating) {
+        showPanelCallCount += 1
+        isPanelVisible = true
+        onVisibilityChange?()
+    }
+
+    func showTransientPanel(appModel: any MacDictationPanelCoordinating) {
+        showTransientPanelCallCount += 1
+        isPanelVisible = true
+        onVisibilityChange?()
+    }
+
+    func hidePanel() {
+        hidePanelCallCount += 1
+        isPanelVisible = false
+        onVisibilityChange?()
+    }
+
+    func togglePanel(appModel: any MacDictationPanelCoordinating) {
+        togglePanelCallCount += 1
+        isPanelVisible.toggle()
+        onVisibilityChange?()
+    }
+
+    func panelDidHide() {
+        isPanelVisible = false
+        onVisibilityChange?()
+    }
+
+    func cancelScheduledPanelHide() {
+        cancelScheduledPanelHideCount += 1
+    }
+
+    func scheduleTransientPanelHideIfNeeded(currentState: @escaping @MainActor () -> DictationState) {
+        schedulePanelHideCallCount += 1
+    }
+
+    func applyDockVisibility(showInDock: Bool) {
+        applyDockVisibilityCalls.append(showInDock)
+    }
+
+    func openSettings(currentShowInDockPreference: Bool, using action: () -> Void) {
+        openSettingsCalls.append(currentShowInDockPreference)
+        action()
+    }
+
+    func settingsDidAppear(currentShowInDockPreference: Bool) {
+        settingsDidAppearCalls.append(currentShowInDockPreference)
+    }
+
+    func settingsDidDisappear(currentShowInDockPreference: Bool) {
+        settingsDidDisappearCalls.append(currentShowInDockPreference)
+    }
+}
+
+@MainActor
+private final class TestPermissionGatePresenter: MacPermissionGatePresenting {
+    private(set) var showCallCount = 0
+    private(set) var hideCallCount = 0
+
+    func show(appModel: any MacPermissionsCoordinating) {
+        showCallCount += 1
+    }
+
+    func hide() {
+        hideCallCount += 1
+    }
+}
+
+@MainActor
+private final class TestHotkeyRegistrar: MacDictationHotkeyRegistering {
+    private(set) var clearHandlersCallCount = 0
+    private(set) var registerKeyDownCallCount = 0
+    private(set) var registerKeyUpCallCount = 0
+
+    func clearDictationHandlers() {
+        clearHandlersCallCount += 1
+    }
+
+    func registerDictationKeyDown(_ handler: @escaping () -> Void) {
+        registerKeyDownCallCount += 1
+    }
+
+    func registerDictationKeyUp(_ handler: @escaping () -> Void) {
+        registerKeyUpCallCount += 1
+    }
+}
+
+@MainActor
+private final class TestMediaPlaybackController: MediaPlaybackControlling {
+    func pausePlaybackIfNeeded() {}
+
+    func resumePlaybackIfNeeded() {}
+}
+
+@MainActor
+@Suite("Mac App Session Controller Settings", .serialized)
+struct MacAppSessionControllerSettingsTests {
+    private func makeSut(
+        defaults: UserDefaults,
+        textInjectionService: TestTextInjectionService
+    ) -> (
+        sessionController: MacAppSessionController,
+        workflowController: MacDictationWorkflowController,
+        shellPresenter: TestShellPresenter,
+        permissionGatePresenter: TestPermissionGatePresenter,
+        hotkeyRegistrar: TestHotkeyRegistrar
+    ) {
+        let shellPresenter = TestShellPresenter()
+        let permissionGatePresenter = TestPermissionGatePresenter()
+        let hotkeyRegistrar = TestHotkeyRegistrar()
+
+        let speechService = ControllableSpeechService()
+        let dictationViewModel = DictationViewModel(speechService: speechService)
+        let clipboardService = TestClipboardService()
+        let captureCoordinator = MacDictationCaptureCoordinator(
+            clipboardService: clipboardService,
+            textInjectionService: textInjectionService
+        )
+        let settingsStore = DictationSettingsStore(
+            defaults: defaults,
+            secretStore: TestSecretStore()
+        )
+        let workflowController = MacDictationWorkflowController(
+            dictationViewModel: dictationViewModel,
+            captureCoordinator: captureCoordinator,
+            textInjectionService: textInjectionService,
+            mediaPlaybackController: TestMediaPlaybackController(),
+            settingsStore: settingsStore,
+            interactionSoundPlayer: InteractionSoundPlayer()
+        )
+        let permissionManager = MacPermissionManager(textInjectionService: textInjectionService)
+
+        let sessionController = MacAppSessionController(
+            workflowController: workflowController,
+            shellPresentationController: shellPresenter,
+            permissionGateController: permissionGatePresenter,
+            permissionManager: permissionManager,
+            defaults: defaults,
+            notificationCenter: NotificationCenter(),
+            hotkeyRegistrar: hotkeyRegistrar
+        )
+
+        return (
+            sessionController: sessionController,
+            workflowController: workflowController,
+            shellPresenter: shellPresenter,
+            permissionGatePresenter: permissionGatePresenter,
+            hotkeyRegistrar: hotkeyRegistrar
+        )
+    }
+
+    @Test func applyDockVisibilityForwardsValueToPresentationController() {
+        let defaults = TestSupport.makeUserDefaults()
+        let textInjectionService = TestTextInjectionService()
+        let (sut, _, shellPresenter, _, _) = makeSut(
+            defaults: defaults,
+            textInjectionService: textInjectionService
+        )
+
+        sut.applyDockVisibility(showInDock: true)
+        sut.applyDockVisibility(showInDock: false)
+
+        #expect(shellPresenter.applyDockVisibilityCalls == [true, false])
+    }
+
+    @Test func openSettingsForwardsCurrentPreferenceAndRunsAction() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.showInDock)
+        let textInjectionService = TestTextInjectionService()
+        let (sut, _, shellPresenter, _, _) = makeSut(
+            defaults: defaults,
+            textInjectionService: textInjectionService
+        )
+        var actionDidRun = false
+
+        sut.openSettings {
+            actionDidRun = true
+        }
+
+        #expect(shellPresenter.openSettingsCalls == [true])
+        #expect(actionDidRun)
+    }
+
+    @Test func settingsDidAppearForwardsCurrentPreference() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(false, forKey: MacPreferences.showInDock)
+        let textInjectionService = TestTextInjectionService()
+        let (sut, _, shellPresenter, _, _) = makeSut(
+            defaults: defaults,
+            textInjectionService: textInjectionService
+        )
+
+        sut.settingsDidAppear()
+
+        #expect(shellPresenter.settingsDidAppearCalls == [false])
+    }
+
+    @Test func settingsDidDisappearForwardsCurrentPreference() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.showInDock)
+        let textInjectionService = TestTextInjectionService()
+        let (sut, _, shellPresenter, _, _) = makeSut(
+            defaults: defaults,
+            textInjectionService: textInjectionService
+        )
+
+        sut.settingsDidDisappear()
+
+        #expect(shellPresenter.settingsDidDisappearCalls == [true])
+    }
+
+    @Test func refreshRuntimeFromSettingsAppliesDockSettingAndNotifiesChange() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set(true, forKey: MacPreferences.showInDock)
+        let textInjectionService = TestTextInjectionService()
+        let (sut, _, shellPresenter, _, _) = makeSut(
+            defaults: defaults,
+            textInjectionService: textInjectionService
+        )
+        var onChangeCount = 0
+        sut.onChange = {
+            onChangeCount += 1
+        }
+
+        sut.refreshRuntimeFromSettings()
+
+        #expect(shellPresenter.applyDockVisibilityCalls == [true])
+        #expect(onChangeCount == 1)
+    }
+}
+#endif

--- a/apps/mac/StetTests/Core/ConfigurableSpeechServiceTests.swift
+++ b/apps/mac/StetTests/Core/ConfigurableSpeechServiceTests.swift
@@ -113,6 +113,39 @@ struct ConfigurableSpeechServiceTests {
         }
     }
 
+    @Test func defaultCaptureServiceFactoryIsNotInvokedUntilRecordingStarts() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+
+        let direct = TestTranscriptionService(result: "source")
+        let relay = TestTranscriptionService(result: "relay")
+        let rewrite = RecordingRewriteService()
+        let (store, _, _) = try makeSettingsStore()
+        let factory = CountingAudioCaptureFactory(audioFileURL: audioFileURL)
+
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                relayAuthenticationContext: { nil },
+                makeDirectTranscriptionService: { _, _ in direct },
+                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRewriteService: { _, _ in rewrite }
+            ),
+            captureServiceFactory: {
+                factory.makeCaptureService()
+            }
+        )
+
+        #expect(factory.invocationCount == 0)
+        _ = await service.makeAudioLevelStream()
+        #expect(factory.invocationCount == 0)
+
+        try await service.startRecording()
+
+        #expect(factory.invocationCount == 1)
+        await service.cancelRecording()
+    }
+
     @Test func startRecordingCanBeCalledOnlyOnceUntilStopOrCancel() async throws {
         let audioFileURL = makeAudioFileURL()
         defer { try? FileManager.default.removeItem(at: audioFileURL) }
@@ -427,6 +460,29 @@ private actor TestAudioCaptureService: AudioCaptureService, AudioLevelSource {
         AsyncStream { continuation in
             continuation.finish()
         }
+    }
+}
+
+private final class CountingAudioCaptureFactory: @unchecked Sendable {
+    private let lock = NSLock()
+    private let audioFileURL: URL
+    private var invocationCountValue = 0
+
+    init(audioFileURL: URL) {
+        self.audioFileURL = audioFileURL
+    }
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCountValue
+    }
+
+    func makeCaptureService() -> any AudioCaptureService {
+        lock.lock()
+        invocationCountValue += 1
+        lock.unlock()
+        return TestAudioCaptureService(audioFileURL: audioFileURL)
     }
 }
 

--- a/apps/mac/StetTests/Features/DictationViewModelTests.swift
+++ b/apps/mac/StetTests/Features/DictationViewModelTests.swift
@@ -80,4 +80,13 @@ struct DictationViewModelTests {
 
         #expect(viewModel.state == .error(TestError.expected.localizedDescription))
     }
+
+    @Test func clipboardPendingActionPublishesClipboardPendingState() {
+        let speechService = ControllableSpeechService()
+        let viewModel = DictationViewModel(speechService: speechService)
+
+        viewModel.send(.clipboardPending("hello"))
+
+        #expect(viewModel.state == .clipboardPending("hello"))
+    }
 }

--- a/apps/mac/StetTests/Features/MacShell/MacDictationPanelViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/MacDictationPanelViewModelTests.swift
@@ -1,0 +1,104 @@
+import Combine
+import Foundation
+import Testing
+
+@testable import Stet
+
+@MainActor
+@Suite("Mac Dictation Panel View Model")
+struct MacDictationPanelViewModelTests {
+    final class StubPanelModel: MacDictationPanelCoordinating {
+        private let updatesSubject = PassthroughSubject<Void, Never>()
+
+        var updates: AnyPublisher<Void, Never> {
+            updatesSubject.eraseToAnyPublisher()
+        }
+
+        var dictationState: DictationState
+        var statusText: String
+        var recordingLevel: Double
+
+        private(set) var hidePanelCallCount = 0
+        private(set) var dismissPendingCopyCallCount = 0
+        private(set) var cancelActiveCaptureCallCount = 0
+        private(set) var performPrimaryActionCallCount = 0
+
+        init(
+            dictationState: DictationState = .idle,
+            statusText: String = "Ready",
+            recordingLevel: Double = 0.0
+        ) {
+            self.dictationState = dictationState
+            self.statusText = statusText
+            self.recordingLevel = recordingLevel
+        }
+
+        func emitUpdate() {
+            updatesSubject.send(())
+        }
+
+        func hidePanel() {
+            hidePanelCallCount += 1
+        }
+
+        func dismissPendingCopy() {
+            dismissPendingCopyCallCount += 1
+        }
+
+        func cancelActiveCapture() {
+            cancelActiveCaptureCallCount += 1
+        }
+
+        func performPrimaryAction() {
+            performPrimaryActionCallCount += 1
+        }
+    }
+
+    @Test func initialStateIsPulledFromAppModel() {
+        let appModel = StubPanelModel(
+            dictationState: .clipboardPending("hello"),
+            statusText: "Ready to paste",
+            recordingLevel: 0.64
+        )
+        let viewModel = MacDictationPanelViewModel(appModel: appModel)
+
+        #expect(viewModel.state == .clipboardPending("hello"))
+        #expect(viewModel.statusText == "Ready to paste")
+        #expect(viewModel.recordingLevel == 0.64)
+    }
+
+    @Test func appModelUpdatesArePropagatedToPublishedProperties() async {
+        let appModel = StubPanelModel(
+            dictationState: .idle,
+            statusText: "Listening",
+            recordingLevel: 0.2
+        )
+        let viewModel = MacDictationPanelViewModel(appModel: appModel)
+
+        appModel.dictationState = .listening
+        appModel.statusText = "Listening..."
+        appModel.recordingLevel = 0.92
+        appModel.emitUpdate()
+
+        #expect(await TestSupport.eventually {
+            viewModel.state == .listening &&
+            viewModel.statusText == "Listening..." &&
+            viewModel.recordingLevel == 0.92
+        })
+    }
+
+    @Test func forwardingActionsCallThroughToAppModel() {
+        let appModel = StubPanelModel()
+        let viewModel = MacDictationPanelViewModel(appModel: appModel)
+
+        viewModel.hidePanel()
+        viewModel.dismissPendingCopy()
+        viewModel.cancelActiveCapture()
+        viewModel.performPrimaryAction()
+
+        #expect(appModel.hidePanelCallCount == 1)
+        #expect(appModel.dismissPendingCopyCallCount == 1)
+        #expect(appModel.cancelActiveCaptureCallCount == 1)
+        #expect(appModel.performPrimaryActionCallCount == 1)
+    }
+}

--- a/apps/mac/StetTests/Features/MacShell/MacPermissionsViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/MacPermissionsViewModelTests.swift
@@ -1,0 +1,128 @@
+#if os(macOS)
+import Combine
+import Foundation
+import Testing
+
+@testable import Stet
+
+@MainActor
+private final class TestMacPermissionsCoordinator: MacPermissionsCoordinating {
+    private let updatesSubject = PassthroughSubject<Void, Never>()
+    let updates: AnyPublisher<Void, Never>
+
+    var autoPasteStatusText: String
+    var microphoneAccessStatusText: String
+    var microphoneAccessNeedsAttention: Bool
+    var microphonePermissionActionTitle: String
+    var autoPasteAccessNeedsAttention: Bool
+
+    private(set) var requestAutoPasteAccessCallCount = 0
+    private(set) var resolveMicrophoneAccessCallCount = 0
+    private(set) var openAccessibilitySettingsCallCount = 0
+
+    init(
+        autoPasteStatusText: String,
+        microphoneAccessStatusText: String,
+        microphoneAccessNeedsAttention: Bool,
+        microphonePermissionActionTitle: String,
+        autoPasteAccessNeedsAttention: Bool
+    ) {
+        self.autoPasteStatusText = autoPasteStatusText
+        self.microphoneAccessStatusText = microphoneAccessStatusText
+        self.microphoneAccessNeedsAttention = microphoneAccessNeedsAttention
+        self.microphonePermissionActionTitle = microphonePermissionActionTitle
+        self.autoPasteAccessNeedsAttention = autoPasteAccessNeedsAttention
+        self.updates = updatesSubject.eraseToAnyPublisher()
+    }
+
+    func emitUpdate() {
+        updatesSubject.send(())
+    }
+
+    func requestAutoPasteAccess() {
+        requestAutoPasteAccessCallCount += 1
+    }
+
+    func resolveMicrophoneAccess() {
+        resolveMicrophoneAccessCallCount += 1
+    }
+
+    func openAccessibilitySettings() {
+        openAccessibilitySettingsCallCount += 1
+    }
+}
+
+@MainActor
+@Suite("Mac Permissions View Model", .serialized)
+struct MacPermissionsViewModelTests {
+    private func makeSut() -> (
+        viewModel: MacPermissionsViewModel,
+        coordinator: TestMacPermissionsCoordinator
+    ) {
+        let coordinator = TestMacPermissionsCoordinator(
+            autoPasteStatusText: "Auto-paste not ready",
+            microphoneAccessStatusText: "Microphone blocked",
+            microphoneAccessNeedsAttention: true,
+            microphonePermissionActionTitle: "Resolve microphone",
+            autoPasteAccessNeedsAttention: true
+        )
+
+        return (MacPermissionsViewModel(coordinator: coordinator), coordinator)
+    }
+
+    @Test func computedPropertiesReflectCoordinatorState() {
+        let (viewModel, coordinator) = makeSut()
+
+        #expect(viewModel.autoPasteStatusText == coordinator.autoPasteStatusText)
+        #expect(viewModel.microphoneAccessStatusText == coordinator.microphoneAccessStatusText)
+        #expect(viewModel.microphoneAccessNeedsAttention == coordinator.microphoneAccessNeedsAttention)
+        #expect(viewModel.microphonePermissionActionTitle == coordinator.microphonePermissionActionTitle)
+        #expect(viewModel.autoPasteAccessNeedsAttention == coordinator.autoPasteAccessNeedsAttention)
+    }
+
+    @Test func updatesDriveViewRefreshForCoordinatorChanges() async {
+        let (viewModel, coordinator) = makeSut()
+
+        var changeCount = 0
+        var changeCancellable: AnyCancellable?
+        changeCancellable = viewModel.objectWillChange.sink {
+            changeCount += 1
+        }
+
+        coordinator.autoPasteStatusText = "Auto-paste ready"
+        coordinator.microphoneAccessNeedsAttention = false
+        coordinator.emitUpdate()
+
+        #expect(await TestSupport.eventually { changeCount == 1 })
+
+        _ = changeCancellable
+
+        #expect(viewModel.autoPasteStatusText == "Auto-paste ready")
+        #expect(viewModel.microphoneAccessNeedsAttention == false)
+    }
+
+    @Test func requestAutoPasteAccessForwardsToCoordinator() {
+        let (viewModel, coordinator) = makeSut()
+
+        viewModel.requestAutoPasteAccess()
+
+        #expect(coordinator.requestAutoPasteAccessCallCount == 1)
+    }
+
+    @Test func resolveMicrophoneAccessForwardsToCoordinator() {
+        let (viewModel, coordinator) = makeSut()
+
+        viewModel.resolveMicrophoneAccess()
+
+        #expect(coordinator.resolveMicrophoneAccessCallCount == 1)
+    }
+
+    @Test func openAccessibilitySettingsForwardsToCoordinator() {
+        let (viewModel, coordinator) = makeSut()
+
+        viewModel.openAccessibilitySettings()
+
+        #expect(coordinator.openAccessibilitySettingsCallCount == 1)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- defer mac audio capture service creation until recording actually starts
- resume paused media immediately when dictation leaves the listening state
- add and update mac workflow and shell tests around panel state, permissions, and playback timing

## Testing
- xcodebuild test -project apps/mac/Stet.xcodeproj -scheme Stet -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:StetTests/MacDictationWorkflowControllerTests