### PR TITLE
Avoid reactivating visible onboarding window

### DIFF
--- a/apps/mac/Stet/App/Windowing/MacOnboardingWindowController.swift
+++ b/apps/mac/Stet/App/Windowing/MacOnboardingWindowController.swift
@@ -8,6 +8,14 @@ final class MacOnboardingWindowController {
 
     func show(appModel: any MacPermissionsCoordinating) {
         if let window = windowController?.window {
+            guard !window.isVisible else {
+                return
+            }
+
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return


### PR DESCRIPTION
## Summary
- stop reactivating the onboarding window when it is already visible
- only bring the onboarding window forward again when it needs to be restored from a hidden or minimized state
- prevent onboarding state refreshes from repeatedly stealing focus from other apps

## Validation
- xcodebuild -project apps/mac/Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' build
- manually confirmed the onboarding window no longer jumps back to the front during normal state updates