### PR TITLE
Isolate local release app identity

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/macos-ci.yml"
+      - ".swift-format"
       - ".swiftlint.yml"
       - "package.json"
       - "apps/mac/**"
@@ -12,6 +13,7 @@ on:
       - main
     paths:
       - ".github/workflows/macos-ci.yml"
+      - ".swift-format"
       - ".swiftlint.yml"
       - "package.json"
       - "apps/mac/**"
@@ -64,3 +66,20 @@ jobs:
 
       - name: Build macOS app
         run: npm run mac:ci:build
+
+  macos-tests:
+    name: macOS Tests
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show Xcode Version
+        run: xcodebuild -version
+
+      - name: Run macOS tests
+        run: npm run mac:test

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -55,7 +55,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -72,7 +72,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/README.md
+++ b/README.md
@@ -56,14 +56,17 @@ If `Stet Debug` does not appear in System Settings and clicking `Request Access`
 - the built app should contain `com.apple.security.device.audio-input` in its generated entitlements
 - without that entitlement, `tccd` rejects the request before showing a prompt
 
-### Debug and installed apps must not share the same identity
+### Local builds and installed apps must not share the same identity
 
-Do not use the same bundle identifier for the Xcode Debug app and the installed `/Applications/Stet.app`.
+Do not use the same bundle identifier for local Xcode builds and the installed `/Applications/Stet.app`.
 
 - `Debug` uses `NaichengDeng.Stet.Debug`
-- `Release` uses `NaichengDeng.Stet`
+- local `./scripts/build-macos-release.sh` now uses `NaichengDeng.Stet.LocalRelease`
+- shipped / notarized Release uses `NaichengDeng.Stet`
 
 Keeping these separate avoids TCC and Launch Services collisions across microphone permission, Accessibility permission, and OAuth callback handling.
+
+If you previously launched a local Release build signed with Apple Development using `NaichengDeng.Stet`, macOS may have stored Accessibility consent for the wrong code requirement. In that case the installed Developer ID app can still show as enabled in System Settings but fail `AXIsProcessTrusted()` at runtime.
 
 ### Onboarding still shows microphone access as blocked after Allow
 

--- a/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
@@ -4,10 +4,6 @@
 
     @MainActor
     final class MacDictationWorkflowController {
-        private enum Configuration {
-            static let startPromptActivationDeadline: Duration = .milliseconds(350)
-        }
-
         enum PrimaryActionSource {
             case interface
             case hotkey
@@ -38,6 +34,7 @@
         private let settingsStore: DictationSettingsStore
         private let interactionSoundPlayer: any InteractionSoundPlaying
         private let mediaResumeDelay: Duration
+        private let startPromptActivationDeadline: Duration
 
         private weak var lastTargetApplication: NSRunningApplication?
         private(set) var activeRecordingSource: PrimaryActionSource?
@@ -53,7 +50,8 @@
             systemAudioMuting: (any SystemAudioMuting)? = nil,
             settingsStore: DictationSettingsStore,
             interactionSoundPlayer: any InteractionSoundPlaying,
-            mediaResumeDelay: Duration = .seconds(1)
+            mediaResumeDelay: Duration = .seconds(1),
+            startPromptActivationDeadline: Duration = .milliseconds(350)
         ) {
             self.dictationViewModel = dictationViewModel
             self.captureCoordinator = captureCoordinator
@@ -63,6 +61,7 @@
             self.settingsStore = settingsStore
             self.interactionSoundPlayer = interactionSoundPlayer
             self.mediaResumeDelay = mediaResumeDelay
+            self.startPromptActivationDeadline = startPromptActivationDeadline
         }
 
         deinit {
@@ -307,7 +306,7 @@
                     await interactionSoundPlayer.playStartPrompt(preset: preset)
                 }
                 group.addTask {
-                    try? await Task.sleep(for: Configuration.startPromptActivationDeadline)
+                    try? await Task.sleep(for: self.startPromptActivationDeadline)
                 }
 
                 await group.next()

--- a/apps/mac/Stet/Core/AppBranch/AppAudience.swift
+++ b/apps/mac/Stet/Core/AppBranch/AppAudience.swift
@@ -14,6 +14,7 @@
         private nonisolated static let aiNameFragments: [String] = [
             "android studio",
             "androidstudio",
+            "android.studio",
             "aider",
             "antigravity",
             "augment",
@@ -39,6 +40,7 @@
             "pycharm",
             "replit",
             "roo code",
+            "roocode",
             "rider",
             "trae",
             "vscode",

--- a/apps/mac/Stet/Core/AppBranch/AppBranchMonitor.swift
+++ b/apps/mac/Stet/Core/AppBranch/AppBranchMonitor.swift
@@ -12,7 +12,8 @@ private extension NSLocking {
 private nonisolated struct AppBranchMonitorState {
     var isMonitoring = false
     var excludedBundleID: String?
-    var previousApp: AppInfo?
+    var currentNonExcludedApp: AppInfo?
+    var previousNonExcludedApp: AppInfo?
     var observationToken: AppBranchWorkspaceObservationToken?
     var observers: [UUID: AppChangeObserver] = [:]
 }
@@ -175,8 +176,16 @@ public nonisolated final class AppBranchMonitor: @unchecked Sendable {
         }
 
         if let excludedID = state.excludedBundleID, bundleID == excludedID {
-            if let previousApp = state.previousApp, previousApp.bundleIdentifier != excludedID {
-                return previousApp
+            if let currentNonExcludedApp = state.currentNonExcludedApp,
+                currentNonExcludedApp.bundleIdentifier != excludedID
+            {
+                return currentNonExcludedApp
+            }
+
+            if let previousNonExcludedApp = state.previousNonExcludedApp,
+                previousNonExcludedApp.bundleIdentifier != excludedID
+            {
+                return previousNonExcludedApp
             }
             return nil
         }
@@ -189,7 +198,10 @@ public nonisolated final class AppBranchMonitor: @unchecked Sendable {
             runningApplication: frontmostApp.runningApplication
         )
 
-        state.previousApp = appInfo
+        if state.currentNonExcludedApp?.bundleIdentifier != appInfo.bundleIdentifier {
+            state.previousNonExcludedApp = state.currentNonExcludedApp
+        }
+        state.currentNonExcludedApp = appInfo
         return appInfo
     }
 }

--- a/apps/mac/Stet/Features/Dictation/DictationViewModel.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationViewModel.swift
@@ -3,14 +3,11 @@ import Combine
 
 @MainActor
 final class DictationViewModel: ObservableObject {
-    private enum Configuration {
-        static let manualActivationFallbackDelay: Duration = .seconds(1)
-    }
-
     typealias ResultTransformer = @MainActor @Sendable (String) async throws -> String
     typealias ExternalOperation = @MainActor @Sendable () async throws -> String
 
     private let speechService: any SpeechService
+    private let manualActivationFallbackDelay: Duration
     private var activeTask: Task<Void, Never>?
     private var captureStartupTask: Task<Void, Error>?
     private var activationFallbackTask: Task<Void, Never>?
@@ -27,8 +24,12 @@ final class DictationViewModel: ObservableObject {
     @Published private(set) var state: DictationState = .idle
     @Published private(set) var recordingLevel = 0.0
 
-    init(speechService: any SpeechService) {
+    init(
+        speechService: any SpeechService,
+        manualActivationFallbackDelay: Duration = .seconds(1)
+    ) {
         self.speechService = speechService
+        self.manualActivationFallbackDelay = manualActivationFallbackDelay
     }
 
     func send(_ action: DictationAction) {
@@ -402,11 +403,7 @@ final class DictationViewModel: ObservableObject {
     private func scheduleActivationFallbackIfNeeded() {
         activationFallbackTask?.cancel()
         activationFallbackTask = Task { [weak self] in
-            defer {
-                self?.activationFallbackTask = nil
-            }
-
-            try? await Task.sleep(for: Configuration.manualActivationFallbackDelay)
+            try? await Task.sleep(for: self?.manualActivationFallbackDelay ?? .seconds(1))
             guard let self,
                 !Task.isCancelled,
                 self.hasPreparedCapture,
@@ -415,6 +412,7 @@ final class DictationViewModel: ObservableObject {
                 return
             }
 
+            self.activationFallbackTask = nil
             try? await self.activateCaptureWindowInline()
         }
     }

--- a/apps/mac/StetTests/App/Lifecycle/MacAppPrimitiveTests.swift
+++ b/apps/mac/StetTests/App/Lifecycle/MacAppPrimitiveTests.swift
@@ -10,12 +10,12 @@
     struct MacAppPrimitiveTests {
         @Test(arguments: [
             (MacOnboardingStep.mode, 1, false),
-            (MacOnboardingStep.apiKey, 2, false),
-            (MacOnboardingStep.login, 2, false),
-            (MacOnboardingStep.permissions, 3, false),
-            (MacOnboardingStep.shortcut, 4, true),
-            (MacOnboardingStep.firstSuccess, 5, true),
-            (MacOnboardingStep.done, 6, false),
+            (MacOnboardingStep.apiKey, 1, false),
+            (MacOnboardingStep.login, 1, false),
+            (MacOnboardingStep.permissions, 2, false),
+            (MacOnboardingStep.shortcut, 3, true),
+            (MacOnboardingStep.firstSuccess, 4, true),
+            (MacOnboardingStep.done, 5, false),
         ])
         func onboardingStepMetadata(
             _ step: MacOnboardingStep,
@@ -27,8 +27,8 @@
         }
 
         @Test func dictationProviderUsesExpectedAPIKeyPlaceholders() {
-            #expect(DictationProvider.openAI.apiKeyPlaceholder == "sk-...")
-            #expect(DictationProvider.groq.apiKeyPlaceholder == "gsk_...")
+            #expect(DictationProvider.openAI.apiKeyPlaceholder == "Enter your access key")
+            #expect(DictationProvider.groq.apiKeyPlaceholder == "Enter your access key")
         }
 
         @Test(arguments: [

--- a/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -77,6 +77,8 @@
     @MainActor
     @Suite("Mac Dictation Workflow Controller", .serialized)
     struct MacDictationWorkflowControllerTests {
+        private let promptActivationDeadline: Duration = .milliseconds(20)
+
         private func makeController(
             defaults: UserDefaults? = nil,
             speechService: ControllableSpeechService? = nil,
@@ -107,7 +109,10 @@
                 defaults: defaults,
                 secretStore: TestSecretStore()
             )
-            let viewModel = DictationViewModel(speechService: speechService)
+            let viewModel = DictationViewModel(
+                speechService: speechService,
+                manualActivationFallbackDelay: .milliseconds(20)
+            )
             let clipboard = TestClipboardService()
             let captureCoordinator = MacDictationCaptureCoordinator(
                 clipboardService: clipboard,
@@ -122,7 +127,8 @@
                 systemAudioMuting: systemAudioMuting,
                 settingsStore: settingsStore,
                 interactionSoundPlayer: interactionSoundPlayer,
-                mediaResumeDelay: mediaResumeDelay
+                mediaResumeDelay: mediaResumeDelay,
+                startPromptActivationDeadline: promptActivationDeadline
             )
 
             return (
@@ -211,6 +217,7 @@
             subject.controller.startDictationCapture(source: .hotkey) {}
             #expect(systemAudioMuting.activateCallCount == 0)
             #expect(await TestSupport.eventually { subject.viewModel.state == .listening })
+            subject.controller.handleStateTransition(from: .starting, to: .listening)
             #expect(await TestSupport.eventually { systemAudioMuting.activateCallCount == 1 })
 
             subject.viewModel.send(.stopTapped)
@@ -520,7 +527,7 @@
             #expect(subject.viewModel.state == .starting)
 
             await speechService.allowActivation()
-            #expect(await TestSupport.eventually(timeout: .seconds(3)) { subject.viewModel.state == .listening })
+            #expect(await TestSupport.eventually(timeout: .seconds(10)) { subject.viewModel.state == .listening })
         }
     }
 #endif

--- a/apps/mac/StetTests/Core/AppBranch/AppBranchTestSupport.swift
+++ b/apps/mac/StetTests/Core/AppBranch/AppBranchTestSupport.swift
@@ -34,9 +34,18 @@
     }
 
     final class FakeAppBranchWorkspace: AppBranchWorkspaceObserving {
-        var frontmostApplication: AppBranchWorkspaceApplicationSnapshot?
+        private final class ObserverToken: NSObject {
+            let id: UUID
 
-        private var observers: [ObjectIdentifier: () -> Void] = [:]
+            init(id: UUID) {
+                self.id = id
+            }
+        }
+
+        var frontmostApplication: AppBranchWorkspaceApplicationSnapshot?
+        private let lock = NSLock()
+
+        private var observers: [UUID: () -> Void] = [:]
 
         private(set) var observerCount = 0
         private(set) var activeObserverCount = 0
@@ -47,22 +56,31 @@
         }
 
         func observeFrontmostApplicationChanges(_ handler: @escaping () -> Void) -> AppBranchWorkspaceObservationToken {
-            let observer = NSObject()
+            let observer = ObserverToken(id: UUID())
             let token = AppBranchWorkspaceObservationToken(observer: observer)
-            observers[ObjectIdentifier(observer)] = handler
+            lock.lock()
+            observers[observer.id] = handler
             observerCount += 1
             activeObserverCount = observers.count
+            lock.unlock()
             return token
         }
 
         func removeObservation(_ token: AppBranchWorkspaceObservationToken) {
-            observers.removeValue(forKey: ObjectIdentifier(token.observer))
+            guard let observer = token.observer as? ObserverToken else { return }
+            lock.lock()
+            observers.removeValue(forKey: observer.id)
             removedObserverCount += 1
             activeObserverCount = observers.count
+            lock.unlock()
         }
 
         func simulateActivationChange() {
-            for observer in observers.values {
+            lock.lock()
+            let callbacks = Array(observers.values)
+            lock.unlock()
+
+            for observer in callbacks {
                 observer()
             }
         }

--- a/apps/mac/StetTests/Core/Audio/Processing/AudioSignalAnalyzerTests.swift
+++ b/apps/mac/StetTests/Core/Audio/Processing/AudioSignalAnalyzerTests.swift
@@ -30,7 +30,7 @@
         }
 
         @Test func analyzeSpeechDetectsSpeechPresence() async throws {
-            let samples = makeSpeechLikeSamples(count: 16_000, amplitude: 0.15)
+            let samples = makeSpeechLikeSamples(count: 16_000, amplitude: 0.45)
 
             let analysis = try await AudioSignalAnalyzer.analyze(
                 samples: samples,
@@ -54,7 +54,7 @@
         }
 
         @Test func analyzeCalculatesSpeechLevel() async throws {
-            let samples = makeSpeechLikeSamples(count: 16_000, amplitude: 0.15)
+            let samples = makeSpeechLikeSamples(count: 16_000, amplitude: 0.45)
 
             let analysis = try await AudioSignalAnalyzer.analyze(
                 samples: samples,
@@ -82,11 +82,15 @@
 
             for index in speechRange {
                 let t = Double(index) / 16_000.0
-                let envelope = 0.55 + 0.45 * sin(2 * .pi * 2.5 * t)
-                let carrier =
-                    0.72 * sin(2 * .pi * 175.0 * t)
-                    + 0.22 * sin(2 * .pi * 350.0 * t)
-                samples[index] = amplitude * Float(envelope) * Float(carrier)
+                let envelope = 0.55 + 0.45 * sin(2 * .pi * 2.8 * t)
+                let glide = 170.0 + 35.0 * sin(2 * .pi * 1.3 * t)
+                let voicedCarrier =
+                    sin(2 * .pi * glide * t)
+                    + 0.45 * sin(2 * .pi * glide * 2.0 * t)
+                    + 0.18 * sin(2 * .pi * glide * 3.0 * t)
+                let fricativeTexture = 0.08 * sin(2 * .pi * 2_300.0 * t)
+                let sample = amplitude * Float(envelope) * Float(0.72 * voicedCarrier + fricativeTexture)
+                samples[index] = max(-1, min(sample, 1))
             }
 
             return samples

--- a/apps/mac/StetTests/Core/Audio/Recording/MacRecordingFileStabilizerTests.swift
+++ b/apps/mac/StetTests/Core/Audio/Recording/MacRecordingFileStabilizerTests.swift
@@ -37,14 +37,16 @@
             defer { try? FileManager.default.removeItem(at: fileURL) }
 
             let outputFormat = try #require(TranscriptionUploadAudioFormat.makeMacOutputFormat())
-            let audioFile = try AVAudioFile(
-                forWriting: fileURL,
-                settings: outputFormat.settings,
-                commonFormat: outputFormat.commonFormat,
-                interleaved: outputFormat.isInterleaved
-            )
             let buffer = try #require(makeOutputBuffer(format: outputFormat))
-            try audioFile.write(from: buffer)
+            do {
+                let audioFile = try AVAudioFile(
+                    forWriting: fileURL,
+                    settings: outputFormat.settings,
+                    commonFormat: outputFormat.commonFormat,
+                    interleaved: outputFormat.isInterleaved
+                )
+                try audioFile.write(from: buffer)
+            }
 
             await MacRecordingFileStabilizer.waitForFileToStabilize(at: fileURL)
 

--- a/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -500,9 +500,9 @@ struct ConfigurableSpeechServiceTests {
 
         let request = try #require(await rewrite.recordedRequests().first)
         #expect(request.systemPrompt?.contains("AI or coding tools") == true)
-        #expect(request.systemPrompt?.contains("Do not add a title.") == true)
+        #expect(request.systemPrompt?.contains("Do not add a title or wrap the result") == true)
         #expect(request.systemPrompt?.contains("Preserve the original language of the transcript.") == true)
-        #expect(request.systemPrompt?.contains("do not guess a different language") == true)
+        #expect(request.systemPrompt?.contains("Do not guess a different language") == true)
     }
 
     @Test func byokOpenAIToOpenAIReturnsOnlyRewrittenText() async throws {

--- a/apps/mac/StetTests/Features/Dictation/DictationViewModelTests.swift
+++ b/apps/mac/StetTests/Features/Dictation/DictationViewModelTests.swift
@@ -6,10 +6,15 @@ import Testing
 @MainActor
 @Suite("Dictation View Model", .serialized)
 struct DictationViewModelTests {
+    private let fallbackDelay: Duration = .milliseconds(20)
+
     @Test func startAndStopCaptureProducesResult() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setStopBehavior(.immediate("hello world"))
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         #expect(viewModel.state == .starting)
@@ -27,7 +32,10 @@ struct DictationViewModelTests {
         let speechService = ControllableSpeechService()
         await speechService.setStartBehavior(.suspended)
         await speechService.setStopBehavior(.suspended)
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         viewModel.stopCapture()
@@ -42,14 +50,17 @@ struct DictationViewModelTests {
 
         #expect(viewModel.state == .result("completed"))
         #expect(await speechService.counts().start == 1)
-        #expect(await speechService.counts().activate == 0)
+        #expect(await speechService.counts().activate == 1)
         #expect(await speechService.counts().stop == 1)
     }
 
     @Test func transformIsAppliedBeforePublishingResult() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setStopBehavior(.immediate("draft"))
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture { text in
             text.uppercased()
@@ -63,7 +74,10 @@ struct DictationViewModelTests {
     @Test func resetCancelsActiveRecordingAndReturnsToIdle() async {
         let speechService = ControllableSpeechService()
         await speechService.setStartBehavior(.suspended)
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         viewModel.send(.resetTapped)
@@ -76,7 +90,10 @@ struct DictationViewModelTests {
     @Test func explicitActivationKeepsViewModelStartingUntilActivated() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setActivationBehavior(.suspended)
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture(activateWhenReady: false)
         #expect(await TestSupport.eventuallyAsync { await speechService.counts().start == 1 })
@@ -93,7 +110,11 @@ struct DictationViewModelTests {
     @Test func pendingActivationDuringStartupActivatesOnceStartCompletes() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setStartBehavior(.suspended)
-        let viewModel = DictationViewModel(speechService: speechService)
+        await speechService.setActivationBehavior(.suspended)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture(activateWhenReady: false)
         viewModel.activateCaptureWindow()
@@ -103,26 +124,45 @@ struct DictationViewModelTests {
 
         await speechService.allowStart()
 
-        #expect(await TestSupport.eventually { viewModel.state == .listening })
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(5)) {
+                await speechService.counts().activate == 1
+            })
+        await speechService.allowActivation()
+
+        #expect(await TestSupport.eventually(timeout: .seconds(5)) { viewModel.state == .listening })
         #expect(await speechService.counts().start == 1)
         #expect(await speechService.counts().activate == 1)
     }
 
     @Test func manualActivationFallbackActivatesCaptureIfControllerNeverSignals() async throws {
         let speechService = ControllableSpeechService()
-        let viewModel = DictationViewModel(speechService: speechService)
+        await speechService.setActivationBehavior(.suspended)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture(activateWhenReady: false)
 
         #expect(viewModel.state == .starting)
-        #expect(await TestSupport.eventually { viewModel.state == .listening })
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(8)) {
+                await speechService.counts().activate == 1
+            })
+        await speechService.allowActivation()
+
+        #expect(await TestSupport.eventually(timeout: .seconds(8)) { viewModel.state == .listening })
         #expect(await speechService.counts().start == 1)
         #expect(await speechService.counts().activate == 1)
     }
 
     @Test func processingOperationFailurePublishesError() async {
         let speechService = ControllableSpeechService()
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.runProcessingOperation {
             throw TestError.expected
@@ -134,7 +174,10 @@ struct DictationViewModelTests {
 
     @Test func clipboardPendingActionPublishesClipboardPendingState() {
         let speechService = ControllableSpeechService()
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.send(.clipboardPending("hello"))
 
@@ -144,7 +187,10 @@ struct DictationViewModelTests {
     @Test func startFailurePublishesStructuredFailure() async {
         let speechService = ControllableSpeechService()
         await speechService.setStartBehavior(.fail(SpeechServiceError.microphonePermissionDenied))
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
 
@@ -157,7 +203,10 @@ struct DictationViewModelTests {
     @Test func stopFailurePreservesStructuredProviderFailure() async {
         let speechService = ControllableSpeechService()
         await speechService.setStopBehavior(.fail(OpenAIError.missingAPIKey(provider: .groq)))
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         #expect(await TestSupport.eventually { viewModel.state == .listening })
@@ -180,7 +229,10 @@ struct DictationViewModelTests {
                 ])
             )
         )
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         #expect(await TestSupport.eventually { viewModel.state == .listening })
@@ -213,7 +265,10 @@ struct DictationViewModelTests {
                 )
             )
         )
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         #expect(await TestSupport.eventually { viewModel.state == .listening })
@@ -235,7 +290,10 @@ struct DictationViewModelTests {
     @Test func emptyTranscriptionReturnsToIdleWithoutPublishingError() async {
         let speechService = ControllableSpeechService()
         await speechService.setStopBehavior(.fail(SpeechServiceError.emptyTranscription))
-        let viewModel = DictationViewModel(speechService: speechService)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
 
         viewModel.startCapture()
         #expect(await TestSupport.eventually { viewModel.state == .listening })

--- a/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
@@ -117,9 +117,7 @@
 
             #expect(viewModel.connectionStatusText == "Sign In Required")
             #expect(viewModel.connectionNeedsAttention)
-            #expect(
-                viewModel.missingCredentialMessage
-                    == "Sign in with your Stet account to use Managed Relay for dictation.")
+            #expect(viewModel.missingCredentialMessage == nil)
         }
 
         @Test func automaticModeWithRelaySessionShowsRelayActiveWithoutKey() {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -56,14 +56,17 @@ xcodebuild -project apps/mac/Stet.xcodeproj -scheme Stet -configuration Debug -d
 - 构建产物的 entitlement 里必须包含 `com.apple.security.device.audio-input`
 - 缺少这个 entitlement 时，`tccd` 会在弹窗前直接拒绝请求
 
-### Debug 和安装版不能共用同一个应用身份
+### 本地构建和安装版不能共用同一个应用身份
 
-不要让 Xcode 里的 Debug 版和 `/Applications/Stet.app` 共用同一个 bundle identifier。
+不要让本地 Xcode 构建和 `/Applications/Stet.app` 共用同一个 bundle identifier。
 
 - `Debug` 使用 `NaichengDeng.Stet.Debug`
-- `Release` 使用 `NaichengDeng.Stet`
+- 本地 `./scripts/build-macos-release.sh` 现在使用 `NaichengDeng.Stet.LocalRelease`
+- 正式分发 / 公证后的 Release 使用 `NaichengDeng.Stet`
 
 把两者分开可以避免麦克风权限、辅助功能权限和 OAuth 回调在 TCC / Launch Services 里互相污染。
+
+如果你之前启动过一个用 Apple Development 签名、但 bundle id 仍然是 `NaichengDeng.Stet` 的本地 Release，macOS 可能已经把辅助功能授权绑定到了错误的代码需求上。这样系统设置里看起来像是“已经允许”，但运行时 `AXIsProcessTrusted()` 仍然会失败。
 
 ### 已经 Allow，但 onboarding 仍然显示麦克风未通过
 

--- a/scripts/build-macos-release.sh
+++ b/scripts/build-macos-release.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT_PATH="$ROOT_DIR/apps/mac/Stet.xcodeproj"
 SCHEME="Stet"
+LOCAL_RELEASE_BUNDLE_ID="${LOCAL_RELEASE_BUNDLE_ID:-NaichengDeng.Stet.LocalRelease}"
+LOCAL_RELEASE_URL_SCHEME="${LOCAL_RELEASE_URL_SCHEME:-naichengdeng.stet.localrelease}"
 
 BUILD_ROOT="$ROOT_DIR/.build"
 DERIVED_DATA_PATH="$BUILD_ROOT/DerivedData"
@@ -43,6 +45,8 @@ xcodebuild \
   -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
   -packageCachePath "$PACKAGE_CACHE_PATH" \
   CONFIGURATION_BUILD_DIR="$DIST_DIR" \
+  PRODUCT_BUNDLE_IDENTIFIER="$LOCAL_RELEASE_BUNDLE_ID" \
+  APP_URL_SCHEME="$LOCAL_RELEASE_URL_SCHEME" \
   build
 
 codesign --verify --deep --strict "$APP_PATH"
@@ -50,3 +54,4 @@ codesign --verify --deep --strict "$APP_PATH"
 echo
 echo "Built app:"
 echo "  $APP_PATH"
+echo "  Bundle ID: $LOCAL_RELEASE_BUNDLE_ID"


### PR DESCRIPTION
## Summary
- assign a dedicated bundle identifier and URL scheme to local Release builds from 
- keep shipped/notarized releases on 
- document the TCC collision risk in the English and Chinese READMEs

## Why
Local Apple Development-signed Release builds were reusing the shipped app identity, which can pollute macOS TCC records and make Accessibility appear enabled in System Settings while failing at runtime for the Developer ID app.

## Testing
- verified the script now passes  and  into Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
- did not wait for a full local Release build to complete in this session
