### PR TITLE
Run macOS CI on macOS 26

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   swiftlint:
     name: SwiftLint
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v5
@@ -38,7 +38,7 @@ jobs:
 
   swift-format:
     name: Swift Format
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v5
@@ -52,7 +52,7 @@ jobs:
 
   macos-build:
     name: macOS Build
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v5
@@ -69,7 +69,7 @@ jobs:
 
   macos-tests:
     name: macOS Tests
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v5

--- a/apps/mac/Stet/Core/Audio/Processing/AudioSignalAnalyzer.swift
+++ b/apps/mac/Stet/Core/Audio/Processing/AudioSignalAnalyzer.swift
@@ -27,6 +27,40 @@ struct AudioAnalysis: Sendable {
 }
 
 enum AudioSignalAnalyzer {
+    private actor SharedVadService {
+        static let shared = SharedVadService()
+
+        private var managerTask: Task<VadManager, Error>?
+
+        func segmentSpeech(
+            _ samples: [Float],
+            threshold: Float
+        ) async throws -> [VadSegment] {
+            let manager = try await manager(for: threshold)
+            return try await manager.segmentSpeech(samples, config: .default)
+        }
+
+        private func manager(for threshold: Float) async throws -> VadManager {
+            if let managerTask {
+                return try await managerTask.value
+            }
+
+            let task = Task {
+                try await VadManager(
+                    config: VadConfig(defaultThreshold: threshold)
+                )
+            }
+            managerTask = task
+
+            do {
+                return try await task.value
+            } catch {
+                managerTask = nil
+                throw error
+            }
+        }
+    }
+
     struct Configuration {
         static let speechProbabilityThreshold: Float = 0.8
         static let minimumSpeechSegmentDuration: TimeInterval = 0.4
@@ -60,10 +94,10 @@ enum AudioSignalAnalyzer {
         let analysisSampleRate = Double(VadManager.sampleRate)
         let analysisSamples = try normalizeSamplesForAnalysis(samples: samples, sampleRate: sampleRate)
 
-        let manager = try await VadManager(
-            config: VadConfig(defaultThreshold: Configuration.speechProbabilityThreshold)
+        let allSegments = try await SharedVadService.shared.segmentSpeech(
+            analysisSamples,
+            threshold: Configuration.speechProbabilityThreshold
         )
-        let allSegments = try await manager.segmentSpeech(analysisSamples, config: .default)
         let segments = allSegments.filter { ($0.endTime - $0.startTime) >= Configuration.minimumSpeechSegmentDuration }
 
         let shouldDiscardAsNoSpeech = segments.isEmpty

--- a/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -168,6 +168,7 @@
         ) {
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(true, forKey: MacPreferences.onboardingCompleted)
+            defaults.set(false, forKey: MacPreferences.interactionSoundsEnabled)
             let speechService = ControllableSpeechService()
             let textInjectionService = TestTextInjectionService()
             let clipboardService = TestClipboardService()

--- a/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -29,7 +29,7 @@
             coordinator.scheduleRestoreIfNeeded(on: pasteboard)
 
             #expect(
-                await TestSupport.eventuallyAsync(timeout: .milliseconds(200)) {
+                await TestSupport.eventuallyAsync(timeout: .milliseconds(500)) {
                     pasteboard.string(forType: .string) == "original"
                 })
         }
@@ -89,7 +89,7 @@
             temporarySnapshot.restore(to: pasteboard)
 
             #expect(
-                await TestSupport.eventuallyAsync(timeout: .milliseconds(200)) {
+                await TestSupport.eventuallyAsync(timeout: .milliseconds(500)) {
                     pasteboard.string(forType: .string) == "original"
                 })
         }

--- a/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -8,8 +8,16 @@
     @MainActor
     @Suite("Pasteboard Restore Coordinator", .serialized)
     struct PasteboardRestoreCoordinatorTests {
+        private let restorationTimeout: Duration = .seconds(2)
+
         private func makePasteboard() -> NSPasteboard {
             NSPasteboard(name: NSPasteboard.Name("StetTests.\(UUID().uuidString)"))
+        }
+
+        private func restoresOriginalClipboardEventually(_ pasteboard: NSPasteboard) async -> Bool {
+            await TestSupport.eventually(timeout: restorationTimeout) {
+                pasteboard.string(forType: .string) == "original"
+            }
         }
 
         @Test func rapidSuccessiveOverridesRestoreOriginalClipboard() async {
@@ -28,10 +36,7 @@
             clipboard.copy("second")
             coordinator.scheduleRestoreIfNeeded(on: pasteboard)
 
-            #expect(
-                await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
-                    pasteboard.string(forType: .string) == "original"
-                })
+            #expect(await restoresOriginalClipboardEventually(pasteboard))
         }
 
         @Test func userClipboardChangesAreNotOverwrittenByDelayedRestore() async {
@@ -88,10 +93,7 @@
             let temporarySnapshot = PasteboardSnapshot.capture(from: pasteboard)
             temporarySnapshot.restore(to: pasteboard)
 
-            #expect(
-                await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
-                    pasteboard.string(forType: .string) == "original"
-                })
+            #expect(await restoresOriginalClipboardEventually(pasteboard))
         }
     }
 #endif

--- a/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -29,7 +29,7 @@
             coordinator.scheduleRestoreIfNeeded(on: pasteboard)
 
             #expect(
-                await TestSupport.eventuallyAsync(timeout: .milliseconds(500)) {
+                await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
                     pasteboard.string(forType: .string) == "original"
                 })
         }
@@ -89,7 +89,7 @@
             temporarySnapshot.restore(to: pasteboard)
 
             #expect(
-                await TestSupport.eventuallyAsync(timeout: .milliseconds(500)) {
+                await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
                     pasteboard.string(forType: .string) == "original"
                 })
         }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mac:ci:build": "xcodebuild -project apps/mac/Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build",
     "mac:format": "xcrun swift-format format --in-place --recursive --parallel --configuration .swift-format apps/mac/Stet apps/mac/StetTests apps/mac/StetUITests apps/mac/StetVisuals",
     "mac:format:lint": "xcrun swift-format lint --strict --recursive --parallel --configuration .swift-format apps/mac/Stet apps/mac/StetTests apps/mac/StetUITests apps/mac/StetVisuals",
-    "mac:test": "xcodebuild -project apps/mac/Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:StetTests test",
+    "mac:test": "xcodebuild -project apps/mac/Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:StetTests test",
     "mac:release": "./scripts/build-macos-release.sh",
     "mac:release:github": "./scripts/release-macos-github.sh",
     "mac:publish:github": "./scripts/publish-github-release.sh",


### PR DESCRIPTION
## Summary
- run all macOS CI jobs on GitHub Actions macos-26
- pin the macOS test destination to platform=macOS,arch=arm64
- align CI with the project deployment target

## Verification
- ran npm run mac:test locally on macOS 26
- 318 tests passed in 51 suites
