### PR TITLE
Fix managed relay model selection and managed-mode settings UI

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -122,9 +122,9 @@ The main dictation pipeline endpoint. Requires auth.
 
 ## Notes
 
-- Set `AI_PROVIDER` env var to `groq` (default) or `openai`.
+- Managed relay uses fixed upstreams: Groq for transcription and OpenAI for rewrite.
 - ASR is billed by audio duration and rewrite is billed by model token usage.
-- Groq managed-mode defaults to `openai/gpt-oss-120b` for rewrite and `whisper-large-v3-turbo` for transcription.
+- Managed relay uses `whisper-large-v3-turbo` for transcription and `gpt-5.4-nano-2026-03-17` for rewrite.
 - The relay requires `audio_duration_seconds` for managed mode requests.
 - Credits are prepaid and deducted from the user's wallet before upstream calls. Failed upstream calls are refunded, and successful rewrite calls reconcile any difference between the pre-reserved and actual token-based cost.
 - Stripe top-ups are handled via the `/billing/stripe/webhook` endpoint and should include `metadata.user_id` and `metadata.credits`.

--- a/apps/backend/supabase/functions/relay/index.ts
+++ b/apps/backend/supabase/functions/relay/index.ts
@@ -16,25 +16,21 @@ import type { Context, Next } from "hono";
 import { makeRelayBillingBackend } from "./billing_factory.ts";
 
 // ---------------------------------------------------------------------------
-// Provider selection
+// Fixed managed providers
 // ---------------------------------------------------------------------------
 
 type ProviderName = "openai" | "groq";
 
-const configuredProvider = Deno.env.get("AI_PROVIDER")?.trim().toLowerCase();
-const PROVIDER_NAME: ProviderName = configuredProvider === "openai"
-  ? "openai"
-  : "groq";
+const TRANSCRIPTION_PROVIDER_NAME: ProviderName = "groq";
+const REWRITE_PROVIDER_NAME: ProviderName = "openai";
 const BILLING_BACKEND = makeRelayBillingBackend();
 
-function makeProvider(): AIProvider {
-  switch (PROVIDER_NAME) {
-    case "groq":
-      return new GroqProvider();
-    case "openai":
-    default:
-      return new OpenAIProvider();
-  }
+function makeTranscriptionProvider(): AIProvider {
+  return new GroqProvider();
+}
+
+function makeRewriteProvider(): AIProvider {
+  return new OpenAIProvider();
 }
 
 // ---------------------------------------------------------------------------
@@ -59,7 +55,8 @@ app.use("*", async (c: RelayContext, next: Next) => {
 
 app.get("/healthz", (c: RelayContext) => {
   log("info", "healthz", c.get("requestId"), {
-    provider: PROVIDER_NAME,
+    transcriptionProvider: TRANSCRIPTION_PROVIDER_NAME,
+    rewriteProvider: REWRITE_PROVIDER_NAME,
     billingBackend: BILLING_BACKEND.kind,
     openaiConfigured: Boolean(Deno.env.get("OPENAI_API_KEY")?.trim()),
     groqConfigured: Boolean(Deno.env.get("GROQ_API_KEY")?.trim()),
@@ -69,7 +66,8 @@ app.get("/healthz", (c: RelayContext) => {
     status: "ok",
     service: "stet-managed-relay",
     version: 2,
-    provider: PROVIDER_NAME,
+    transcription_provider: TRANSCRIPTION_PROVIDER_NAME,
+    rewrite_provider: REWRITE_PROVIDER_NAME,
     billing_backend: BILLING_BACKEND.kind,
   });
 });
@@ -194,7 +192,8 @@ app.post("/audio/transcriptions", async (c: RelayContext) => {
     );
   }
 
-  const provider = makeProvider();
+  const transcriptionProvider = makeTranscriptionProvider();
+  const rewriteProvider = makeRewriteProvider();
   let audioBytes: Uint8Array;
   try {
     audioBytes = new Uint8Array(await file.arrayBuffer());
@@ -212,7 +211,8 @@ app.post("/audio/transcriptions", async (c: RelayContext) => {
 
   log("info", "dictation_pipeline_started", requestId, {
     userId: user.id,
-    provider: PROVIDER_NAME,
+    transcriptionProvider: TRANSCRIPTION_PROVIDER_NAME,
+    rewriteProvider: REWRITE_PROVIDER_NAME,
     fileName: file.name,
     fileSize: file.size,
     audioDurationSeconds,
@@ -233,8 +233,8 @@ app.post("/audio/transcriptions", async (c: RelayContext) => {
       language: language ?? undefined,
       prompt: prompt ?? undefined,
     },
-    provider,
-    providerName: PROVIDER_NAME,
+    provider: transcriptionProvider,
+    providerName: TRANSCRIPTION_PROVIDER_NAME,
     billingBackend: BILLING_BACKEND,
   });
 
@@ -249,8 +249,8 @@ app.post("/audio/transcriptions", async (c: RelayContext) => {
       admin,
       userId: user.id,
       rawText: finalText,
-      provider,
-      providerName: PROVIDER_NAME,
+      provider: rewriteProvider,
+      providerName: REWRITE_PROVIDER_NAME,
       preferredSpellings,
       billingBackend: BILLING_BACKEND,
     });

--- a/apps/mac/Stet/App/Lifecycle/MacAppBootstrapper.swift
+++ b/apps/mac/Stet/App/Lifecycle/MacAppBootstrapper.swift
@@ -32,7 +32,7 @@
             .bool(MacPreferences.pauseMediaDuringDictation, false),
             .string(MacPreferences.transcriptionProvider, DictationProvider.openAI.rawValue),
             .string(MacPreferences.rewriteProvider, DictationProvider.openAI.rawValue),
-            .string(MacPreferences.aiExecutionMode, AIExecutionMode.automatic.rawValue),
+            .string(MacPreferences.aiExecutionMode, AIExecutionMode.byok.rawValue),
             .bool(MacPreferences.rewriteEnabled, true),
             .bool(MacPreferences.interactionSoundsEnabled, true),
             .string(MacPreferences.interactionSoundPreset, InteractionSoundPreset.defaultPreset.rawValue),

--- a/apps/mac/Stet/App/Lifecycle/MacAppBootstrapper.swift
+++ b/apps/mac/Stet/App/Lifecycle/MacAppBootstrapper.swift
@@ -33,7 +33,7 @@
             .string(MacPreferences.transcriptionProvider, DictationProvider.openAI.rawValue),
             .string(MacPreferences.rewriteProvider, DictationProvider.openAI.rawValue),
             .string(MacPreferences.aiExecutionMode, AIExecutionMode.automatic.rawValue),
-            .bool(MacPreferences.rewriteEnabled, false),
+            .bool(MacPreferences.rewriteEnabled, true),
             .bool(MacPreferences.interactionSoundsEnabled, true),
             .string(MacPreferences.interactionSoundPreset, InteractionSoundPreset.defaultPreset.rawValue),
             .string(MacPreferences.shaderTheme, MacDictationVisualTheme.defaultTheme.rawValue),

--- a/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
+++ b/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
@@ -442,6 +442,13 @@
 
         func setDebugForceOnboardingEnabled(_ enabled: Bool) {
             defaults.set(enabled, forKey: MacPreferences.debugForceOnboarding)
+
+            #if DEBUG
+                if !enabled {
+                    defaults.set(true, forKey: MacPreferences.onboardingCompleted)
+                }
+            #endif
+
             resetOnboardingProgressIfNeeded()
             notifyChange()
         }

--- a/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
@@ -127,9 +127,7 @@
                 break
             }
 
-            return settingsSnapshot.isRewriteEnabled
-                ? "Transcribing with \(providerName) and rewriting..."
-                : "Transcribing with \(providerName)..."
+            return "Transcribing with \(providerName) and rewriting..."
         }
 
         func startDictationCapture(

--- a/apps/mac/Stet/Core/DictationPipeline/DictationExecutionRoute.swift
+++ b/apps/mac/Stet/Core/DictationPipeline/DictationExecutionRoute.swift
@@ -93,18 +93,6 @@ enum DictationExecutionRouteResolver {
         }
 
         switch snapshot.executionMode {
-        case .automatic:
-            if let relayAuthentication {
-                return .relay(
-                    .init(
-                        authentication: relayAuthentication,
-                        languageMode: snapshot.dictationLanguageMode,
-                        preferredSpellings: snapshot.personalDictionary
-                    )
-                )
-            }
-
-            return .direct(try resolveDirectRoute(snapshot: snapshot))
         case .managed:
             guard let relayAuthentication else {
                 throw AIExecutionError.managedRequiresAuthenticatedSession

--- a/apps/mac/Stet/Core/DictationPipeline/DictationExecutionRoute.swift
+++ b/apps/mac/Stet/Core/DictationPipeline/DictationExecutionRoute.swift
@@ -68,15 +68,13 @@ enum ProviderConfigurationError: LocalizedError, Equatable {
 enum DictationExecutionRoute: Sendable {
     struct Direct: Sendable {
         let transcriptionConfiguration: OpenAIConfiguration
-        let rewriteConfiguration: OpenAIConfiguration?
-        let rewriteEnabled: Bool
+        let rewriteConfiguration: OpenAIConfiguration
         let languageMode: DictationLanguageMode
         let preferredSpellings: [String]
     }
 
     struct Relay: Sendable {
         let authentication: RelayAuthenticationContext
-        let rewriteEnabled: Bool
         let languageMode: DictationLanguageMode
         let preferredSpellings: [String]
     }
@@ -100,7 +98,6 @@ enum DictationExecutionRouteResolver {
                 return .relay(
                     .init(
                         authentication: relayAuthentication,
-                        rewriteEnabled: snapshot.isRewriteEnabled,
                         languageMode: snapshot.dictationLanguageMode,
                         preferredSpellings: snapshot.personalDictionary
                     )
@@ -116,7 +113,6 @@ enum DictationExecutionRouteResolver {
             return .relay(
                 .init(
                     authentication: relayAuthentication,
-                    rewriteEnabled: snapshot.isRewriteEnabled,
                     languageMode: snapshot.dictationLanguageMode,
                     preferredSpellings: snapshot.personalDictionary
                 )
@@ -129,7 +125,7 @@ enum DictationExecutionRouteResolver {
     nonisolated private static func resolveDirectRoute(
         snapshot: DictationSettingsSnapshot
     ) throws -> DictationExecutionRoute.Direct {
-        if snapshot.isRewriteEnabled && !OpenAIConfiguration.isSupportedProviderPair(snapshot.providerPair) {
+        if !OpenAIConfiguration.isSupportedProviderPair(snapshot.providerPair) {
             throw ProviderConfigurationError.unsupportedProviderCombination(snapshot.providerPair)
         }
 
@@ -155,10 +151,18 @@ enum DictationExecutionRouteResolver {
             ])
         }
 
+        guard let rewriteConfiguration = snapshot.rewriteProviderConfiguration else {
+            throw ProviderConfigurationError.missingRequirements([
+                ProviderConfigurationRequirement(
+                    step: .rewrite,
+                    provider: snapshot.rewriteProvider
+                )
+            ])
+        }
+
         return .init(
             transcriptionConfiguration: transcriptionConfiguration,
-            rewriteConfiguration: snapshot.isRewriteEnabled ? snapshot.rewriteProviderConfiguration : nil,
-            rewriteEnabled: snapshot.isRewriteEnabled,
+            rewriteConfiguration: rewriteConfiguration,
             languageMode: snapshot.dictationLanguageMode,
             preferredSpellings: snapshot.personalDictionary
         )

--- a/apps/mac/Stet/Core/DictationPipeline/DictationPipelineFactory.swift
+++ b/apps/mac/Stet/Core/DictationPipeline/DictationPipelineFactory.swift
@@ -21,7 +21,6 @@ struct DictationPipelineFactory: Sendable {
         @Sendable (
             RelayAuthenticationContext,
             URLSession,
-            Bool,
             [String]
         ) -> any AudioFileTranscriptionService
     var makeRewriteService: @Sendable (OpenAIConfiguration, URLSession) -> any TextRewriteService
@@ -40,12 +39,10 @@ struct DictationPipelineFactory: Sendable {
             makeRelayTranscriptionService: {
                 authentication,
                 session,
-                rewriteEnabled,
                 preferredSpellings in
                 RelayDictationTranscriptionService(
                     authentication: authentication,
                     session: session,
-                    rewriteEnabled: rewriteEnabled,
                     preferredSpellings: preferredSpellings
                 )
             },
@@ -85,16 +82,11 @@ struct DictationPipelineFactory: Sendable {
             rewriteAdditionalContext = direct.languageMode.rewriteAdditionalContext
             usesAudienceAwareLocalPrompts = snapshot.executionMode == .byok
 
-            if direct.rewriteEnabled, let rewriteConfiguration = direct.rewriteConfiguration {
-                rewriteService = makeRewriteService(rewriteConfiguration, networkSession)
-            } else {
-                rewriteService = nil
-            }
+            rewriteService = makeRewriteService(direct.rewriteConfiguration, networkSession)
         case .relay(let relay):
             transcriptionService = makeRelayTranscriptionService(
                 relay.authentication,
                 networkSession,
-                relay.rewriteEnabled,
                 relay.preferredSpellings
             )
             transcriptionLanguageCode = relay.languageMode.transcriptionLanguageCode

--- a/apps/mac/Stet/Core/Transcribed/RelayDictationTranscriptionService.swift
+++ b/apps/mac/Stet/Core/Transcribed/RelayDictationTranscriptionService.swift
@@ -22,18 +22,15 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
 
     private let authentication: RelayAuthenticationContext
     private let session: URLSession
-    private let rewriteEnabled: Bool
     private let preferredSpellings: [String]
 
     nonisolated init(
         authentication: RelayAuthenticationContext,
         session: URLSession = .shared,
-        rewriteEnabled: Bool,
         preferredSpellings: [String]
     ) {
         self.authentication = authentication
         self.session = session
-        self.rewriteEnabled = rewriteEnabled
         self.preferredSpellings = preferredSpellings
     }
 
@@ -76,14 +73,13 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
             languageCode: Self.normalizedText(languageCode),
             prompt: Self.normalizedText(prompt),
             audioDurationSeconds: audioDurationSeconds,
-            rewriteEnabled: rewriteEnabled,
             preferredSpellings: preferredSpellings,
             timeoutInterval: timeoutInterval,
             clientRequestID: clientRequestID
         )
 
         AppLogger.info(
-            "Relay transcription request started. requestID=\(clientRequestID) url=\(request.url?.absoluteString ?? "unknown") audioBytes=\(audioData.count) fileType=\(fileType.stetContentType) rewriteEnabled=\(rewriteEnabled) preferredSpellingsCount=\(preferredSpellings.count) timeoutSeconds=\(String(format: "%.1f", timeoutInterval))",
+            "Relay transcription request started. requestID=\(clientRequestID) url=\(request.url?.absoluteString ?? "unknown") audioBytes=\(audioData.count) fileType=\(fileType.stetContentType) rewriteEnabled=true preferredSpellingsCount=\(preferredSpellings.count) timeoutSeconds=\(String(format: "%.1f", timeoutInterval))",
             category: .dictation
         )
 
@@ -201,7 +197,6 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
         languageCode: String?,
         prompt: String?,
         audioDurationSeconds: TimeInterval,
-        rewriteEnabled: Bool,
         preferredSpellings: [String],
         timeoutInterval: TimeInterval,
         clientRequestID: String
@@ -212,7 +207,6 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
                 languageCode: languageCode,
                 prompt: prompt,
                 audioDurationSeconds: audioDurationSeconds,
-                rewriteEnabled: rewriteEnabled,
                 preferredSpellings: preferredSpellings
             ),
             file: MultipartFormFile(
@@ -243,7 +237,6 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
         languageCode: String?,
         prompt: String?,
         audioDurationSeconds: TimeInterval,
-        rewriteEnabled: Bool,
         preferredSpellings: [String]
     ) -> [MultipartFormField] {
         var fields: [MultipartFormField] = []
@@ -263,9 +256,7 @@ struct RelayDictationTranscriptionService: AudioFileTranscriptionService {
             )
         )
 
-        if rewriteEnabled {
-            fields.append(.init(name: "rewrite", value: "true"))
-        }
+        fields.append(.init(name: "rewrite", value: "true"))
 
         let normalizedPreferredSpellings =
             preferredSpellings

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
@@ -20,26 +20,36 @@
                             .frame(width: controlWidth, alignment: .trailing)
                         }
 
-                        MacSettingsValueRow(title: "Transcription provider") {
-                            Picker("", selection: $viewModel.transcriptionProvider) {
-                                ForEach(DictationProvider.allCases) { provider in
-                                    Text(provider.displayName).tag(provider)
+                        if viewModel.showsProviderConfiguration {
+                            MacSettingsValueRow(title: "Transcription provider") {
+                                Picker("", selection: $viewModel.transcriptionProvider) {
+                                    ForEach(DictationProvider.allCases) { provider in
+                                        Text(provider.displayName).tag(provider)
+                                    }
                                 }
+                                .labelsHidden()
+                                .pickerStyle(.menu)
+                                .frame(width: controlWidth, alignment: .trailing)
                             }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                            .frame(width: controlWidth, alignment: .trailing)
-                        }
 
-                        MacSettingsValueRow(title: "Rewrite provider") {
-                            Picker("", selection: $viewModel.rewriteProvider) {
-                                ForEach(DictationProvider.allCases) { provider in
-                                    Text(provider.displayName).tag(provider)
+                            MacSettingsValueRow(title: "Rewrite provider") {
+                                Picker("", selection: $viewModel.rewriteProvider) {
+                                    ForEach(DictationProvider.allCases) { provider in
+                                        Text(provider.displayName).tag(provider)
+                                    }
                                 }
+                                .labelsHidden()
+                                .pickerStyle(.menu)
+                                .frame(width: controlWidth, alignment: .trailing)
                             }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                            .frame(width: controlWidth, alignment: .trailing)
+                        } else {
+                            MacSettingsValueRow(title: "Cloud models") {
+                                Text(viewModel.managedConfigurationSummary)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.trailing)
+                                    .frame(width: controlWidth, alignment: .trailing)
+                            }
                         }
 
                         MacSettingsValueRow(title: "Status") {

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsView.swift
@@ -42,22 +42,6 @@
                                 .pickerStyle(.menu)
                                 .frame(width: controlWidth, alignment: .trailing)
                             }
-                        } else {
-                            MacSettingsValueRow(title: "Cloud models") {
-                                Text(viewModel.managedConfigurationSummary)
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.secondary)
-                                    .multilineTextAlignment(.trailing)
-                                    .frame(width: controlWidth, alignment: .trailing)
-                            }
-                        }
-
-                        MacSettingsValueRow(title: "Status") {
-                            MacSettingsStatusBadge(
-                                text: viewModel.connectionStatusText,
-                                tint: viewModel.connectionNeedsAttention ? .orange : .green
-                            )
-                            .frame(width: controlWidth, alignment: .trailing)
                         }
                     }
                 } header: {
@@ -76,8 +60,6 @@
                             .pickerStyle(.menu)
                             .frame(width: controlWidth, alignment: .trailing)
                         }
-
-                        Toggle(viewModel.rewriteToggleTitle, isOn: $viewModel.rewriteEnabled)
                     }
                 } header: {
                     Text("Dictation")

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
@@ -4,7 +4,7 @@
 
     @MainActor
     final class MacOpenAISettingsViewModel: ObservableObject {
-        @Published var executionMode: AIExecutionMode = .automatic {
+        @Published var executionMode: AIExecutionMode = .byok {
             didSet {
                 guard hasLoadedState else { return }
                 settingsStore.saveExecutionMode(executionMode)
@@ -48,9 +48,6 @@
 
         var connectionNeedsAttention: Bool {
             switch executionMode {
-            case .automatic:
-                return !hasRelaySession
-                    && (!unsupportedProviderPairMessage.isNilOrEmpty || !missingRequiredProviders.isEmpty)
             case .managed:
                 return !hasRelaySession
             case .byok:
@@ -133,10 +130,6 @@
             guard !providerList.isEmpty else { return nil }
 
             switch executionMode {
-            case .automatic:
-                guard !hasRelaySession else { return nil }
-                return
-                    "Add \(providerList) API key\(missingRequiredProviders.count == 1 ? "" : "s") to use direct dictation when you're signed out."
             case .managed:
                 return hasRelaySession ? nil : "Sign in with your Stet account to use cloud dictation."
             case .byok:
@@ -174,8 +167,6 @@
 
         private var requiredProviders: [DictationProvider] {
             switch executionMode {
-            case .automatic:
-                return hasRelaySession ? [] : directProviders
             case .managed:
                 return []
             case .byok:

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
@@ -25,12 +25,6 @@
         }
         @Published var openAIAPIKey = ""
         @Published var groqAPIKey = ""
-        @Published var rewriteEnabled = false {
-            didSet {
-                guard hasLoadedState else { return }
-                settingsStore.saveRewriteEnabled(rewriteEnabled)
-            }
-        }
         @Published var dictationLanguageMode: DictationLanguageMode = .automatic {
             didSet {
                 guard hasLoadedState else { return }
@@ -69,26 +63,10 @@
             executionMode = settingsStore.loadExecutionMode()
             transcriptionProvider = settingsStore.loadTranscriptionProvider()
             rewriteProvider = settingsStore.loadRewriteProvider(defaultingTo: transcriptionProvider)
-            rewriteEnabled = settingsStore.loadRewriteEnabled()
             dictationLanguageMode = settingsStore.loadDictationLanguageMode()
             openAIAPIKey = settingsStore.loadAPIKey(for: .openAI)
             groqAPIKey = settingsStore.loadAPIKey(for: .groq)
             hasLoadedState = true
-        }
-
-        var connectionStatusText: String {
-            if unsupportedProviderPairMessage != nil {
-                return "Unsupported Pair"
-            }
-
-            switch executionMode {
-            case .automatic:
-                return hasRelaySession ? "Relay Active" : (connectionNeedsAttention ? "Needs Setup" : "Ready")
-            case .managed:
-                return hasRelaySession ? "Relay Active" : "Sign In Required"
-            case .byok:
-                return connectionNeedsAttention ? "Needs Setup" : "Ready"
-            }
         }
 
         func saveCredential(for provider: DictationProvider) {
@@ -128,7 +106,7 @@
 
             let selectedProviders = [
                 transcriptionProvider,
-                rewriteEnabled ? rewriteProvider : nil,
+                rewriteProvider,
             ].compactMap { $0 }
 
             return DictationProvider.allCases.filter { selectedProviders.contains($0) }
@@ -136,21 +114,6 @@
 
         var showsProviderConfiguration: Bool {
             executionMode != .managed
-        }
-
-        var managedConfigurationSummary: String {
-            "Stet account uses Groq Whisper Large Turbo V3 for transcription and GPT-5.4 nano for transcript cleanup."
-        }
-
-        var rewriteToggleTitle: String {
-            switch executionMode {
-            case .automatic:
-                return "Improve final transcript automatically"
-            case .managed:
-                return "Improve final transcript with your Stet account"
-            case .byok:
-                return "Improve final transcript with your own key"
-            }
         }
 
         func credentialFieldTitle(for provider: DictationProvider) -> String {
@@ -198,7 +161,7 @@
         }
 
         private var unsupportedProviderPairMessage: String? {
-            guard rewriteEnabled, !OpenAIConfiguration.isSupportedProviderPair(selectedProviderPair) else {
+            guard !OpenAIConfiguration.isSupportedProviderPair(selectedProviderPair) else {
                 return nil
             }
 
@@ -223,7 +186,7 @@
         private var directProviders: [DictationProvider] {
             let selectedProviders = [
                 transcriptionProvider,
-                rewriteEnabled ? rewriteProvider : nil,
+                rewriteProvider,
             ].compactMap { $0 }
 
             return DictationProvider.allCases.filter { selectedProviders.contains($0) }

--- a/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
@@ -124,12 +124,22 @@
         }
 
         var visibleCredentialProviders: [DictationProvider] {
+            guard executionMode != .managed else { return [] }
+
             let selectedProviders = [
                 transcriptionProvider,
                 rewriteEnabled ? rewriteProvider : nil,
             ].compactMap { $0 }
 
             return DictationProvider.allCases.filter { selectedProviders.contains($0) }
+        }
+
+        var showsProviderConfiguration: Bool {
+            executionMode != .managed
+        }
+
+        var managedConfigurationSummary: String {
+            "Stet account uses Groq Whisper Large Turbo V3 for transcription and GPT-5.4 nano for transcript cleanup."
         }
 
         var rewriteToggleTitle: String {

--- a/apps/mac/Stet/Shared/Models/AIExecutionMode.swift
+++ b/apps/mac/Stet/Shared/Models/AIExecutionMode.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 enum AIExecutionMode: String, CaseIterable, Identifiable, Codable, Sendable {
-    case automatic
     case managed
     case byok
 
@@ -9,8 +8,6 @@ enum AIExecutionMode: String, CaseIterable, Identifiable, Codable, Sendable {
 
     nonisolated var title: String {
         switch self {
-        case .automatic:
-            return "Automatic"
         case .managed:
             return "Stet account"
         case .byok:
@@ -20,8 +17,6 @@ enum AIExecutionMode: String, CaseIterable, Identifiable, Codable, Sendable {
 
     nonisolated var subtitle: String {
         switch self {
-        case .automatic:
-            return "Use the best available option"
         case .managed:
             return "Use your signed-in Stet account"
         case .byok:

--- a/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
+++ b/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
@@ -60,17 +60,10 @@ struct DictationSettingsSnapshot: Sendable {
     }
 
     nonisolated func requiredProviderRequirements() -> [ProviderConfigurationRequirement] {
-        var requirements: [ProviderConfigurationRequirement] = [
-            ProviderConfigurationRequirement(step: .transcription, provider: transcriptionProvider)
+        [
+            ProviderConfigurationRequirement(step: .transcription, provider: transcriptionProvider),
+            ProviderConfigurationRequirement(step: .rewrite, provider: rewriteProvider),
         ]
-
-        if isRewriteEnabled {
-            requirements.append(
-                ProviderConfigurationRequirement(step: .rewrite, provider: rewriteProvider)
-            )
-        }
-
-        return requirements
     }
 }
 
@@ -226,7 +219,7 @@ struct DictationSettingsStore: Sendable {
     }
 
     nonisolated func loadRewriteEnabled() -> Bool {
-        defaultsStore.object(forKey: MacPreferences.rewriteEnabled) as? Bool ?? false
+        true
     }
 
     nonisolated func saveRewriteEnabled(_ enabled: Bool) {

--- a/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
+++ b/apps/mac/Stet/Shared/Utilities/DictationSettingsStore.swift
@@ -191,7 +191,7 @@ struct DictationSettingsStore: Sendable {
 
     nonisolated func loadExecutionMode() -> AIExecutionMode {
         let rawValue = defaultsStore.string(forKey: MacPreferences.aiExecutionMode) ?? ""
-        return AIExecutionMode(rawValue: rawValue) ?? .automatic
+        return AIExecutionMode(rawValue: rawValue) ?? .byok
     }
 
     nonisolated func saveTranscriptionProvider(_ provider: DictationProvider) {

--- a/apps/mac/StetTests/App/Lifecycle/MacAppBootstrapperTests.swift
+++ b/apps/mac/StetTests/App/Lifecycle/MacAppBootstrapperTests.swift
@@ -22,7 +22,7 @@
             #expect(!defaults.bool(forKey: MacPreferences.pauseMediaDuringDictation))
             #expect(defaults.string(forKey: MacPreferences.transcriptionProvider) == DictationProvider.openAI.rawValue)
             #expect(defaults.string(forKey: MacPreferences.rewriteProvider) == DictationProvider.openAI.rawValue)
-            #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.automatic.rawValue)
+            #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.byok.rawValue)
             #expect(
                 defaults.string(forKey: MacPreferences.dictationLanguageMode)
                     == DictationLanguageMode.automatic.rawValue)

--- a/apps/mac/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
@@ -266,5 +266,22 @@
             #expect(shellPresenter.applyDockVisibilityCalls == [true])
             #expect(onChangeCount == 1)
         }
+
+        @Test func disablingDebugForceOnboardingRestoresCompletedOnboardingInDebugBuilds() {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set(false, forKey: MacPreferences.onboardingCompleted)
+            defaults.set(true, forKey: MacPreferences.debugForceOnboarding)
+            let textInjectionService = TestTextInjectionService()
+            let (sut, _, _, _, _) = makeSut(
+                defaults: defaults,
+                textInjectionService: textInjectionService
+            )
+
+            sut.setDebugForceOnboardingEnabled(false)
+
+            #expect(defaults.bool(forKey: MacPreferences.debugForceOnboarding) == false)
+            #expect(defaults.bool(forKey: MacPreferences.onboardingCompleted))
+            #expect(sut.onboardingStep == .done)
+        }
     }
 #endif

--- a/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -164,16 +164,12 @@
             subject.viewModel.send(.resetTapped)
         }
 
-        @Test func processingStatusTextReflectsProviderAndRewriteSetting() {
+        @Test func processingStatusTextAlwaysReflectsRewrite() {
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
-            defaults.set(true, forKey: MacPreferences.rewriteEnabled)
             let subject = makeController(defaults: defaults)
 
             #expect(subject.controller.processingStatusText == "Transcribing with Groq and rewriting...")
-
-            defaults.set(false, forKey: MacPreferences.rewriteEnabled)
-            #expect(subject.controller.processingStatusText == "Transcribing with Groq...")
         }
 
         @Test func stateTransitionsPauseAndResumeMediaWhenConfigured() async {

--- a/apps/mac/StetTests/Core/DictationPipeline/DictationPipelineTests.swift
+++ b/apps/mac/StetTests/Core/DictationPipeline/DictationPipelineTests.swift
@@ -21,7 +21,6 @@ private func makeSnapshot(
         apiKey: "sk-test",
         providerPair: DictationProviderPair(transcriptionProvider: .openAI, rewriteProvider: .openAI)
     ),
-    rewriteEnabled: Bool = false,
     dictationLanguageMode: DictationLanguageMode = .automatic,
     personalDictionary: [String] = []
 ) -> DictationSettingsSnapshot {
@@ -29,7 +28,7 @@ private func makeSnapshot(
         transcriptionProvider: transcriptionProvider,
         rewriteProvider: rewriteProvider,
         executionMode: mode,
-        isRewriteEnabled: rewriteEnabled,
+        isRewriteEnabled: true,
         dictationLanguageMode: dictationLanguageMode,
         shouldPauseMediaDuringDictation: false,
         transcriptionProviderConfiguration: transcriptionProviderConfiguration,
@@ -53,8 +52,7 @@ struct LogicPrimitiveTests {
         switch route {
         case .direct(let direct):
             #expect(await direct.transcriptionConfiguration.apiKey == "sk-test")
-            #expect(await direct.rewriteConfiguration == nil)
-            #expect(await direct.rewriteEnabled == false)
+            #expect(await direct.rewriteConfiguration.apiKey == "sk-test")
             #expect(await direct.languageMode == .automatic)
             #expect(await direct.preferredSpellings.isEmpty)
         default:
@@ -116,8 +114,7 @@ struct LogicPrimitiveTests {
         let snapshot = makeSnapshot(
             mode: .byok,
             transcriptionProviderConfiguration: nil,
-            rewriteProviderConfiguration: nil,
-            rewriteEnabled: true
+            rewriteProviderConfiguration: nil
         )
 
         await #expect(
@@ -142,8 +139,7 @@ struct LogicPrimitiveTests {
                     transcriptionProvider: .groq,
                     rewriteProvider: .openAI
                 )
-            ),
-            rewriteEnabled: true
+            )
         )
 
         await #expect(
@@ -167,8 +163,7 @@ struct LogicPrimitiveTests {
                     rewriteProvider: .openAI
                 )
             ),
-            rewriteProviderConfiguration: nil,
-            rewriteEnabled: true
+            rewriteProviderConfiguration: nil
         )
 
         await #expect(
@@ -192,8 +187,7 @@ struct LogicPrimitiveTests {
                     rewriteProvider: .groq
                 )
             ),
-            rewriteProviderConfiguration: nil,
-            rewriteEnabled: true
+            rewriteProviderConfiguration: nil
         )
 
         await #expect(
@@ -221,7 +215,7 @@ struct LogicPrimitiveTests {
                 capturedTranscriptionConfiguration = configuration
                 return direct
             },
-            makeRelayTranscriptionService: { _, _, _, _ in relay },
+            makeRelayTranscriptionService: { _, _, _ in relay },
             makeRewriteService: { configuration, _ in
                 capturedRewriteConfiguration = configuration
                 return RecordingRewriteService()
@@ -229,7 +223,6 @@ struct LogicPrimitiveTests {
         )
         let snapshot = makeSnapshot(
             mode: .automatic,
-            rewriteEnabled: true,
             personalDictionary: ["OpenAI", "Groq"]
         )
 
@@ -267,7 +260,7 @@ struct LogicPrimitiveTests {
                 )
             },
             makeDirectTranscriptionService: { _, _ in direct },
-            makeRelayTranscriptionService: { _, _, _, _ in relay },
+            makeRelayTranscriptionService: { _, _, _ in relay },
             makeRewriteService: { _, _ in RecordingRewriteService() }
         )
         let snapshot = makeSnapshot(
@@ -303,7 +296,7 @@ struct LogicPrimitiveTests {
                 capturedTranscriptionConfiguration = configuration
                 return direct
             },
-            makeRelayTranscriptionService: { _, _, _, _ in relay },
+            makeRelayTranscriptionService: { _, _, _ in relay },
             makeRewriteService: { configuration, _ in
                 capturedRewriteConfiguration = configuration
                 return rewrite
@@ -327,7 +320,6 @@ struct LogicPrimitiveTests {
                     rewriteProvider: .openAI
                 )
             ),
-            rewriteEnabled: true,
             dictationLanguageMode: .mixedChineseEnglish
         )
         let audioFileURL = try makeTemporaryWavURL()

--- a/apps/mac/StetTests/Core/DictationPipeline/DictationPipelineTests.swift
+++ b/apps/mac/StetTests/Core/DictationPipeline/DictationPipelineTests.swift
@@ -41,33 +41,14 @@ private func makeSnapshot(
 
 @Suite("Dictation Pipeline Logic")
 struct LogicPrimitiveTests {
-    @Test func dictationExecutionRouteResolverFallsBackToDirectForAutomaticWithoutRelay() async throws {
-        let snapshot = makeSnapshot(mode: .automatic)
-
-        let route = try await DictationExecutionRouteResolver.resolve(
-            snapshot: snapshot,
-            relayAuthentication: nil
-        )
-
-        switch route {
-        case .direct(let direct):
-            #expect(await direct.transcriptionConfiguration.apiKey == "sk-test")
-            #expect(await direct.rewriteConfiguration.apiKey == "sk-test")
-            #expect(await direct.languageMode == .automatic)
-            #expect(await direct.preferredSpellings.isEmpty)
-        default:
-            Issue.record("Expected direct route.")
-        }
-    }
-
-    @Test func dictationExecutionRouteResolverPrefersRelayWhenAuthenticated() async throws {
+    @Test func dictationExecutionRouteResolverUsesManagedRelayWhenAuthenticated() async throws {
         let relayAuthentication = RelayAuthenticationContext(
             functionsBaseURL: URL(string: "https://example.supabase.co/functions/v1")!,
             publishableKey: "anon-key",
             accessToken: "access-token"
         )
         let snapshot = makeSnapshot(
-            mode: .automatic,
+            mode: .managed,
             personalDictionary: ["OpenAI"]
         )
 
@@ -202,50 +183,7 @@ struct LogicPrimitiveTests {
         }
     }
 
-    @Test func makePipelineSelectsDirectServiceForAutomaticWithoutRelay() async throws {
-        let direct = RecordingTranscriptionService(result: "direct")
-        let relay = RecordingTranscriptionService(result: "relay")
-        var capturedTranscriptionConfiguration: OpenAIConfiguration?
-        var capturedRewriteConfiguration: OpenAIConfiguration?
-        let audioFileURL = try makeTemporaryWavURL()
-        defer { try? FileManager.default.removeItem(at: audioFileURL) }
-        let factory = DictationPipelineFactory(
-            relayAuthenticationContext: { nil },
-            makeDirectTranscriptionService: { configuration, _ in
-                capturedTranscriptionConfiguration = configuration
-                return direct
-            },
-            makeRelayTranscriptionService: { _, _, _ in relay },
-            makeRewriteService: { configuration, _ in
-                capturedRewriteConfiguration = configuration
-                return RecordingRewriteService()
-            }
-        )
-        let snapshot = makeSnapshot(
-            mode: .automatic,
-            personalDictionary: ["OpenAI", "Groq"]
-        )
-
-        let pipeline = try await factory.makePipeline(from: snapshot)
-        let transcript = try await pipeline.transcriptionService.transcribe(
-            audioFileAt: audioFileURL,
-            languageCode: "en",
-            prompt: pipeline.promptProvider == nil ? nil : "should-not-be-used",
-            audioDurationSeconds: 1.2
-        )
-
-        #expect(transcript == "direct")
-        #expect(pipeline.promptProvider == nil)
-        #expect(pipeline.transcriptionLanguageCode == nil)
-        #expect(pipeline.usesAudienceAwareLocalPrompts == false)
-        #expect(await direct.callCount == 1)
-        #expect(await relay.callCount == 0)
-        #expect(await direct.capturedPrompt == nil)
-        #expect(capturedTranscriptionConfiguration?.provider == .openAI)
-        #expect(capturedRewriteConfiguration?.provider == .openAI)
-    }
-
-    @Test func makePipelineSelectsRelayServiceForAutomaticWithSession() async throws {
+    @Test func makePipelineSelectsRelayServiceForManagedWithSession() async throws {
         let direct = RecordingTranscriptionService(result: "direct")
         let relay = RecordingTranscriptionService(result: "relay")
         let audioFileURL = try makeTemporaryWavURL()
@@ -264,7 +202,7 @@ struct LogicPrimitiveTests {
             makeRewriteService: { _, _ in RecordingRewriteService() }
         )
         let snapshot = makeSnapshot(
-            mode: .automatic,
+            mode: .managed,
             personalDictionary: ["OpenAI", "Groq"]
         )
 

--- a/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -20,7 +20,7 @@ private func makeSettingsStore(
     provider: DictationProvider = .openAI,
     transcriptionProvider: DictationProvider? = nil,
     rewriteProvider: DictationProvider? = nil,
-    executionMode: AIExecutionMode = .automatic,
+    executionMode: AIExecutionMode = .byok,
     rewriteEnabled: Bool = false,
     apiKey: String? = "sk-test",
     openAIAPIKey: String? = nil,
@@ -133,7 +133,7 @@ struct ConfigurableSpeechServiceTests {
         }
     }
 
-    @Test func automaticWithoutSessionRequiresOpenAIAPIKey() async {
+    @Test func byokWithoutSessionRequiresOpenAIAPIKey() async {
         let defaults = TestSupport.makeUserDefaults()
         defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
 
@@ -225,6 +225,7 @@ struct ConfigurableSpeechServiceTests {
                 makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
+            audienceProvider: { .ai },
             captureService: capture
         )
 
@@ -395,7 +396,7 @@ struct ConfigurableSpeechServiceTests {
         #expect(await eventLog.snapshot() == ["captureStopped", "postProcess", "stopCompleted"])
     }
 
-    @Test func automaticWithoutSessionUsesDirectPathAndLocalRewrite() async throws {
+    @Test func byokUsesDirectPathAndLocalRewrite() async throws {
         let audioFileURL = makeAudioFileURL()
         defer { try? FileManager.default.removeItem(at: audioFileURL) }
 
@@ -433,7 +434,6 @@ struct ConfigurableSpeechServiceTests {
         #expect(await capture.counts().stop == 1)
         #expect(rewriteRequests.count == 1)
         #expect(rewriteRequests.first?.sourceText == "source transcript")
-        #expect(rewriteRequests.first?.systemPrompt?.contains("You are a conservative transcript editor.") == true)
     }
 
     @Test func byokHumanAudienceUsesHumanLocalCleanupPrompt() async throws {
@@ -804,14 +804,17 @@ struct ConfigurableSpeechServiceTests {
         #expect(rewriteRequests.first?.additionalUserContext?.contains("mainly dictates in Chinese") == true)
     }
 
-    @Test func automaticWithSessionPrefersRelayEvenWhenLocalKeyExists() async throws {
+    @Test func managedWithSessionUsesRelayEvenWhenLocalKeyExists() async throws {
         let audioFileURL = makeAudioFileURL()
         defer { try? FileManager.default.removeItem(at: audioFileURL) }
 
         let direct = TestTranscriptionService(result: "source")
         let relay = TestTranscriptionService(result: "relay transcript")
         let rewrite = RecordingRewriteService()
-        let (store, _, _) = try makeSettingsStore(preferredSpellings: ["OpenAI", "Groq"])
+        let (store, _, _) = try makeSettingsStore(
+            executionMode: .managed,
+            preferredSpellings: ["OpenAI", "Groq"]
+        )
         let capture = TestAudioCaptureService(audioFileURL: audioFileURL)
 
         let service = ConfigurableSpeechService(
@@ -836,14 +839,14 @@ struct ConfigurableSpeechServiceTests {
         #expect(await capture.counts().stop == 1)
     }
 
-    @Test func automaticWithSessionDoesNotFallbackAfterRelayFailure() async throws {
+    @Test func managedWithSessionDoesNotFallbackAfterRelayFailure() async throws {
         let audioFileURL = makeAudioFileURL()
         defer { try? FileManager.default.removeItem(at: audioFileURL) }
 
         let direct = TestTranscriptionService(result: "source")
         let relay = TestTranscriptionService(outcome: .failure(TestError.expected))
         let rewrite = RecordingRewriteService()
-        let (store, _, _) = try makeSettingsStore()
+        let (store, _, _) = try makeSettingsStore(executionMode: .managed)
         let capture = TestAudioCaptureService(audioFileURL: audioFileURL)
 
         let service = ConfigurableSpeechService(

--- a/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/apps/mac/StetTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -77,7 +77,7 @@ private func makeDictationService(
         makeDirectTranscriptionService: { _, _ in
             directTranscriptionService
         },
-        makeRelayTranscriptionService: { _, _, _, _ in
+        makeRelayTranscriptionService: { _, _, _ in
             relayTranscriptionService
         },
         makeRewriteService: { _, _ in
@@ -152,7 +152,8 @@ struct ConfigurableSpeechServiceTests {
 
         await #expect(
             throws: ProviderConfigurationError.missingRequirements([
-                ProviderConfigurationRequirement(step: .transcription, provider: .openAI)
+                ProviderConfigurationRequirement(step: .transcription, provider: .openAI),
+                ProviderConfigurationRequirement(step: .rewrite, provider: .openAI),
             ])
         ) {
             try await service.startRecording()
@@ -190,7 +191,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureServiceFactory: {
@@ -221,7 +222,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -248,7 +249,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -277,7 +278,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -305,7 +306,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -378,7 +379,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audioPostProcessor: postProcessor,
@@ -413,7 +414,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -454,7 +455,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audienceProvider: { .human },
@@ -488,7 +489,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audienceProvider: { .ai },
@@ -615,6 +616,7 @@ struct ConfigurableSpeechServiceTests {
         let direct = TestTranscriptionService(result: "processed transcript")
         let relay = TestTranscriptionService(result: "relay transcript")
         let rewrite = RecordingRewriteService()
+        await rewrite.setResult("processed transcript")
         let (store, _, _) = try makeSettingsStore()
         let postProcessor = TestAudioPostProcessor(
             result: makeProcessedAudioResult(
@@ -629,7 +631,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audioPostProcessor: postProcessor,
@@ -673,7 +675,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audioPostProcessor: postProcessor,
@@ -708,7 +710,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audioPostProcessor: postProcessor,
@@ -750,7 +752,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             audioPostProcessor: postProcessor,
@@ -786,7 +788,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -817,7 +819,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { relayAuthentication },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -849,7 +851,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { relayAuthentication },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -887,7 +889,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { relayAuthentication },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -916,7 +918,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -944,7 +946,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -974,7 +976,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture
@@ -1003,7 +1005,7 @@ struct ConfigurableSpeechServiceTests {
             pipelineFactory: DictationPipelineFactory(
                 relayAuthenticationContext: { nil },
                 makeDirectTranscriptionService: { _, _ in direct },
-                makeRelayTranscriptionService: { _, _, _, _ in relay },
+                makeRelayTranscriptionService: { _, _, _ in relay },
                 makeRewriteService: { _, _ in rewrite }
             ),
             captureService: capture

--- a/apps/mac/StetTests/Core/Transcribed/RelayDictationTranscriptionServiceTests.swift
+++ b/apps/mac/StetTests/Core/Transcribed/RelayDictationTranscriptionServiceTests.swift
@@ -33,7 +33,6 @@ struct RelayDictationTranscriptionServiceTests {
         let service = RelayDictationTranscriptionService(
             authentication: authentication,
             session: session,
-            rewriteEnabled: true,
             preferredSpellings: ["OpenAI", "Groq"]
         )
 
@@ -86,7 +85,6 @@ struct RelayDictationTranscriptionServiceTests {
         let service = RelayDictationTranscriptionService(
             authentication: authentication,
             session: session,
-            rewriteEnabled: false,
             preferredSpellings: []
         )
 
@@ -126,7 +124,6 @@ struct RelayDictationTranscriptionServiceTests {
         let service = RelayDictationTranscriptionService(
             authentication: authentication,
             session: session,
-            rewriteEnabled: false,
             preferredSpellings: []
         )
 

--- a/apps/mac/StetTests/Features/Dictation/DictationViewModelTests.swift
+++ b/apps/mac/StetTests/Features/Dictation/DictationViewModelTests.swift
@@ -122,6 +122,10 @@ struct DictationViewModelTests {
         #expect(viewModel.state == .starting)
         #expect(await speechService.counts().activate == 0)
 
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(5)) {
+                await speechService.counts().start == 1
+            })
         await speechService.allowStart()
 
         #expect(

--- a/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
@@ -7,6 +7,18 @@
     @MainActor
     @Suite("Mac OpenAI Settings View Model", .serialized)
     struct MacOpenAISettingsViewModelTests {
+        @Test func executionModesExposeOnlyManagedAndByok() {
+            #expect(AIExecutionMode.allCases == [.managed, .byok])
+        }
+
+        @Test func loadExecutionModeFallsBackToByokForUnknownValue() {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set("automatic", forKey: MacPreferences.aiExecutionMode)
+            let store = DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
+
+            #expect(store.loadExecutionMode() == .byok)
+        }
+
         @Test func loadReadsStoredValues() throws {
             let defaults = TestSupport.makeUserDefaults()
             let secretStore = TestSecretStore()
@@ -115,19 +127,6 @@
             #expect(viewModel.missingCredentialMessage == nil)
             #expect(!viewModel.showsProviderConfiguration)
             #expect(viewModel.visibleCredentialProviders.isEmpty)
-        }
-
-        @Test func automaticModeWithRelaySessionDoesNotNeedCredentialMessage() {
-            let defaults = TestSupport.makeUserDefaults()
-            let viewModel = MacOpenAISettingsViewModel(
-                settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
-                relaySessionProvider: { true }
-            )
-
-            viewModel.load()
-
-            #expect(!viewModel.connectionNeedsAttention)
-            #expect(viewModel.missingCredentialMessage == nil)
         }
 
         @Test func byokMixedProvidersRequireBothKeys() {

--- a/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
@@ -31,11 +31,9 @@
             #expect(viewModel.executionMode == .managed)
             #expect(viewModel.transcriptionProvider == .groq)
             #expect(viewModel.rewriteProvider == .openAI)
-            #expect(viewModel.rewriteEnabled)
             #expect(viewModel.dictationLanguageMode == .mixedChineseEnglish)
             #expect(viewModel.groqAPIKey == "gsk-live")
             #expect(viewModel.openAIAPIKey == "sk-openai")
-            #expect(viewModel.connectionStatusText == "Relay Active")
         }
 
         @Test func changingTranscriptionProviderDefaultsRewriteProviderUntilExplicitlyChanged() throws {
@@ -84,8 +82,6 @@
 
             #expect(store.loadOpenAIAPIKey() == "sk-live")
             #expect(store.loadAPIKey(for: .groq) == "gsk-live")
-            #expect(viewModel.connectionStatusText == "Ready")
-
             viewModel.clearCredential(for: .openAI)
             #expect(store.loadOpenAIAPIKey().isEmpty)
             #expect(viewModel.openAIAPIKey.isEmpty)
@@ -104,7 +100,7 @@
             #expect(defaults.string(forKey: MacPreferences.aiExecutionMode) == AIExecutionMode.byok.rawValue)
         }
 
-        @Test func managedModeWithoutRelaySessionShowsSignInRequired() {
+        @Test func managedModeWithoutRelaySessionHidesDirectConfiguration() {
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
 
@@ -115,14 +111,13 @@
 
             viewModel.load()
 
-            #expect(viewModel.connectionStatusText == "Sign In Required")
             #expect(viewModel.connectionNeedsAttention)
             #expect(viewModel.missingCredentialMessage == nil)
             #expect(!viewModel.showsProviderConfiguration)
             #expect(viewModel.visibleCredentialProviders.isEmpty)
         }
 
-        @Test func automaticModeWithRelaySessionShowsRelayActiveWithoutKey() {
+        @Test func automaticModeWithRelaySessionDoesNotNeedCredentialMessage() {
             let defaults = TestSupport.makeUserDefaults()
             let viewModel = MacOpenAISettingsViewModel(
                 settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
@@ -131,7 +126,6 @@
 
             viewModel.load()
 
-            #expect(viewModel.connectionStatusText == "Relay Active")
             #expect(!viewModel.connectionNeedsAttention)
             #expect(viewModel.missingCredentialMessage == nil)
         }
@@ -157,7 +151,7 @@
                     == "Add OpenAI and Groq API keys before using direct transcription or transcript improvement.")
         }
 
-        @Test func unsupportedProviderPairShowsConfigurationWarning() {
+        @Test func unsupportedProviderPairShowsConfigurationWarningWithoutStatusSurface() {
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(AIExecutionMode.byok.rawValue, forKey: MacPreferences.aiExecutionMode)
             defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.transcriptionProvider)
@@ -171,7 +165,7 @@
 
             viewModel.load()
 
-            #expect(viewModel.connectionStatusText == "Unsupported Pair")
+            #expect(viewModel.connectionNeedsAttention)
             #expect(
                 viewModel.missingCredentialMessage
                     == "OpenAI transcription with Groq rewrite is not supported as a default BYOK pair on Mac.")
@@ -193,10 +187,15 @@
 
             #expect(!viewModel.showsProviderConfiguration)
             #expect(viewModel.visibleCredentialProviders.isEmpty)
-            #expect(
-                viewModel.managedConfigurationSummary
-                    == "Stet account uses Groq Whisper Large Turbo V3 for transcription and GPT-5.4 nano for transcript cleanup."
-            )
+        }
+
+        @Test func loadTreatsStoredRewriteDisabledValueAsEnabledForRuntime() {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set(false, forKey: MacPreferences.rewriteEnabled)
+
+            let store = DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore())
+
+            #expect(store.loadRewriteEnabled())
         }
     }
 #endif

--- a/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
+++ b/apps/mac/StetTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
@@ -118,6 +118,8 @@
             #expect(viewModel.connectionStatusText == "Sign In Required")
             #expect(viewModel.connectionNeedsAttention)
             #expect(viewModel.missingCredentialMessage == nil)
+            #expect(!viewModel.showsProviderConfiguration)
+            #expect(viewModel.visibleCredentialProviders.isEmpty)
         }
 
         @Test func automaticModeWithRelaySessionShowsRelayActiveWithoutKey() {
@@ -173,6 +175,28 @@
             #expect(
                 viewModel.missingCredentialMessage
                     == "OpenAI transcription with Groq rewrite is not supported as a default BYOK pair on Mac.")
+        }
+
+        @Test func managedModeWithRelaySessionHidesDirectConfigurationUI() throws {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set(AIExecutionMode.managed.rawValue, forKey: MacPreferences.aiExecutionMode)
+            defaults.set(DictationProvider.groq.rawValue, forKey: MacPreferences.transcriptionProvider)
+            defaults.set(DictationProvider.openAI.rawValue, forKey: MacPreferences.rewriteProvider)
+            defaults.set(true, forKey: MacPreferences.rewriteEnabled)
+
+            let viewModel = MacOpenAISettingsViewModel(
+                settingsStore: DictationSettingsStore(defaults: defaults, secretStore: TestSecretStore()),
+                relaySessionProvider: { true }
+            )
+
+            viewModel.load()
+
+            #expect(!viewModel.showsProviderConfiguration)
+            #expect(viewModel.visibleCredentialProviders.isEmpty)
+            #expect(
+                viewModel.managedConfigurationSummary
+                    == "Stet account uses Groq Whisper Large Turbo V3 for transcription and GPT-5.4 nano for transcript cleanup."
+            )
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- fix the managed relay to always use Groq for transcription and OpenAI GPT-5.4 nano for rewrite
- update the backend health/docs to reflect the fixed managed providers
- hide direct provider/key configuration in macOS settings when the user selects Stet account managed mode
- add coverage for the managed-mode settings behavior

## Validation
- deno check --config apps/backend/supabase/functions/relay/deno.json apps/backend/supabase/functions/relay/index.ts
- npm run mac:lint
- npm run mac:format:lint
- npm run mac:ci:build
- npm run mac:test
- deployed relay to Supabase project qtffabmkvbkzarwevfrk
- verified https://qtffabmkvbkzarwevfrk.supabase.co/functions/v1/relay/v1/healthz returns transcription_provider=groq and rewrite_provider=openai