### PR TITLE
Refine dictation capsule shader behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,23 @@ Build a local Release app bundle:
 Build the signed and notarized GitHub release artifacts:
 
 ```bash
-./scripts/release-macos-github.sh
-./scripts/publish-github-release.sh
+GITHUB_TAG=v0.0.6 GITHUB_REPOSITORY=DengNaichen/Stet ./scripts/release-macos-github.sh
+GITHUB_TAG=v0.0.6 GITHUB_REPOSITORY=DengNaichen/Stet ./scripts/publish-github-release.sh
 ```
 
 Release artifacts are written to `dist/github-release/<tag>/`.
+
+Useful release overrides:
+
+```bash
+# Override archive signing if your local setup needs it
+ARCHIVE_CODE_SIGN_STYLE=Manual
+ARCHIVE_CODE_SIGN_IDENTITY="Developer ID Application"
+ARCHIVE_PROVISIONING_PROFILE_SPECIFIER="Mac Team Provisioning Profile: NaichengDeng.Stet"
+
+# Override Sparkle tool path if auto-discovery misses your local install
+SPARKLE_GENERATE_APPCAST=/absolute/path/to/generate_appcast
+```
 
 ## Documentation
 

--- a/apps/mac/Stet/Features/MacShell/DictationPanel/MacDictationPanelViewModel.swift
+++ b/apps/mac/Stet/Features/MacShell/DictationPanel/MacDictationPanelViewModel.swift
@@ -10,7 +10,7 @@
             static let attackTime: TimeInterval = 0.080
             static let releaseTime: TimeInterval = 0.320
             static let decayTime: TimeInterval = 0.200
-            static let silenceFloor: Double = 0.006
+            static let silenceFloor: Double = 0.003
             static let publishEpsilon: Double = 0.0005
             static let snapToZeroThreshold: Double = 0.0015
         }
@@ -22,7 +22,9 @@
         }
 
         enum Normalization {
-            static let levelPower: Double = 0.66
+            static let levelPower: Double = 0.54
+            static let quietSpeechThreshold: Double = 0.42
+            static let quietSpeechBoost: Double = 0.52
             static let divisorEpsilon: Double = 0.0001
         }
     }
@@ -163,7 +165,11 @@
             let gated =
                 max(0, clamped - Constants.Tuning.silenceFloor)
                 / max(1.0 - Constants.Tuning.silenceFloor, Constants.Normalization.divisorEpsilon)
-            return pow(gated, Constants.Normalization.levelPower)
+            let curved = pow(gated, Constants.Normalization.levelPower)
+            let quietBand = max(0, Constants.Normalization.quietSpeechThreshold - gated)
+                / max(Constants.Normalization.quietSpeechThreshold, Constants.Normalization.divisorEpsilon)
+            let quietCompensation = gated * quietBand * Constants.Normalization.quietSpeechBoost
+            return min(1, curved + quietCompensation)
         }
 
         private static func isVoiceReactiveState(_ state: DictationState) -> Bool {

--- a/apps/mac/Stet/Features/MacShell/DictationPanel/MacDictationPanelVisualSignalMapper.swift
+++ b/apps/mac/Stet/Features/MacShell/DictationPanel/MacDictationPanelVisualSignalMapper.swift
@@ -19,6 +19,18 @@
             }
         }
 
+        private enum Tuning {
+            static let amplitudeGain: Double = 1.84
+            static let quietAssistThreshold: Double = 0.62
+            static let quietAmplitudeBoost: Double = 0.48
+            static let quietPresenceBoost: Double = 0.38
+            static let quietPulseBoost: Double = 0.10
+            static let quietArticulationBoost: Double = 0.08
+            static let sustainedPulseFloor: Double = 0.16
+            static let sustainedArticulationFloor: Double = 0.14
+            static let lowTonePresenceWeight: Double = 0.22
+        }
+
         private enum Timing {
             static let bodyAttack: TimeInterval = 0.12
             static let bodyRelease: TimeInterval = 0.22
@@ -71,7 +83,14 @@
             )
 
             let transient = max(0, nextFast - nextBody)
-            let pulseTarget = isVoiceReactive ? clamp01(transient * 4.20 + target * 0.10) : 0
+            let quietAssist = quietResponse(for: target)
+            let pulseTarget = isVoiceReactive
+                ? clamp01(
+                    transient * 4.20
+                        + target * (0.10 + quietAssist * Tuning.quietPulseBoost)
+                        + nextBody * Tuning.sustainedPulseFloor
+                )
+                : 0
             let nextPulse = smooth(
                 current: state.pulse,
                 target: pulseTarget,
@@ -93,7 +112,8 @@
                 ? clamp01(
                     transient * 2.0
                         + max(0, nextFast - nextPresence * 0.66) * 1.02
-                        + target * 0.22
+                        + target * (0.22 + quietAssist * Tuning.quietArticulationBoost)
+                        + nextBody * Tuning.sustainedArticulationFloor
                 ) : 0
             let nextArticulation = smooth(
                 current: state.articulation,
@@ -113,7 +133,12 @@
         }
 
         private static func presenceTarget(body: Double, fast: Double) -> Double {
-            clamp01(max(body * 1.16 + fast * 0.58, fast * 1.02))
+            let anchor = max(body, fast)
+            let quietAssist = quietResponse(for: anchor)
+            return clamp01(
+                max(body * 1.24 + fast * 0.46, fast * 0.92 + body * Tuning.lowTonePresenceWeight)
+                    + anchor * quietAssist * Tuning.quietPresenceBoost
+            )
         }
 
         private static func smooth(
@@ -133,7 +158,17 @@
         }
 
         private static func amplifiedLevel(_ value: Double) -> Double {
-            clamp01(value * 1.68)
+            let clamped = clamp01(value)
+            let quietAssist = quietResponse(for: clamped)
+            let boosted = clamped * Tuning.amplitudeGain
+                + clamped * quietAssist * Tuning.quietAmplitudeBoost
+            return clamp01(boosted)
+        }
+
+        private static func quietResponse(for value: Double) -> Double {
+            let clamped = clamp01(value)
+            let quietRange = max(Tuning.quietAssistThreshold - clamped, 0)
+            return clamp01(quietRange / Tuning.quietAssistThreshold)
         }
     }
 #endif

--- a/apps/mac/StetVisuals/CapsuleOrbShaders.metal
+++ b/apps/mac/StetVisuals/CapsuleOrbShaders.metal
@@ -47,29 +47,39 @@ namespace Config {
     constant float VORTEX_SPIN_AMP = 0.28;
     
     // Rendering Params
+    constant float VIEW_PULLBACK = 1.8;
     constant float WARP_SCALE = 0.42;
     constant float WARP_TIME_SCALE = 0.82;
     constant float FBM_NOISE_SCALE = 0.48;
     constant float FBM_WARP_SKEW_BASE = 1.20;
     constant float FBM_TIME_FLOW = 0.14;
+    constant float MICRO_DETAIL_SCALE = 3.4;
+    constant float MICRO_DETAIL_WARP = 0.24;
+    constant float MICRO_DETAIL_TIME_FLOW = 0.11;
+    constant float MICRO_DETAIL_STRENGTH = 0.055;
     constant float SMOOTHSTEP_LOW = 0.10;
     constant float SMOOTHSTEP_HIGH = 0.92;
     
     // Colors & Fluid
     constant float FLUID_Y_BIAS = 0.78;
     constant float FLUID_WARP_BIAS = 0.95;
-    constant float COLOR_LIFT_FACTOR = 0.08;
-    constant float MASK_BLUE_LOW = 0.09;
-    constant float MASK_BLUE_HIGH = 0.56;
+    constant float COLOR_LIFT_FACTOR = 0.06;
+    constant float MASK_BLUE_LOW = 0.16;
+    constant float MASK_BLUE_HIGH = 0.46;
     constant float MASK_BLUE_SKEW = 0.34;
-    constant float MASK_ORANGE_LOW = 0.10;
-    constant float MASK_ORANGE_HIGH = 0.60;
+    constant float MASK_ORANGE_LOW = 0.18;
+    constant float MASK_ORANGE_HIGH = 0.48;
     constant float MASK_ORANGE_SKEW = 0.30;
     
     // Depth
     constant float DEPTH_SKEW = 0.48;
     constant float DEPTH_BLEND_BASE = 0.74;
     constant float DEPTH_BLEND_AMP = 0.26;
+    constant float MID_BASE_STRENGTH = 0.92;
+    constant float LOW_COLOR_STRENGTH = 0.72;
+    constant float LOW_DEPTH_BLEND = 0.08;
+    constant float TOP_COLOR_STRENGTH = 0.70;
+    constant float TOP_EDGE_SUPPRESSION = 0.14;
     
     // Cloud Appearance
     constant float CLOUD_DENSE_LOW = 0.32;
@@ -203,7 +213,7 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     float aspect = safeSize.x / safeSize.y;
 
     float2 pRaw = float2((uv.x - 0.5) * 2.0 * aspect,
-                         (uv.y - 0.5) * 2.0);
+                         (uv.y - 0.5) * 2.0) * Config::VIEW_PULLBACK;
 
     float detailClamped = clamp(detail, 0.0, 1.0);
     float bodyClamped = clamp(body, 0.0, 1.0);
@@ -248,53 +258,64 @@ static float2 vortexField(float2 p, float2 center, float strength) {
 
     float bulge = 1.0 - (0.06 * breath + 0.03 * kick) * centerMask;
     float2 p = pRaw * bulge
-             + wind * (0.18 + 0.10 * kick)
-             + curl * ((0.08 + 0.20 * breath + 0.24 * kick + 0.10 * edge) * detailClamped);
+             + wind * (0.18 + 0.05 * kick)
+             + curl * ((0.08 + 0.20 * breath + 0.10 * kick + 0.04 * edge) * detailClamped);
 
     float2 w;
     float n;
     if (detailClamped < 0.72) {
-        w = domainWarpFast(p * (Config::WARP_SCALE + 0.03 * edge), time * Config::WARP_TIME_SCALE * (0.92 + 0.28 * life));
+        w = domainWarpFast(p * (Config::WARP_SCALE + 0.015 * edge), time * Config::WARP_TIME_SCALE * (0.92 + 0.28 * life));
         n = fbmFast(
             p * Config::FBM_NOISE_SCALE
-            + w * (0.72 + breath * 0.34 + kick * 0.26)
+            + w * (0.72 + breath * 0.34 + kick * 0.12)
             + float2(0.0, time * Config::FBM_TIME_FLOW * (0.85 + 0.30 * life))
         );
     } else {
-        w = domainWarp(p * (Config::WARP_SCALE + 0.04 * edge), time * Config::WARP_TIME_SCALE * (0.92 + 0.30 * life));
+        w = domainWarp(p * (Config::WARP_SCALE + 0.02 * edge), time * Config::WARP_TIME_SCALE * (0.92 + 0.30 * life));
         n = fbm(
             p * Config::FBM_NOISE_SCALE
-            + w * (Config::FBM_WARP_SKEW_BASE + breath * 0.56 + kick * 0.30 + edge * 0.22)
+            + w * (Config::FBM_WARP_SKEW_BASE + breath * 0.56 + kick * 0.14 + edge * 0.08)
             + float2(0.0, time * Config::FBM_TIME_FLOW * (0.88 + 0.34 * life))
         );
     }
+
+    float microDetail = noise2D(
+        p * (Config::FBM_NOISE_SCALE * Config::MICRO_DETAIL_SCALE + 0.12 * edge)
+        + w * Config::MICRO_DETAIL_WARP
+        + float2(
+            time * Config::MICRO_DETAIL_TIME_FLOW * (0.82 + 0.18 * life),
+            -time * Config::MICRO_DETAIL_TIME_FLOW * (0.68 + 0.16 * breath)
+        )
+    );
+    n += (microDetail - 0.5) * Config::MICRO_DETAIL_STRENGTH * (0.35 + 0.65 * detailClamped);
     n = smoothstep(Config::SMOOTHSTEP_LOW, Config::SMOOTHSTEP_HIGH, n);
 
     float3 top = float3(colorTop.rgb);
     float3 mid = float3(colorMid.rgb);
     float3 low = float3(colorLow.rgb);
 
-    float fluidBias = p.y * Config::FLUID_Y_BIAS + (w.y - 0.5) * (Config::FLUID_WARP_BIAS + 0.16 * edge);
-    float colorLift = centerMask * (breath + 0.55 * kick) * Config::COLOR_LIFT_FACTOR;
-    float colorMix = 0.68;
+    float fluidBias = p.y * Config::FLUID_Y_BIAS + (w.y - 0.5) * (Config::FLUID_WARP_BIAS + 0.08 * edge);
+    float colorLift = centerMask * (breath + 0.22 * kick) * Config::COLOR_LIFT_FACTOR;
+    float colorMix = 0.38;
 
     float maskBlue = smoothstep(
         Config::MASK_BLUE_LOW,
         Config::MASK_BLUE_HIGH,
-        n - fluidBias * (Config::MASK_BLUE_SKEW + 0.06 * edge) - colorLift
+        n - fluidBias * (Config::MASK_BLUE_SKEW + 0.02 * edge) - colorLift
     );
     float maskOrange = smoothstep(
         Config::MASK_ORANGE_LOW,
         Config::MASK_ORANGE_HIGH,
-        w.x + fluidBias * Config::MASK_ORANGE_SKEW + colorLift + edge * 0.06
+        w.x + fluidBias * Config::MASK_ORANGE_SKEW + colorLift + edge * 0.02
     );
 
     float depth = smoothstep(-1.0, 1.0, pRaw.y + (n - 0.5) * Config::DEPTH_SKEW);
 
-    float3 base = mid;
-    float lowWeight = clamp(maskBlue * colorMix + (1.0 - depth) * 0.14, 0.0, 1.0);
+    float3 base = mid * Config::MID_BASE_STRENGTH;
+    float lowWeight = clamp(maskBlue * colorMix * Config::LOW_COLOR_STRENGTH + (1.0 - depth) * Config::LOW_DEPTH_BLEND, 0.0, 1.0);
+    float topWeight = clamp(maskOrange * colorMix * Config::TOP_COLOR_STRENGTH - lowWeight * Config::TOP_EDGE_SUPPRESSION, 0.0, 1.0);
     base = mix(base, low, lowWeight);
-    base = mix(base, top, maskOrange * colorMix * 0.92);
+    base = mix(base, top, topWeight);
 
     float cloudDense = smoothstep(Config::CLOUD_DENSE_LOW, Config::CLOUD_DENSE_HIGH, n + centerMask * (breath + 0.40 * kick) * Config::COLOR_LIFT_FACTOR);
     float cloudSoft = smoothstep(Config::CLOUD_SOFT_LOW, Config::CLOUD_SOFT_HIGH, Config::CLOUD_SOFT_n_SKEW * n + Config::CLOUD_SOFT_w_SKEW * w.x + 0.08 * edge);

--- a/apps/mac/StetVisuals/CapsuleOrbShaders.metal
+++ b/apps/mac/StetVisuals/CapsuleOrbShaders.metal
@@ -15,73 +15,65 @@ namespace Config {
     constant float2 FBM_ROT_ROW1 = float2(0.80, 0.60);
     constant float2 FBM_ROT_ROW2 = float2(-0.60, 0.80);
     constant float FBM_SCALE = 2.0;
-    
-    // Warp
+
+    // Warp (restored from original)
     constant float2 WARP_Q_OFFSET = float2(5.2, 1.3);
     constant float2 WARP_R_OFFSET_1 = float2(1.7, 9.2);
     constant float2 WARP_R_OFFSET_2 = float2(8.3, 2.8);
     constant float WARP_Q_TIME_SKEW_A = 0.05;
     constant float WARP_Q_TIME_SKEW_B = 0.04;
     constant float WARP_R_TIME_SKEW = 0.02;
-    
-    // Motion
+
+    // Motion (restored from original)
     constant float MOTION_Y_AMP = 0.010;
     constant float MOTION_Y_FREQ = 1.20;
     constant float MOTION_X_AMP = 0.006;
     constant float MOTION_X_FREQ = 0.74;
     constant float MOTION_X_Y_SKEW = 1.25;
-    
-    // Shape & Masking
-    constant float SHAPE_CORE_Y = 5.0;
-    constant float SHAPE_CORE_X = 1.6;
-    constant float SHAPE_CENTER_BASE = 0.35;
-    constant float SHAPE_CENTER_X_INF = 0.65;
-    constant float SHAPE_SIDE_FACTOR = 0.22;
-    constant float SHAPE_PUSH_BASE = 0.05;
-    constant float SHAPE_PUSH_SKEW = 0.72;
-    constant float SHAPE_SPREAD_FACTOR = 0.32;
-    
-    // Vortex
-    constant float VORTEX_SOFTNESS = 0.14;
-    constant float VORTEX_SPIN_BASE = 0.04;
-    constant float VORTEX_SPIN_AMP = 0.28;
-    
-    // Rendering Params
-    constant float VIEW_PULLBACK = 1.8;
+
+    // View
+    constant float VIEW_PULLBACK = 1.5;
     constant float WARP_SCALE = 0.42;
     constant float WARP_TIME_SCALE = 0.82;
     constant float FBM_NOISE_SCALE = 0.48;
     constant float FBM_WARP_SKEW_BASE = 1.20;
     constant float FBM_TIME_FLOW = 0.14;
+    constant float SMOOTHSTEP_LOW = 0.10;
+    constant float SMOOTHSTEP_HIGH = 0.92;
+
+    // Micro detail (restored from original)
     constant float MICRO_DETAIL_SCALE = 3.4;
     constant float MICRO_DETAIL_WARP = 0.24;
     constant float MICRO_DETAIL_TIME_FLOW = 0.11;
     constant float MICRO_DETAIL_STRENGTH = 0.055;
-    constant float SMOOTHSTEP_LOW = 0.10;
-    constant float SMOOTHSTEP_HIGH = 0.92;
-    
-    // Colors & Fluid
-    constant float FLUID_Y_BIAS = 0.78;
-    constant float FLUID_WARP_BIAS = 0.95;
-    constant float COLOR_LIFT_FACTOR = 0.06;
-    constant float MASK_BLUE_LOW = 0.16;
-    constant float MASK_BLUE_HIGH = 0.46;
-    constant float MASK_BLUE_SKEW = 0.34;
-    constant float MASK_ORANGE_LOW = 0.18;
-    constant float MASK_ORANGE_HIGH = 0.48;
-    constant float MASK_ORANGE_SKEW = 0.30;
-    
-    // Depth
-    constant float DEPTH_SKEW = 0.48;
-    constant float DEPTH_BLEND_BASE = 0.74;
-    constant float DEPTH_BLEND_AMP = 0.26;
-    constant float MID_BASE_STRENGTH = 0.92;
-    constant float LOW_COLOR_STRENGTH = 0.72;
-    constant float LOW_DEPTH_BLEND = 0.08;
-    constant float TOP_COLOR_STRENGTH = 0.70;
-    constant float TOP_EDGE_SUPPRESSION = 0.14;
-    
-    // Cloud Appearance
+
+    // Blob orbiting system (continuously rearranging, never static)
+    constant float ORBIT_RADIUS_X = 0.50;
+    constant float ORBIT_RADIUS_Y = 0.16;
+    constant float ORBIT_ASPECT_SCALE = 0.35;
+    constant float ORBIT_SPEED_A = 0.13;
+    constant float ORBIT_SPEED_B = 0.09;
+    constant float ORBIT_SPEED_C = 0.11;
+    constant float ORBIT_PHASE_A = 0.0;
+    constant float ORBIT_PHASE_B = 2.20;
+    constant float ORBIT_PHASE_C = 4.10;
+
+    // Blob radii (slight variation, but balanced)
+    constant float BLOB_A_RADIUS = 1.0;
+    constant float BLOB_B_RADIUS = 1.05;
+    constant float BLOB_C_RADIUS = 1.0;
+
+    // Audio drift (visible in capsule)
+    constant float DRIFT_AUDIO_AMP = 0.06;
+    constant float PULSE_DISPLACEMENT = 0.05;
+
+    // Ownership field
+    constant float OWNERSHIP_TEMP = 3.6;
+    constant float NOISE_PERTURB_SCALE = 0.9;
+    constant float NOISE_PERTURB_AMP = 0.14;
+    constant float WARP_OWNERSHIP_INFLUENCE = 0.26;
+
+    // Cloud appearance (restored, but uses blob colors not white)
     constant float CLOUD_DENSE_LOW = 0.32;
     constant float CLOUD_DENSE_HIGH = 0.80;
     constant float CLOUD_SOFT_LOW = 0.20;
@@ -95,30 +87,58 @@ namespace Config {
     constant float CLOUD_LIFT_CENTER_SKEW = 0.15;
     constant float CLOUD_MIX_BASE = 0.58;
     constant float CLOUD_MIX_AMP = 0.42;
-    constant float CLOUD_WHITE_BASE = 0.68;
-    constant float CLOUD_WHITE_AMP = 0.06;
-    
-    // Glow & Final
+    constant float CLOUD_COLOR_STRENGTH = 0.32;
+
+    // Internal shading
+    constant float INTERNAL_SHADE_STRENGTH = 0.16;
+
+    // Shape & center mask (restored from original)
+    constant float SHAPE_CORE_Y = 5.0;
+    constant float SHAPE_CORE_X = 1.6;
+    constant float SHAPE_CENTER_BASE = 0.35;
+    constant float SHAPE_CENTER_X_INF = 0.65;
+    constant float SHAPE_SIDE_FACTOR = 0.22;
+    constant float SHAPE_PUSH_BASE = 0.03;
+    constant float SHAPE_PUSH_SKEW = 0.40;
+    constant float SHAPE_SPREAD_FACTOR = 0.32;
+
+    // Vortex (restored from original)
+    constant float VORTEX_SOFTNESS = 0.14;
+    constant float VORTEX_SPIN_BASE = 0.03;
+    constant float VORTEX_SPIN_AMP = 0.14;
+
+    // Depth
+    constant float DEPTH_SKEW = 0.48;
+    constant float DEPTH_BLEND_BASE = 0.74;
+    constant float DEPTH_BLEND_AMP = 0.26;
+
+    // Audio
+    constant float AUDIO_FLOOR = 0.10;
+    constant float AUDIO_BOOST = 1.10;
+    constant float AUDIO_POWER = 0.50;
+    // (PULSE_DISPLACEMENT moved to blob orbit section)
+    constant float PRESENCE_BRIGHT = 0.04;
+
+    // Glow & Final (restored from original)
     constant float GLOW_Y_SKEW = 7.0;
     constant float GLOW_X_SKEW = 1.2;
     constant float3 GLOW_COLOR_BASE = float3(0.12, 0.10, 0.08);
     constant float GLOW_INTENSITY = 0.45;
-    constant float3 LIFT_COLOR = float3(0.045, 0.038, 0.032);
-    constant float AUDIO_FLOOR = 0.05;
-    constant float AUDIO_BOOST = 1.18;
-    constant float AUDIO_POWER = 0.82;
-    
+    constant float3 LIFT_COLOR = float3(0.025, 0.020, 0.016);
+
     // Sun
     constant float2 SUN_POS_SKEW = float2(0.28, 0.38);
     constant float SUN_SIZE = 0.8;
     constant float3 SUN_COLOR = float3(1.0, 0.98, 0.92);
     constant float SUN_STRENGTH = 0.07;
-    
+
     // Vignette
-    constant float VIGNETTE_START = 0.28;
-    constant float VIGNETTE_END = 1.28;
+    constant float VIGNETTE_START = 0.38;
+    constant float VIGNETTE_END = 1.40;
     constant float VIGNETTE_STRENGTH = 0.10;
 }
+
+// MARK: - Noise primitives
 
 static float hash21(float2 p) {
     p = fract(p * Config::HASH_VEC);
@@ -194,6 +214,25 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     return strength * inv * float2(-d.y, d.x);
 }
 
+// MARK: - Blob orbit
+
+static float2 blobOrbitCenter(float time, float orbitSpeed, float orbitPhase,
+                               float audioAmp, float pulseDisp, float aspectStretch) {
+    float angle = time * orbitSpeed + orbitPhase;
+    // Orbit X radius stretches with aspect ratio so blobs fill wide capsules
+    float radiusX = Config::ORBIT_RADIUS_X + aspectStretch;
+    float radiusY = Config::ORBIT_RADIUS_Y;
+    return float2(
+        radiusX * cos(angle) + audioAmp * sin(angle * 1.7 + orbitPhase),
+        radiusY * sin(angle) + audioAmp * cos(angle * 1.3 + orbitPhase)
+    ) + float2(
+        pulseDisp * sin(time * 3.2 + orbitPhase * 0.7),
+        pulseDisp * cos(time * 2.8 + orbitPhase * 1.3)
+    );
+}
+
+// MARK: - Main shader
+
 [[ stitchable ]] half4 cloudOrbGlassWide(
     float2 position,
     half4 currentColor,
@@ -204,10 +243,11 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     float pulse,
     float articulation,
     float detail,
-    half4 colorTop,
-    half4 colorMid,
-    half4 colorLow
+    half4 colorA_in,
+    half4 colorB_in,
+    half4 colorC_in
 ) {
+    // --- Coordinate setup ---
     float2 safeSize = float2(max(size.x, 1.0), max(size.y, 1.0));
     float2 uv = position / safeSize;
     float aspect = safeSize.x / safeSize.y;
@@ -215,6 +255,7 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     float2 pRaw = float2((uv.x - 0.5) * 2.0 * aspect,
                          (uv.y - 0.5) * 2.0) * Config::VIEW_PULLBACK;
 
+    // --- Clamp & derive audio ---
     float detailClamped = clamp(detail, 0.0, 1.0);
     float bodyClamped = clamp(body, 0.0, 1.0);
     float presenceClamped = clamp(presence, 0.0, 1.0);
@@ -225,17 +266,25 @@ static float2 vortexField(float2 p, float2 center, float strength) {
         Config::AUDIO_FLOOR
         + pow(bodyClamped, Config::AUDIO_POWER) * Config::AUDIO_BOOST
         + pulseClamped * 0.16,
-        0.0,
-        1.0
+        0.0, 1.0
     );
-    float breath = talk * talk * (3.0 - 2.0 * talk);
+    // Breath: mix sqrt (lifts low values) with smoothstep (shapes high values)
+    float breathSmooth = talk * talk * (3.0 - 2.0 * talk);
+    float breathSqrt = sqrt(talk);
+    float breath = mix(breathSqrt, breathSmooth, 0.5);
+
+    // Edge/kick: keep smoothstep but add a floor so quiet articulation is visible
     float edge = articulationClamped * articulationClamped * (3.0 - 2.0 * articulationClamped);
+    edge = max(edge, articulationClamped * 0.35);
     float kick = pulseClamped * pulseClamped * (3.0 - 2.0 * pulseClamped);
+    kick = max(kick, pulseClamped * 0.30);
     float life = max(presenceClamped, 0.18);
 
+    // --- Original motion (restored) ---
     pRaw.y += Config::MOTION_Y_AMP * (0.60 + 0.55 * life) * sin(time * Config::MOTION_Y_FREQ);
     pRaw.x += Config::MOTION_X_AMP * (0.55 + 0.70 * life) * sin(time * Config::MOTION_X_FREQ + pRaw.y * Config::MOTION_X_Y_SKEW);
 
+    // --- Original shape masks (restored for cloud & glow) ---
     float coreY = exp(-pRaw.y * pRaw.y * Config::SHAPE_CORE_Y);
     float coreX = exp(-pRaw.x * pRaw.x * Config::SHAPE_CORE_X);
     float centerMask = coreY * (Config::SHAPE_CENTER_BASE + Config::SHAPE_CENTER_X_INF * coreX);
@@ -256,11 +305,12 @@ static float2 vortexField(float2 p, float2 center, float strength) {
              + vortexField(pRaw, float2( spread, 0.0), -spin);
     }
 
-    float bulge = 1.0 - (0.06 * breath + 0.03 * kick) * centerMask;
+    float bulge = 1.0 - (0.03 * breath + 0.015 * kick) * centerMask;
     float2 p = pRaw * bulge
-             + wind * (0.18 + 0.05 * kick)
-             + curl * ((0.08 + 0.20 * breath + 0.10 * kick + 0.04 * edge) * detailClamped);
+             + wind * (0.12 + 0.03 * kick)
+             + curl * ((0.06 + 0.10 * breath + 0.05 * kick + 0.03 * edge) * detailClamped);
 
+    // --- Domain warp & FBM (restored from original — this is the texture engine) ---
     float2 w;
     float n;
     if (detailClamped < 0.72) {
@@ -279,6 +329,7 @@ static float2 vortexField(float2 p, float2 center, float strength) {
         );
     }
 
+    // Micro detail (restored)
     float microDetail = noise2D(
         p * (Config::FBM_NOISE_SCALE * Config::MICRO_DETAIL_SCALE + 0.12 * edge)
         + w * Config::MICRO_DETAIL_WARP
@@ -290,43 +341,110 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     n += (microDetail - 0.5) * Config::MICRO_DETAIL_STRENGTH * (0.35 + 0.65 * detailClamped);
     n = smoothstep(Config::SMOOTHSTEP_LOW, Config::SMOOTHSTEP_HIGH, n);
 
-    float3 top = float3(colorTop.rgb);
-    float3 mid = float3(colorMid.rgb);
-    float3 low = float3(colorLow.rgb);
+    // ============================================================
+    // COLOR ASSIGNMENT: Blob ownership (replaces old mask mixing)
+    // ============================================================
 
-    float fluidBias = p.y * Config::FLUID_Y_BIAS + (w.y - 0.5) * (Config::FLUID_WARP_BIAS + 0.08 * edge);
-    float colorLift = centerMask * (breath + 0.22 * kick) * Config::COLOR_LIFT_FACTOR;
-    float colorMix = 0.38;
+    // --- Blob centers (orbiting, aspect-aware so they fill wide capsules) ---
+    float audioAmp = breath * Config::DRIFT_AUDIO_AMP;
+    float pulseDrift = kick * Config::PULSE_DISPLACEMENT;
+    float aspectStretch = max(0.0, (aspect - 1.0)) * Config::ORBIT_ASPECT_SCALE;
 
-    float maskBlue = smoothstep(
-        Config::MASK_BLUE_LOW,
-        Config::MASK_BLUE_HIGH,
-        n - fluidBias * (Config::MASK_BLUE_SKEW + 0.02 * edge) - colorLift
-    );
-    float maskOrange = smoothstep(
-        Config::MASK_ORANGE_LOW,
-        Config::MASK_ORANGE_HIGH,
-        w.x + fluidBias * Config::MASK_ORANGE_SKEW + colorLift + edge * 0.02
-    );
+    float2 centerA = blobOrbitCenter(time, Config::ORBIT_SPEED_A, Config::ORBIT_PHASE_A, audioAmp, pulseDrift, aspectStretch);
+    float2 centerB = blobOrbitCenter(time, Config::ORBIT_SPEED_B, Config::ORBIT_PHASE_B, audioAmp, pulseDrift, aspectStretch);
+    float2 centerC = blobOrbitCenter(time, Config::ORBIT_SPEED_C, Config::ORBIT_PHASE_C, audioAmp, pulseDrift, aspectStretch);
 
-    float depth = smoothstep(-1.0, 1.0, pRaw.y + (n - 0.5) * Config::DEPTH_SKEW);
+    // --- Distances with noise perturbation + mild warp influence ---
+    float noiseTime = time * 0.03;
+    float nPertA = fbmFast(p * Config::NOISE_PERTURB_SCALE + float2( 0.0,  0.0) + noiseTime * 0.9) * Config::NOISE_PERTURB_AMP;
+    float nPertB = fbmFast(p * Config::NOISE_PERTURB_SCALE + float2( 5.3,  2.7) + noiseTime * 0.8) * Config::NOISE_PERTURB_AMP;
+    float nPertC = fbmFast(p * Config::NOISE_PERTURB_SCALE + float2(10.1,  7.4) + noiseTime * 1.1) * Config::NOISE_PERTURB_AMP;
 
-    float3 base = mid * Config::MID_BASE_STRENGTH;
-    float lowWeight = clamp(maskBlue * colorMix * Config::LOW_COLOR_STRENGTH + (1.0 - depth) * Config::LOW_DEPTH_BLEND, 0.0, 1.0);
-    float topWeight = clamp(maskOrange * colorMix * Config::TOP_COLOR_STRENGTH - lowWeight * Config::TOP_EDGE_SUPPRESSION, 0.0, 1.0);
-    base = mix(base, low, lowWeight);
-    base = mix(base, top, topWeight);
+    // Warp nudges ownership — use different warp components per blob so no one is
+    // systematically favored or suppressed
+    float warpNudgeX = (w.x - 0.5) * Config::WARP_OWNERSHIP_INFLUENCE;
+    float warpNudgeY = (w.y - 0.5) * Config::WARP_OWNERSHIP_INFLUENCE;
 
-    float cloudDense = smoothstep(Config::CLOUD_DENSE_LOW, Config::CLOUD_DENSE_HIGH, n + centerMask * (breath + 0.40 * kick) * Config::COLOR_LIFT_FACTOR);
-    float cloudSoft = smoothstep(Config::CLOUD_SOFT_LOW, Config::CLOUD_SOFT_HIGH, Config::CLOUD_SOFT_n_SKEW * n + Config::CLOUD_SOFT_w_SKEW * w.x + 0.08 * edge);
-    float cloudLift = smoothstep(Config::CLOUD_LIFT_LOW, Config::CLOUD_LIFT_HIGH, Config::CLOUD_LIFT_n_SKEW * n + Config::CLOUD_LIFT_w_SKEW * w.y + centerMask * (breath + 0.40 * kick) * Config::CLOUD_LIFT_CENTER_SKEW);
+    // Aspect-normalized distance: divide X diff by aspect so blobs appear
+    // circular on screen, not stretched. This also makes Y movements
+    // (which are very visible in the short capsule) properly weighted.
+    float invAspect = 1.0 / max(aspect, 1.0);
+
+    float2 diffA = p - centerA;
+    diffA.x *= invAspect;
+    float dA = length(diffA) / Config::BLOB_A_RADIUS + nPertA + warpNudgeX;
+
+    float2 diffB = p - centerB;
+    diffB.x *= invAspect;
+    float dB = length(diffB) / Config::BLOB_B_RADIUS + nPertB + warpNudgeY;
+
+    float2 diffC = p - centerC;
+    diffC.x *= invAspect;
+    float dC = length(diffC) / Config::BLOB_C_RADIUS + nPertC - warpNudgeX;
+
+    // --- Soft ownership weights ---
+    float temp = Config::OWNERSHIP_TEMP;
+    float wA = exp(-dA * temp);
+    float wB = exp(-dB * temp);
+    float wC = exp(-dC * temp);
+    float wSum = wA + wB + wC + 1e-6;
+    wA /= wSum;
+    wB /= wSum;
+    wC /= wSum;
+
+    // --- Base color from ownership ---
+    float3 colA = float3(colorA_in.rgb);
+    float3 colB = float3(colorB_in.rgb);
+    float3 colC = float3(colorC_in.rgb);
+
+    float3 base = wA * colA + wB * colB + wC * colC;
+
+    // --- Internal shading from fbm (adds depth, stays within blob) ---
+    float maxW = max(wA, max(wB, wC));
+    float boundaryness = 1.0 - smoothstep(0.36, 0.55, maxW);
+    float internalShade = (n - 0.5) * Config::INTERNAL_SHADE_STRENGTH * (0.4 + 0.6 * detailClamped);
+    base *= (1.0 + internalShade * (1.0 - boundaryness * 0.5));
+
+    // ============================================================
+    // CLOUD LAYER: Uses blob colors instead of white
+    // ============================================================
+
+    float cloudDense = smoothstep(Config::CLOUD_DENSE_LOW, Config::CLOUD_DENSE_HIGH,
+        n + centerMask * (breath + 0.40 * kick) * 0.06);
+    float cloudSoft = smoothstep(Config::CLOUD_SOFT_LOW, Config::CLOUD_SOFT_HIGH,
+        Config::CLOUD_SOFT_n_SKEW * n + Config::CLOUD_SOFT_w_SKEW * w.x + 0.08 * edge);
+    float cloudLift = smoothstep(Config::CLOUD_LIFT_LOW, Config::CLOUD_LIFT_HIGH,
+        Config::CLOUD_LIFT_n_SKEW * n + Config::CLOUD_LIFT_w_SKEW * w.y
+        + centerMask * (breath + 0.40 * kick) * Config::CLOUD_LIFT_CENTER_SKEW);
 
     float cloud = max(cloudDense, cloudSoft * 0.92);
     cloud = max(cloud, cloudLift * (Config::CLOUD_MIX_BASE + Config::CLOUD_MIX_AMP * breath));
-    cloud *= (Config::DEPTH_BLEND_BASE + Config::DEPTH_BLEND_AMP * depth);
+    cloud *= (Config::DEPTH_BLEND_BASE + Config::DEPTH_BLEND_AMP * smoothstep(-1.0, 1.0, pRaw.y + (n - 0.5) * Config::DEPTH_SKEW));
     cloud = clamp(cloud, 0.0, 1.0);
 
-    base = mix(base, float3(1.0), cloud * 0.22 * (Config::CLOUD_WHITE_BASE + Config::CLOUD_WHITE_AMP * (0.80 * breath + 0.20 * edge)));
+    // Wave-layered cloud color: three colors flow in rolling bands like ocean surf
+    // Use a slow directional noise field as the "wave position"
+    float waveField = fbmFast(
+        p * 0.5 + float2(time * 0.025, -time * 0.018)
+    ) + p.x * 0.12 + p.y * 0.08;  // slight directional bias for wave flow
+
+    // Map to [0, 3) range and create soft cosine bands for each color
+    float waveCycle = fract(waveField * 1.2) * 3.0;
+    float bandA = max(0.0, cos((waveCycle - 0.0) * 2.094) * 0.5 + 0.5);  // 2.094 = 2π/3
+    float bandB = max(0.0, cos((waveCycle - 1.0) * 2.094) * 0.5 + 0.5);
+    float bandC = max(0.0, cos((waveCycle - 2.0) * 2.094) * 0.5 + 0.5);
+    float bandSum = bandA + bandB + bandC + 1e-6;
+    float3 cloudColor = (bandA * colA + bandB * colB + bandC * colC) / bandSum;
+
+    // Keep cloud color deep — no white dilution
+    cloudColor = mix(cloudColor, float3(1.0), 0.05);
+
+    float cloudAmount = cloud * Config::CLOUD_COLOR_STRENGTH * (0.80 + 0.20 * breath);
+    base = mix(base, cloudColor, cloudAmount);
+
+    // ============================================================
+    // GLOW, SUN, VIGNETTE (restored from original)
+    // ============================================================
 
     float breathGlow = exp(-pRaw.y * pRaw.y * Config::GLOW_Y_SKEW) * exp(-pRaw.x * pRaw.x * Config::GLOW_X_SKEW);
     base += Config::GLOW_COLOR_BASE * breathGlow * (0.55 * breath + 0.85 * kick) * Config::GLOW_INTENSITY;
@@ -339,6 +457,7 @@ static float2 vortexField(float2 p, float2 center, float strength) {
     base *= 1.0 - vignette * Config::VIGNETTE_STRENGTH;
 
     base += Config::LIFT_COLOR * (0.70 * breath + 0.30 * life);
+    base *= (1.0 + Config::PRESENCE_BRIGHT * life);
     base = clamp(base, 0.0, 1.0);
 
     return half4(half3(base), currentColor.a);

--- a/apps/mac/StetVisuals/MacDictationCapsuleVisualModel.swift
+++ b/apps/mac/StetVisuals/MacDictationCapsuleVisualModel.swift
@@ -147,9 +147,9 @@
                 pulse: 0.05,
                 articulation: 0.08,
                 detail: 1.0,
-                top: .white,
-                mid: .white,
-                low: .white
+                a: .white,
+                b: .white,
+                c: .white
             )
             try? await shader.compile(as: .colorEffect)
         }

--- a/apps/mac/StetVisuals/MacDictationCapsuleVisualView.swift
+++ b/apps/mac/StetVisuals/MacDictationCapsuleVisualView.swift
@@ -2,15 +2,15 @@
     import SwiftUI
 
     private enum MacDictationCapsuleVisualTuning {
-        static let orbSpacing: CGFloat = 28
-        static let orbTravelDistance: CGFloat = 132
-        static let orbHiddenScale: CGFloat = 0.92
+        static let orbSpacing: CGFloat = 18.144
+        static let orbTravelDistance: CGFloat = 150
+        static let orbHiddenScale: CGFloat = 0.84
         static let panelHiddenScale: CGFloat = 0.90
-        static let orbRevealDelay: Duration = .milliseconds(70)
+        static let orbRevealDelay: Duration = .milliseconds(130)
         static let closeAnimationDuration: UInt64 = 320_000_000
 
         static let panelSpring = Animation.spring(response: 0.34, dampingFraction: 0.90)
-        static let orbSpring = Animation.spring(response: 0.42, dampingFraction: 0.96)
+        static let orbSpring = Animation.spring(response: 0.62, dampingFraction: 0.90)
         static let closeSpring = Animation.spring(response: 0.30, dampingFraction: 0.92)
     }
 
@@ -49,7 +49,7 @@
                             }
                             .buttonStyle(.plain)
                             .frame(width: model.controlHeight, height: model.controlHeight)
-                            .glassEffect(.regular)
+                            .glassEffect(.regular.tint(nil))
                             .glassEffectID("cancel", in: glassNamespace)
                             .opacity(isPanelShown && showOrbs ? 1 : 0)
                             .offset(x: isPanelShown && showOrbs ? 0 : MacDictationCapsuleVisualTuning.orbTravelDistance)
@@ -58,7 +58,7 @@
 
                             Capsule()
                                 .frame(width: model.mainWidth, height: model.controlHeight)
-                                .glassEffect(.regular.tint(.white))
+                                .glassEffect(.regular.tint(nil))
                                 .glassEffectID("main", in: glassNamespace)
 
                             Button(action: actions.onConfirm) {
@@ -68,7 +68,7 @@
                             }
                             .buttonStyle(.plain)
                             .frame(width: model.controlHeight, height: model.controlHeight)
-                            .glassEffect(.regular)
+                            .glassEffect(.regular.tint(nil))
                             .glassEffectID("done", in: glassNamespace)
                             .opacity(isPanelShown && showOrbs ? 1 : 0)
                             .offset(

--- a/apps/mac/StetVisuals/MacDictationPanelConstants.swift
+++ b/apps/mac/StetVisuals/MacDictationPanelConstants.swift
@@ -3,13 +3,13 @@
 
     enum MacDictationPanelConstants {
         enum Layout {
-            static let mainWidthIdle: CGFloat = 200
-            static let mainWidthStarting: CGFloat = 200
-            static let mainWidthListening: CGFloat = 200
-            static let mainWidthProcessing: CGFloat = 200
-            static let mainWidthResult: CGFloat = 200
-            static let mainWidthClipboard: CGFloat = 200
-            static let mainWidthError: CGFloat = 200
+            static let mainWidthIdle: CGFloat = 152
+            static let mainWidthStarting: CGFloat = 152
+            static let mainWidthListening: CGFloat = 152
+            static let mainWidthProcessing: CGFloat = 152
+            static let mainWidthResult: CGFloat = 152
+            static let mainWidthClipboard: CGFloat = 152
+            static let mainWidthError: CGFloat = 152
 
             static let controlHeight: CGFloat = 40
             static let clipboardHeight: CGFloat = 118

--- a/apps/mac/StetVisuals/MacDictationShaderDebugView.swift
+++ b/apps/mac/StetVisuals/MacDictationShaderDebugView.swift
@@ -122,9 +122,9 @@
                                     pulse: signals.pulse,
                                     articulation: signals.articulation,
                                     detail: detail,
-                                    top: colors.top,
-                                    mid: colors.mid,
-                                    low: colors.low
+                                    a: colors.a,
+                                    b: colors.b,
+                                    c: colors.c
                                 )
                             )
                             .frame(width: surfaceWidth, height: surfaceHeight)

--- a/apps/mac/StetVisuals/MacDictationShaderLayer.swift
+++ b/apps/mac/StetVisuals/MacDictationShaderLayer.swift
@@ -38,9 +38,9 @@
                             pulse: effectiveSignals.pulse,
                             articulation: effectiveSignals.articulation,
                             detail: shaderDetail,
-                            top: colors.top,
-                            mid: colors.mid,
-                            low: colors.low
+                            a: colors.a,
+                            b: colors.b,
+                            c: colors.c
                         )
                     )
                     .overlay {

--- a/apps/mac/StetVisuals/MacDictationShaderStyling.swift
+++ b/apps/mac/StetVisuals/MacDictationShaderStyling.swift
@@ -26,85 +26,83 @@
             theme: MacDictationShaderTheme,
             elapsed: Double,
             signals: MacDictationCapsuleVisualSignals
-        ) -> (top: Color, mid: Color, low: Color) {
+        ) -> (a: Color, b: Color, c: Color) {
             let palette = theme.palette
-            let sustained = eased(max(signals.body, signals.presence * 0.92))
-            let accent = eased(max(signals.pulse, signals.articulation * 0.68))
-            let mixStrength = 0.72
 
-            let baseTop: (Double, Double, Double)
-            let baseMid: (Double, Double, Double)
-            let baseLow: (Double, Double, Double)
-            let injection: Double
-            let targetTop: (Double, Double, Double)
-            let targetMid: (Double, Double, Double)
-            let targetLow: (Double, Double, Double)
+            // State-time driven transition instead of audio-driven injection.
+            // The elapsed time since entering the state drives the crossfade,
+            // not the instantaneous audio strength.
+            let transitionSpeed = 0.35
+            let stateProgress = min(1.0, elapsed * transitionSpeed)
+            let injection = eased(stateProgress)
+
+            let baseA: (Double, Double, Double)
+            let baseB: (Double, Double, Double)
+            let baseC: (Double, Double, Double)
+            let targetA: (Double, Double, Double)
+            let targetB: (Double, Double, Double)
+            let targetC: (Double, Double, Double)
 
             switch state {
             case .processing:
-                baseTop = palette.idle.top
-                baseMid = palette.idle.mid
-                baseLow = palette.idle.low
-                injection = min(0.86, (0.46 + sustained * 0.32 + accent * 0.22) * mixStrength)
-                targetTop = palette.processing.top
-                targetMid = palette.processing.mid
-                targetLow = palette.processing.low
+                baseA = palette.idle.a
+                baseB = palette.idle.b
+                baseC = palette.idle.c
+                targetA = palette.processing.a
+                targetB = palette.processing.b
+                targetC = palette.processing.c
             case .starting:
-                baseTop = palette.starting.top
-                baseMid = palette.starting.mid
-                baseLow = palette.starting.low
-                injection = min(0.62, (0.28 + sustained * 0.18 + accent * 0.10) * mixStrength)
-                targetTop = palette.starting.top
-                targetMid = palette.starting.mid
-                targetLow = palette.starting.low
+                baseA = palette.idle.a
+                baseB = palette.idle.b
+                baseC = palette.idle.c
+                targetA = palette.starting.a
+                targetB = palette.starting.b
+                targetC = palette.starting.c
             case .listening:
-                baseTop = palette.idle.top
-                baseMid = palette.idle.mid
-                baseLow = palette.idle.low
-                injection = min(0.86, (0.12 + sustained * 0.68 + accent * 0.20) * mixStrength)
-                targetTop = palette.speaking.top
-                targetMid = palette.speaking.mid
-                targetLow = palette.speaking.low
+                baseA = palette.idle.a
+                baseB = palette.idle.b
+                baseC = palette.idle.c
+                targetA = palette.speaking.a
+                targetB = palette.speaking.b
+                targetC = palette.speaking.c
             case .result:
-                baseTop = palette.idle.top
-                baseMid = palette.idle.mid
-                baseLow = palette.idle.low
-                injection = 0.28
-                targetTop = palette.speaking.top
-                targetMid = palette.speaking.mid
-                targetLow = palette.speaking.low
+                baseA = palette.idle.a
+                baseB = palette.idle.b
+                baseC = palette.idle.c
+                targetA = palette.speaking.a
+                targetB = palette.speaking.b
+                targetC = palette.speaking.c
             default:
-                baseTop = palette.idle.top
-                baseMid = palette.idle.mid
-                baseLow = palette.idle.low
-                injection = 0
-                targetTop = palette.idle.top
-                targetMid = palette.idle.mid
-                targetLow = palette.idle.low
+                baseA = palette.idle.a
+                baseB = palette.idle.b
+                baseC = palette.idle.c
+                targetA = palette.idle.a
+                targetB = palette.idle.b
+                targetC = palette.idle.c
             }
 
-            let top = color(
+            let a = color(
                 from: (
-                    lerp(baseTop.0, targetTop.0, injection),
-                    lerp(baseTop.1, targetTop.1, injection),
-                    lerp(baseTop.2, targetTop.2, injection)
+                    lerp(baseA.0, targetA.0, injection),
+                    lerp(baseA.1, targetA.1, injection),
+                    lerp(baseA.2, targetA.2, injection)
                 )
             )
-            let mid = color(
+            let b = color(
                 from: (
-                    lerp(baseMid.0, targetMid.0, injection),
-                    lerp(baseMid.1, targetMid.1, injection),
-                    lerp(baseMid.2, targetMid.2, injection)
+                    lerp(baseB.0, targetB.0, injection),
+                    lerp(baseB.1, targetB.1, injection),
+                    lerp(baseB.2, targetB.2, injection)
                 )
             )
-            let low = color(
+            let c = color(
                 from: (
-                    lerp(baseLow.0, targetLow.0, injection),
-                    lerp(baseLow.1, targetLow.1, injection),
-                    lerp(baseLow.2, targetLow.2, injection)
+                    lerp(baseC.0, targetC.0, injection),
+                    lerp(baseC.1, targetC.1, injection),
+                    lerp(baseC.2, targetC.2, injection)
                 )
             )
-            return (top, mid, low)
+            return (a, b, c)
         }
 
         private static func lerp(_ a: Double, _ b: Double, _ t: Double) -> Double {

--- a/apps/mac/StetVisuals/MacDictationShaderTheme.swift
+++ b/apps/mac/StetVisuals/MacDictationShaderTheme.swift
@@ -36,24 +36,24 @@
                 let petal = (0.9058823529411765, 0.5568627450980392, 0.5725490196078431)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: sky,
-                        mid: leaf,
-                        low: petal
+                        a: sky,
+                        b: leaf,
+                        c: petal
                     ),
                     starting: .init(
-                        top: sky,
-                        mid: leaf,
-                        low: petal
+                        a: sky,
+                        b: leaf,
+                        c: petal
                     ),
                     speaking: .init(
-                        top: sky,
-                        mid: leaf,
-                        low: petal
+                        a: sky,
+                        b: leaf,
+                        c: petal
                     ),
                     processing: .init(
-                        top: sky,
-                        mid: leaf,
-                        low: petal
+                        a: sky,
+                        b: leaf,
+                        c: petal
                     )
                 )
             case .egg:
@@ -62,24 +62,24 @@
                 let shell = (0.792156862745098, 0.792156862745098, 0.7490196078431373)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: sky,
-                        mid: yolk,
-                        low: shell
+                        a: sky,
+                        b: yolk,
+                        c: shell
                     ),
                     starting: .init(
-                        top: sky,
-                        mid: yolk,
-                        low: shell
+                        a: sky,
+                        b: yolk,
+                        c: shell
                     ),
                     speaking: .init(
-                        top: shell,
-                        mid: sky,
-                        low: yolk
+                        a: shell,
+                        b: sky,
+                        c: yolk
                     ),
                     processing: .init(
-                        top: yolk,
-                        mid: shell,
-                        low: sky
+                        a: yolk,
+                        b: shell,
+                        c: sky
                     )
                 )
             case .harbor:
@@ -88,24 +88,24 @@
                 let clay = (0.6901960784313725, 0.3686274509803922, 0.3568627450980392)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: tide,
-                        mid: timber,
-                        low: clay
+                        a: tide,
+                        b: timber,
+                        c: clay
                     ),
                     starting: .init(
-                        top: tide,
-                        mid: timber,
-                        low: clay
+                        a: tide,
+                        b: timber,
+                        c: clay
                     ),
                     speaking: .init(
-                        top: clay,
-                        mid: tide,
-                        low: timber
+                        a: clay,
+                        b: tide,
+                        c: timber
                     ),
                     processing: .init(
-                        top: timber,
-                        mid: clay,
-                        low: tide
+                        a: timber,
+                        b: clay,
+                        c: tide
                     )
                 )
             case .cat:
@@ -114,24 +114,24 @@
                 let black = (0.09803921568627451, 0.09019607843137255, 0.09411764705882353)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: red,
-                        mid: paper,
-                        low: black
+                        a: red,
+                        b: paper,
+                        c: black
                     ),
                     starting: .init(
-                        top: red,
-                        mid: paper,
-                        low: black
+                        a: red,
+                        b: paper,
+                        c: black
                     ),
                     speaking: .init(
-                        top: paper,
-                        mid: red,
-                        low: black
+                        a: paper,
+                        b: red,
+                        c: black
                     ),
                     processing: .init(
-                        top: red,
-                        mid: black,
-                        low: paper
+                        a: red,
+                        b: black,
+                        c: paper
                     )
                 )
             case .beacon:
@@ -140,24 +140,24 @@
                 let gold = (0.9372549019607843, 0.6470588235294118, 0.058823529411764705)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: gold,
-                        mid: blue,
-                        low: teal
+                        a: gold,
+                        b: blue,
+                        c: teal
                     ),
                     starting: .init(
-                        top: blue,
-                        mid: gold,
-                        low: teal
+                        a: blue,
+                        b: gold,
+                        c: teal
                     ),
                     speaking: .init(
-                        top: teal,
-                        mid: gold,
-                        low: blue
+                        a: teal,
+                        b: gold,
+                        c: blue
                     ),
                     processing: .init(
-                        top: gold,
-                        mid: teal,
-                        low: blue
+                        a: gold,
+                        b: teal,
+                        c: blue
                     )
                 )
             case .autumn:
@@ -166,24 +166,24 @@
                 let teal = (0.09411764705882353, 0.4666666666666667, 0.5372549019607843)
                 return MacDictationShaderThemePalette(
                     idle: .init(
-                        top: yellow,
-                        mid: red,
-                        low: teal
+                        a: yellow,
+                        b: red,
+                        c: teal
                     ),
                     starting: .init(
-                        top: yellow,
-                        mid: red,
-                        low: teal
+                        a: yellow,
+                        b: red,
+                        c: teal
                     ),
                     speaking: .init(
-                        top: red,
-                        mid: yellow,
-                        low: teal
+                        a: red,
+                        b: yellow,
+                        c: teal
                     ),
                     processing: .init(
-                        top: yellow,
-                        mid: teal,
-                        low: red
+                        a: yellow,
+                        b: teal,
+                        c: red
                     )
                 )
             }
@@ -198,8 +198,8 @@
     }
 
     struct MacDictationShaderThemeColorSet {
-        let top: (Double, Double, Double)
-        let mid: (Double, Double, Double)
-        let low: (Double, Double, Double)
+        let a: (Double, Double, Double)
+        let b: (Double, Double, Double)
+        let c: (Double, Double, Double)
     }
 #endif

--- a/apps/mac/StetVisuals/MacDictationShaderWorkbenchView.swift
+++ b/apps/mac/StetVisuals/MacDictationShaderWorkbenchView.swift
@@ -59,9 +59,9 @@
         @State private var exportStatusText: String?
         @State private var useLiveMicrophone = false
         @State private var microphoneStatusText: String?
-        @State private var topHex = "#F2F4FA"
-        @State private var midHex = "#DCE0E8"
-        @State private var lowHex = "#B7BCC8"
+        @State private var hexA = "#F2F4FA"
+        @State private var hexB = "#DCE0E8"
+        @State private var hexC = "#B7BCC8"
         @StateObject private var microphoneMonitor = MacDictationShaderWorkbenchMicrophoneMonitor()
 
         public init() {}
@@ -197,9 +197,9 @@
 
                 GroupBox("Color codes") {
                     VStack(alignment: .leading, spacing: 10) {
-                        hexField(title: "Top", text: $topHex)
-                        hexField(title: "Mid", text: $midHex)
-                        hexField(title: "Low", text: $lowHex)
+                        hexField(title: "A", text: $hexA)
+                        hexField(title: "B", text: $hexB)
+                        hexField(title: "C", text: $hexC)
                     }
                     .padding(.top, 2)
                 }
@@ -262,7 +262,7 @@
         }
 
         private var summaryText: String {
-            "state=\(selectedState.rawValue.lowercased()) theme=\(selectedTheme.rawValue) source=\(useLiveMicrophone ? "mic" : "manual") top=\(topHex) mid=\(midHex) low=\(lowHex)"
+            "state=\(selectedState.rawValue.lowercased()) theme=\(selectedTheme.rawValue) source=\(useLiveMicrophone ? "mic" : "manual") a=\(hexA) b=\(hexB) c=\(hexC)"
         }
 
         private var resolvedSignals: MacDictationCapsuleVisualSignals {
@@ -340,18 +340,18 @@
                 target = palette.speaking
             }
 
-            topHex = Self.hexString(from: target.top)
-            midHex = Self.hexString(from: target.mid)
-            lowHex = Self.hexString(from: target.low)
+            hexA = Self.hexString(from: target.a)
+            hexB = Self.hexString(from: target.b)
+            hexC = Self.hexString(from: target.c)
         }
 
         private func manualColors(elapsed _: Double, detail _: Double, signals _: MacDictationCapsuleVisualSignals) -> (
-            top: Color, mid: Color, low: Color
+            a: Color, b: Color, c: Color
         ) {
             (
-                top: Self.color(fromHex: topHex) ?? .white,
-                mid: Self.color(fromHex: midHex) ?? .white,
-                low: Self.color(fromHex: lowHex) ?? .white
+                a: Self.color(fromHex: hexA) ?? .white,
+                b: Self.color(fromHex: hexB) ?? .white,
+                c: Self.color(fromHex: hexC) ?? .white
             )
         }
 
@@ -386,7 +386,7 @@
             elapsed: Double,
             signals: MacDictationCapsuleVisualSignals,
             detail: Double,
-            colors: (top: Color, mid: Color, low: Color)
+            colors: (a: Color, b: Color, c: Color)
         ) -> some View {
             Rectangle()
                 .fill(
@@ -411,9 +411,9 @@
                                 pulse: signals.pulse,
                                 articulation: signals.articulation,
                                 detail: detail,
-                                top: colors.top,
-                                mid: colors.mid,
-                                low: colors.low
+                                a: colors.a,
+                                b: colors.b,
+                                c: colors.c
                             )
                         )
                         .frame(width: size.width, height: size.height)

--- a/apps/mac/StetVisuals/StetVisualsShaderLibrary.swift
+++ b/apps/mac/StetVisuals/StetVisualsShaderLibrary.swift
@@ -14,9 +14,9 @@
             pulse: Double,
             articulation: Double,
             detail: Double,
-            top: Color,
-            mid: Color,
-            low: Color
+            a: Color,
+            b: Color,
+            c: Color
         ) -> Shader {
             ShaderLibrary.bundle(shaderBundle).cloudOrbGlassWide(
                 .float2(size.width, size.height),
@@ -26,9 +26,9 @@
                 .float(pulse),
                 .float(articulation),
                 .float(detail),
-                .color(top),
-                .color(mid),
-                .color(low)
+                .color(a),
+                .color(b),
+                .color(c)
             )
         }
 

--- a/scripts/release-macos-github.sh
+++ b/scripts/release-macos-github.sh
@@ -41,6 +41,9 @@ load_env_file "$ENV_FILE"
 : "${GITHUB_TAG:?GITHUB_TAG is required, for example v1.0.0.}"
 
 DEVELOPER_ID_APPLICATION="${DEVELOPER_ID_APPLICATION:-Developer ID Application}"
+ARCHIVE_CODE_SIGN_STYLE="${ARCHIVE_CODE_SIGN_STYLE:-Automatic}"
+ARCHIVE_CODE_SIGN_IDENTITY="${ARCHIVE_CODE_SIGN_IDENTITY:-$DEVELOPER_ID_APPLICATION}"
+ARCHIVE_PROVISIONING_PROFILE_SPECIFIER="${ARCHIVE_PROVISIONING_PROFILE_SPECIFIER:-}"
 GENERATE_SPARKLE_APPCAST="${GENERATE_SPARKLE_APPCAST:-1}"
 SPARKLE_KEYCHAIN_ACCOUNT="${SPARKLE_KEYCHAIN_ACCOUNT:-ed25519}"
 SPARKLE_FEED_BASE_URL="${SPARKLE_FEED_BASE_URL:-https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_TAG}}"
@@ -58,10 +61,36 @@ DMG_OUTPUT_DIR="$WORK_DIR/dmg"
 NOTARY_SUBMISSION_PLIST="$WORK_DIR/notary-submission.plist"
 NOTARY_LOG_JSON="$WORK_DIR/notary-log.json"
 SPARKLE_DIR="$WORK_DIR/sparkle"
-SPARKLE_GENERATE_APPCAST="$ROOT_DIR/.build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
 APP_ENTITLEMENTS="$WORK_DIR/${APP_NAME}.entitlements.plist"
 NPX_BIN="${NPX_BIN:-$(command -v npx || true)}"
 NPM_CACHE_DIR="${NPM_CACHE_DIR:-$WORK_DIR/.npm-cache}"
+
+find_sparkle_generate_appcast() {
+  local candidates=()
+
+  if [[ -n "${SPARKLE_GENERATE_APPCAST:-}" ]]; then
+    candidates+=("$SPARKLE_GENERATE_APPCAST")
+  fi
+
+  candidates+=(
+    "$ROOT_DIR/.build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+    "$ROOT_DIR/apps/mac/build/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+    "$ROOT_DIR/apps/mac/.derivedData/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast"
+  )
+
+  candidates+=("$HOME"/Library/Developer/Xcode/DerivedData/*/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast(N))
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+SPARKLE_GENERATE_APPCAST="$(find_sparkle_generate_appcast || true)"
 
 mkdir -p "$WORK_DIR"
 rm -rf "$ARCHIVE_PATH" "$APP_PATH" "$DMG_OUTPUT_DIR" "$SPARKLE_DIR" "$APP_ENTITLEMENTS" "$NPM_CACHE_DIR"
@@ -77,7 +106,7 @@ if ! security find-identity -v -p codesigning | grep -Fq "$DEVELOPER_ID_APPLICAT
   exit 1
 fi
 
-echo "Archiving $APP_NAME with Developer ID signing..."
+echo "Archiving $APP_NAME with $ARCHIVE_CODE_SIGN_STYLE signing..."
 XCODEBUILD_COMMAND=(
   xcodebuild
   -project "$PROJECT_PATH" \
@@ -86,11 +115,22 @@ XCODEBUILD_COMMAND=(
   -destination 'generic/platform=macOS' \
   -archivePath "$ARCHIVE_PATH" \
   archive \
-  CODE_SIGN_STYLE=Manual \
-  DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-  CODE_SIGN_IDENTITY="$DEVELOPER_ID_APPLICATION" \
-  OTHER_CODE_SIGN_FLAGS="--timestamp"
+  CODE_SIGN_STYLE="$ARCHIVE_CODE_SIGN_STYLE" \
+  DEVELOPMENT_TEAM="$APPLE_TEAM_ID"
 )
+
+if [[ "$ARCHIVE_CODE_SIGN_STYLE" == "Manual" ]]; then
+  XCODEBUILD_COMMAND+=(
+    CODE_SIGN_IDENTITY="$ARCHIVE_CODE_SIGN_IDENTITY"
+    OTHER_CODE_SIGN_FLAGS="--timestamp"
+  )
+fi
+
+if [[ -n "$ARCHIVE_PROVISIONING_PROFILE_SPECIFIER" ]]; then
+  XCODEBUILD_COMMAND+=(
+    PROVISIONING_PROFILE_SPECIFIER="$ARCHIVE_PROVISIONING_PROFILE_SPECIFIER"
+  )
+fi
 
 if [[ "$GENERATE_SPARKLE_APPCAST" == "1" ]]; then
   XCODEBUILD_COMMAND+=(
@@ -117,17 +157,18 @@ resign_component() {
     --sign "$DEVELOPER_ID_APPLICATION" \
     --timestamp \
     --options runtime \
-    --preserve-metadata=identifier,entitlements,requirements,flags \
+    --preserve-metadata=identifier,entitlements,flags \
     "$target_path"
 }
 
-SPARKLE_ROOT="$APP_PATH/Contents/Frameworks/Sparkle.framework/Versions/Current"
+SPARKLE_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sparkle.framework"
+SPARKLE_ROOT="$SPARKLE_FRAMEWORK/Versions/Current"
 resign_component "$SPARKLE_ROOT/Autoupdate"
 resign_component "$SPARKLE_ROOT/XPCServices/Downloader.xpc"
 resign_component "$SPARKLE_ROOT/XPCServices/Installer.xpc"
 resign_component "$SPARKLE_ROOT/Updater.app"
-resign_component "$SPARKLE_ROOT"
-resign_component "$APP_PATH/Contents/Frameworks/StetVisuals.framework/Versions/Current"
+resign_component "$SPARKLE_FRAMEWORK"
+resign_component "$APP_PATH/Contents/Frameworks/StetVisuals.framework"
 
 codesign \
   --force \
@@ -202,7 +243,7 @@ fi
 
 if [[ "$GENERATE_SPARKLE_APPCAST" == "1" ]]; then
   if [[ ! -x "$SPARKLE_GENERATE_APPCAST" ]]; then
-    echo "Missing Sparkle tool: $SPARKLE_GENERATE_APPCAST"
+    echo "Missing Sparkle tool. Set SPARKLE_GENERATE_APPCAST or install Sparkle artifacts in a standard location."
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- rework the capsule shader from layered top/mid/low mixing toward three-color ownership blobs
- switch shader theme and styling APIs from top/mid/low to a/b/c and make palette transitions state-time driven
- improve quiet speech and low-tone voice responsiveness in the dictation panel signal mapper

## Verification
- npm run mac:ci:build

## Commits
- c97361c Refine capsule shader color ownership
- b2fa816 Improve quiet speech visual response