### PR TITLE
Restore macOS text output handling semantics

### DIFF
--- a/apps/mac/.kiro/specs/text-output-handling/.config.kiro
+++ b/apps/mac/.kiro/specs/text-output-handling/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "ca275a67-5e9c-4675-8b72-dd79de721d2c", "workflowType": "requirements-first", "specType": "feature"}

--- a/apps/mac/.kiro/specs/text-output-handling/design.md
+++ b/apps/mac/.kiro/specs/text-output-handling/design.md
@@ -1,0 +1,739 @@
+# 设计文档：文本输出处理
+
+## 概述
+
+本文档描述了 Stet 在 macOS 上完成语音识别后的文本输出处理功能的技术设计。
+
+当用户完成语音输入并获得识别结果后，系统需要将识别出的文本传递给用户。该功能提供两种输出方式：
+
+1. **剪切板输出**：将文本拷贝到系统剪切板，用户可以手动粘贴到任何应用
+2. **文本注入输出**：将文本直接注入到用户当前活动的输入框
+
+系统基于当前配置和当前焦点采用“乐观注入 + 结果验证 + 自动降级”的方式输出文本。开启自动注入时，系统会先尝试通过模拟 `Cmd+V` 将文本发送到当前焦点；如果验证失败，则自动降级到剪切板输出，确保文本不丢失。
+
+该功能是 Stet 语音输入工作流的最后一个关键环节，必须可靠执行。
+
+---
+
+## 设计目标
+
+- 提供可靠的文本输出机制，确保识别结果不丢失
+- 基于当前配置和当前焦点，以最小判断成本选择最合适的输出方式
+- 在文本注入时保护用户原有的剪切板内容（best effort）
+- 提供清晰的降级策略和错误处理
+- 保持识别文本的原始格式，不进行额外修改
+- 与现有的权限管理系统集成
+
+---
+
+## 架构
+
+### 系统架构图
+
+```mermaid
+graph TB
+    User["用户完成语音输入"] --> Coordinator["MacDictationCaptureCoordinator"]
+    Coordinator --> Decision{"shouldAutoPaste?"}
+
+    Decision -->|true| Protect["PasteboardRestoreCoordinator<br/>保存剪切板"]
+    Decision -->|false| Clipboard["ClipboardService<br/>直接拷贝或保持待处理"]
+
+    Protect --> Copy1["ClipboardService<br/>临时拷贝文本"]
+    Copy1 --> Paste["TextInjectionService<br/>模拟 Cmd+V"]
+
+    Paste --> Verify{"验证焦点元素发生变化?"}
+    Verify -->|成功| Restore["PasteboardRestoreCoordinator<br/>延迟恢复剪切板"]
+    Verify -->|失败| Fallback["恢复原剪切板并降级为永久拷贝"]
+
+    Fallback --> Copy2["ClipboardService<br/>永久拷贝文本"]
+
+    Restore --> Complete["输出完成"]
+    Clipboard --> Complete
+    Copy2 --> Complete
+```
+
+### 数据流图
+
+```mermaid
+sequenceDiagram
+    participant User as 用户
+    participant Coord as MacDictationCaptureCoordinator
+    participant Inject as TextInjectionService
+    participant Clip as ClipboardService
+    participant Restore as PasteboardRestoreCoordinator
+    participant System as 系统剪切板
+    
+    User->>Coord: 语音识别完成
+    alt shouldAutoPaste = true
+        Coord->>Restore: 准备临时覆盖
+        Restore->>System: 保存当前剪切板内容
+        Coord->>Clip: 拷贝识别文本（transient=true）
+        Clip->>System: 写入剪切板
+        Coord->>Inject: 模拟 Cmd+V
+        Inject->>System: 发送按键事件
+        Inject->>Inject: 读取焦点元素快照并验证变化
+        
+        alt 注入成功
+            Coord->>Restore: 调度恢复任务
+            Note over Restore: 延迟 800ms
+            Restore->>System: 恢复原剪切板内容
+        else 注入失败
+            Coord->>Restore: 立即恢复剪切板
+            Coord->>Clip: 降级：拷贝到剪切板（transient=false）
+        end
+    else shouldAutoPaste = false
+        alt shouldCopyToClipboard = true
+            Coord->>Clip: 拷贝识别文本（transient=false）
+            Clip->>System: 写入剪切板
+        else 不自动输出
+            Coord->>Coord: 返回 clipboardPending，等待用户后续操作
+        end
+    end
+```
+
+---
+
+## 组件和接口
+
+### 文件结构
+
+```text
+apps/mac/Stet/
+├── App/Workflows/
+│   └── MacDictationCaptureCoordinator.swift
+├── Core/Clipboard/
+│   ├── ClipboardService.swift
+│   └── PasteboardRestoreCoordinator.swift
+└── Core/TextInput/
+    └── TextInjectionService.swift
+```
+
+### 1. MacDictationCaptureCoordinator
+
+**职责：**
+- 协调整个文本输出流程
+- 根据捕获设置决定输出策略
+- 处理文本注入失败时的降级逻辑
+- 管理剪切板保护的生命周期
+
+**关键接口：**
+
+```swift
+@MainActor
+final class MacDictationCaptureCoordinator {
+    enum CompletionOutcome: Equatable {
+        case completed           // 输出完成
+        case clipboardPending    // 等待用户手动粘贴
+    }
+    
+    struct CaptureSettings {
+        let shouldCopyToClipboard: Bool      // 是否拷贝到剪切板
+        let shouldAutoPaste: Bool            // 是否自动注入
+        let shouldRevealPanelOnCapture: Bool // 失败时是否显示面板
+    }
+
+    init(
+        clipboardService: any ClipboardService,
+        textInjectionService: any TextInjectionService,
+        pasteboard: NSPasteboard = .general,
+        pasteboardRestoreCoordinator: PasteboardRestoreCoordinator? = nil
+    )
+    
+    func handleCompletedCapture(
+        text: String,
+        targetApplication: NSRunningApplication?,
+        settings: CaptureSettings,
+        showPanel: @escaping @MainActor () -> Void
+    ) async -> CompletionOutcome
+    
+    func copyToClipboard(_ text: String)
+}
+```
+
+**实现要点：**
+
+1. **输出模式决策**：
+   - `shouldAutoPaste = true` → 优先走文本注入流程
+   - `shouldAutoPaste = false` 且 `shouldCopyToClipboard = true` → 剪切板输出
+   - `shouldAutoPaste = false` 且 `shouldCopyToClipboard = false` → 返回 `clipboardPending`
+
+2. **剪切板保护策略**：
+   - 文本注入且不拷贝到剪切板：启用保护（transient=true）
+   - 其他情况：不启用保护（transient=false）
+
+3. **降级处理**：
+   - 文本注入失败 → 立即恢复剪切板 → 自动降级为永久剪切板拷贝
+
+### 2. ClipboardService
+
+**职责：**
+- 提供剪切板写入的抽象接口
+- 支持 transient 标记（用于剪切板保护）
+- 标记剪切板内容的来源应用
+
+**关键接口：**
+
+```swift
+@MainActor
+protocol ClipboardService {
+    func copy(_ text: String, transient: Bool)
+}
+
+@MainActor
+final class SystemClipboardService: ClipboardService {
+    init(pasteboard: NSPasteboard = .general)
+    func copy(_ text: String, transient: Bool)
+}
+```
+
+**实现要点：**
+
+1. **Transient 标记**：
+   - 使用自定义 pasteboard type `org.nspasteboard.TransientType`
+   - 标记临时内容，配合 PasteboardRestoreCoordinator 使用
+
+2. **来源标记**：
+   - 使用自定义 pasteboard type `org.nspasteboard.source`
+   - 记录 bundle identifier，用于调试和追踪
+
+### 3. TextInjectionService
+
+**职责：**
+- 执行文本注入（通过模拟 Cmd+V）
+- 基于当前焦点验证注入是否成功
+- 管理辅助功能权限
+
+**关键接口：**
+
+```swift
+@MainActor
+protocol TextInjectionService {
+    var accessState: TextInjectionAccessState { get }
+    var isAvailable: Bool { get }
+    func requestAccess()
+    func requestAccessIfNeeded()
+    func openAccessibilitySettings()
+    func pasteClipboard(into application: NSRunningApplication?) async -> Bool
+    func selectedText() -> String?
+    func replaceSelectedText(
+        _ text: String,
+        into application: NSRunningApplication?,
+        keepResultInClipboard: Bool
+    ) async -> Bool
+}
+```
+
+**实现要点：**
+
+1. **活跃输入框检测**：
+   - 不单独暴露“是否存在活跃输入框”的前置判断接口
+   - 在注入前后使用 AXUIElement API 读取当前焦点元素快照
+   - 通过比较快照变化验证注入是否成功
+
+2. **文本注入实现**：
+   - 激活目标应用（如果指定）
+   - 模拟 Cmd+V 按键事件
+   - 通过比较注入前后的焦点元素状态验证成功
+
+3. **权限管理**：
+   - 检查 Accessibility 权限（`AXIsProcessTrusted()`）
+   - 检查 PostEvent 权限（`CGPreflightPostEventAccess()`）
+   - 至少需要一个权限才能尝试发出注入事件；可靠验证通常依赖 Accessibility 访问
+
+### 4. PasteboardRestoreCoordinator
+
+**职责：**
+- 在文本注入前保存剪切板内容
+- 在文本注入成功后延迟恢复剪切板
+- 在文本注入失败时立即恢复剪切板
+- 管理恢复任务的生命周期
+
+**关键接口：**
+
+```swift
+@MainActor
+final class PasteboardRestoreCoordinator {
+    init(restoreDelay: Duration = .milliseconds(800))
+    func prepareForTemporaryOverride(on pasteboard: NSPasteboard)
+    func scheduleRestoreIfNeeded(on pasteboard: NSPasteboard)
+    func restoreImmediatelyIfNeeded(on pasteboard: NSPasteboard)
+    func discardPendingRestore()
+}
+
+struct PasteboardSnapshot {
+    static func capture(from pasteboard: NSPasteboard) -> Self
+    func matches(_ pasteboard: NSPasteboard) -> Bool
+    func restore(to pasteboard: NSPasteboard)
+}
+```
+
+**实现要点：**
+
+1. **保存策略**：
+   - 捕获所有 pasteboard items 和所有 types
+   - 保存为 `[NSPasteboard.PasteboardType: Data]` 字典
+
+2. **恢复策略**：
+   - 延迟 800ms 后恢复（给目标应用足够时间处理粘贴）
+   - 恢复前检查剪切板是否被用户修改
+   - 如果已修改，取消恢复（避免覆盖用户新内容）
+
+3. **Best Effort 语义**：
+   - 不保证原子性
+   - 不保证所有数据类型都能完美恢复
+   - 失败不影响文本注入的执行
+
+---
+
+## 数据模型
+
+### TextInjectionAccessState
+
+```swift
+struct TextInjectionAccessState: Equatable {
+    let hasAccessibilityAccess: Bool  // Accessibility 权限
+    let hasPostEventAccess: Bool      // PostEvent 权限
+    
+    var canSimulateInput: Bool {
+        hasAccessibilityAccess || hasPostEventAccess
+    }
+}
+```
+
+### CaptureSettings
+
+```swift
+struct CaptureSettings {
+    let shouldCopyToClipboard: Bool      // 用户设置：是否拷贝到剪切板
+    let shouldAutoPaste: Bool            // 用户设置：是否自动注入
+    let shouldRevealPanelOnCapture: Bool // 用户设置：失败时是否显示面板
+}
+```
+
+### PasteboardSnapshot
+
+```swift
+struct PasteboardSnapshot {
+    private let items: [[NSPasteboard.PasteboardType: Data]]
+    
+    // 捕获当前剪切板状态
+    static func capture(from pasteboard: NSPasteboard) -> Self
+    
+    // 检查剪切板是否与快照匹配
+    func matches(_ pasteboard: NSPasteboard) -> Bool
+    
+    // 恢复剪切板到快照状态
+    func restore(to pasteboard: NSPasteboard)
+}
+```
+
+---
+
+## 正确性属性
+
+*属性是一个特征或行为，应该在系统的所有有效执行中保持为真——本质上是关于系统应该做什么的形式化陈述。属性是人类可读规范和机器可验证正确性保证之间的桥梁。*
+
+### 属性 1：输出模式选择一致性
+
+*对于任何*识别文本和捕获设置，当 `shouldAutoPaste = true` 时系统应该优先尝试文本注入；当 `shouldAutoPaste = false` 且 `shouldCopyToClipboard = true` 时系统应该执行剪切板输出；当两者都为 `false` 时系统应该返回待处理状态而不执行系统写入。
+
+**验证需求：1.2, 1.3**
+
+### 属性 2：每次输出前重新检测
+
+*对于任何*连续的文本注入操作序列，每次注入尝试都应该重新获取当前焦点元素快照，而不是复用上一次的验证上下文。
+
+**验证需求：1.4**
+
+### 属性 3：剪切板输出的文本完整性
+
+*对于任何*识别文本，当使用剪切板输出时，拷贝到剪切板的内容应该与原始识别文本完全相同（往返属性）。
+
+**验证需求：2.1, 2.3, 2.4, 7.1, 7.2, 7.3, 7.4**
+
+### 属性 4：剪切板内容持久性
+
+*对于任何*成功的永久剪切板输出操作，Stet 不应该主动清空或再次覆盖该剪切板内容，除非后续显式执行新的剪切板写入。
+
+**验证需求：2.2**
+
+### 属性 5：文本注入前权限验证
+
+*对于任何*文本注入操作，系统应该在执行注入前验证文本注入权限是否可用。
+
+**验证需求：3.2**
+
+### 属性 6：文本注入的文本完整性
+
+*对于任何*识别文本，当使用文本注入输出时，注入到输入框的内容应该与原始识别文本完全相同（往返属性）。
+
+**验证需求：3.1, 3.3, 3.4, 7.1, 7.2, 7.3, 7.4**
+
+### 属性 7：注入后光标位置
+
+*对于任何*成功的文本注入操作，注入完成后输入框的插入点应该位于已注入文本之后。
+
+**验证需求：3.5**
+
+### 属性 8：剪切板保护往返
+
+*对于任何*文本注入操作（transient=true），如果注入成功且用户未修改剪切板，则注入前后的剪切板内容应该保持一致（往返属性）。
+
+**验证需求：4.1, 4.2, 4.3**
+
+### 属性 9：剪切板恢复失败不影响注入
+
+*对于任何*文本注入操作，即使剪切板恢复失败，文本注入本身也应该成功完成。
+
+**验证需求：4.4**
+
+### 属性 10：注入失败自动降级
+
+*对于任何*文本注入失败的情况，系统应该在恢复临时剪切板后自动执行永久剪切板拷贝。
+
+**验证需求：5.5**
+
+### 属性 11：空文本不执行输出
+
+*对于任何*空字符串、仅包含空白字符或 null 的识别文本，系统不应该执行任何输出操作。
+
+**验证需求：6.1, 6.3**
+
+---
+
+## 错误处理
+
+### 1. 剪切板操作失败
+
+**场景**：系统剪切板被其他应用占用或系统资源不足
+
+**处理策略**：
+- 当前实现将剪切板写入视为同步 best effort 操作
+- `SystemClipboardService` 本身不负责用户提示和重试 UI
+- 如果未来需要显式失败处理，应由更高层协调器补充错误上报
+
+**实现位置**：`SystemClipboardService.copy(_:transient:)`
+
+### 2. 文本注入权限缺失
+
+**场景**：用户未授予 Accessibility 或 PostEvent 权限
+
+**处理策略**：
+- 检查 `TextInjectionService.isAvailable`
+- 调用 `requestAccessIfNeeded()` 提示用户授权
+- 自动降级到剪切板输出
+- 如果 `shouldRevealPanelOnCapture = true`，显示面板提示用户
+
+**实现位置**：`MacDictationCaptureCoordinator.handleCompletedCapture(...)`
+
+### 3. 文本注入失败（无法找到输入框）
+
+**场景**：注入时输入框焦点丢失或目标应用不响应
+
+**处理策略**：
+- 通过比较注入前后的输入框快照检测失败
+- 立即恢复剪切板（如果启用了保护）
+- 自动降级到永久剪切板输出
+- 如果 `shouldRevealPanelOnCapture = true`，显示面板
+
+**实现位置**：`TextInjectionService.pasteClipboard(into:)` + `MacDictationCaptureCoordinator.handleCompletedCapture(...)`
+
+### 4. 剪切板恢复失败
+
+**场景**：恢复时剪切板状态异常或数据损坏
+
+**处理策略**：
+- 记录错误日志
+- 不影响文本注入的执行结果
+- 不向用户显示错误（best effort 语义）
+
+**实现位置**：`PasteboardRestoreCoordinator.scheduleRestoreIfNeeded(on:)`
+
+### 5. 空文本输入
+
+**场景**：识别结果为空字符串、空白字符或 null
+
+**处理策略**：
+- 不执行任何输出操作
+- 返回空转录错误或跳过输出
+- 记录日志信息
+
+**实现位置**：`MacDictationWorkflowController.handleCompletedResult(...)` + `MacDictationCaptureCoordinator.handleCompletedCapture(...)`
+
+### 6. 目标应用无响应
+
+**场景**：文本注入时目标应用崩溃或无响应
+
+**处理策略**：
+- 设置合理的超时时间（180ms 验证延迟）
+- 超时后判定为注入失败
+- 执行标准的降级流程
+
+**实现位置**：`TextInjectionService.pasteClipboard(into:)`
+
+---
+
+## 测试策略
+
+### 单元测试和基于属性的测试
+
+本功能采用双重测试方法：
+
+- **单元测试**：验证特定示例、边缘情况和错误条件
+- **基于属性的测试**：通过随机化验证所有输入的通用属性
+
+两者是互补的，共同提供全面的覆盖：
+- 单元测试捕获具体的 bug
+- 基于属性的测试验证一般正确性
+
+### 单元测试重点
+
+1. **输出模式选择**：
+   - `shouldAutoPaste = true` 时优先尝试文本注入
+   - 自动注入失败时降级到永久剪切板拷贝
+   - `shouldAutoPaste = false` 时根据 `shouldCopyToClipboard` 决定直接拷贝还是进入待处理状态
+
+2. **剪切板保护**：
+   - transient=true 时启用保护
+   - transient=false 时不启用保护
+   - 注入成功后延迟恢复
+   - 注入失败后立即恢复
+
+3. **错误处理**：
+   - 空文本不执行输出
+   - 注入失败自动降级
+   - 权限缺失时提示用户
+
+4. **边缘情况**：
+   - 空字符串、空白字符、null
+   - 多行文本
+   - 特殊字符和 Unicode
+   - 目标应用无响应
+
+### 基于属性的测试
+
+**测试库**：Swift Testing 框架 + 自定义属性测试工具
+
+**配置**：每个属性测试至少运行 100 次迭代
+
+**标记格式**：`// Feature: text-output-handling, Property {number}: {property_text}`
+
+**属性测试用例**：
+
+1. **属性 1：输出模式选择一致性**
+   ```swift
+   // Feature: text-output-handling, Property 1: 输出模式选择一致性
+   // 生成随机的捕获设置和识别文本
+   // 验证协调器按照 capture settings 选择注入、拷贝或待处理路径
+   ```
+
+2. **属性 3：剪切板输出的文本完整性**
+   ```swift
+   // Feature: text-output-handling, Property 3: 剪切板输出的文本完整性
+   // 生成随机的识别文本（包括多行、特殊字符、Unicode）
+   // 拷贝到剪切板后读取
+   // 验证内容完全相同
+   ```
+
+3. **属性 6：文本注入的文本完整性**
+   ```swift
+   // Feature: text-output-handling, Property 6: 文本注入的文本完整性
+   // 生成随机的识别文本
+   // 注入到测试输入框
+   // 验证输入框内容与原始文本相同
+   ```
+
+4. **属性 8：剪切板保护往返**
+   ```swift
+   // Feature: text-output-handling, Property 8: 剪切板保护往返
+   // 生成随机的原始剪切板内容
+   // 执行文本注入（transient=true）
+   // 等待恢复完成
+   // 验证剪切板内容恢复到原始状态
+   ```
+
+5. **属性 10：注入失败自动降级**
+   ```swift
+   // Feature: text-output-handling, Property 10: 注入失败自动降级
+   // 生成随机的识别文本
+   // 模拟注入失败（权限缺失、验证失败、目标应用无响应等）
+   // 验证临时剪切板已恢复，且文本已被永久拷贝到剪切板
+   ```
+
+6. **属性 11：空文本不执行输出**
+   ```swift
+   // Feature: text-output-handling, Property 11: 空文本不执行输出
+   // 生成随机的空白文本（空字符串、空格、制表符、换行符组合）
+   // 执行输出操作
+   // 验证剪切板和输入框都未被修改
+   ```
+
+### 集成测试
+
+1. **完整输出流程**：
+   - 模拟语音识别完成
+   - 验证输出模式选择
+   - 验证文本正确输出
+
+2. **降级流程**：
+   - 模拟注入失败
+   - 验证自动降级到剪切板
+   - 验证剪切板内容正确
+
+3. **权限集成**：
+   - 模拟权限缺失
+   - 验证权限提示
+   - 验证降级行为
+
+---
+
+## 设计决策
+
+### 为什么使用模拟 Cmd+V 而不是直接 API？
+
+macOS 没有提供通用的文本注入 API。使用模拟按键的方式：
+- 兼容性最好，适用于几乎所有应用
+- 不需要针对不同应用做特殊处理
+- 用户体验与手动粘贴一致
+
+### 为什么需要剪切板保护？
+
+文本注入依赖剪切板作为中转，会临时覆盖用户的剪切板内容。剪切板保护确保：
+- 用户的工作流不被打断
+- 用户可以继续使用之前复制的内容
+- 提供更好的用户体验
+
+### 为什么是 best effort 而不是保证？
+
+剪切板是系统级共享资源，无法保证原子性：
+- 其他应用可能随时修改剪切板
+- 某些数据类型可能无法完美序列化
+- 系统资源限制可能导致恢复失败
+
+因此采用 best effort 策略，在大多数情况下工作良好，失败时不影响核心功能。
+
+### 为什么延迟 800ms 恢复剪切板？
+
+给目标应用足够时间处理粘贴事件：
+- 某些应用处理粘贴需要时间
+- 过早恢复可能导致应用读取到错误的剪切板内容
+- 800ms 是经过测试的平衡值
+
+### 为什么注入失败时自动降级？
+
+确保文本不丢失：
+- 注入失败的原因多样（权限、焦点丢失、应用无响应等）
+- 自动降级提供可靠的后备方案
+- 用户可以手动粘贴，不会丢失识别结果
+
+### 为什么使用 transient 标记？
+
+区分临时内容和永久内容：
+- transient=true：临时中转，应该被恢复
+- transient=false：用户明确要求拷贝，不应该被恢复
+- 配合 PasteboardRestoreCoordinator 实现智能恢复
+
+---
+
+## 实现顺序
+
+当前已有部分实现，本设计文档定义目标实现和后续对齐方向；已落地部分应尽量向本文档收敛，必要时允许小范围重构。
+
+如果需要修改或扩展功能，建议按以下顺序：
+
+1. 修改 `ClipboardService` 接口和实现
+2. 修改 `TextInjectionService` 的检测和注入逻辑
+3. 修改 `PasteboardRestoreCoordinator` 的保护策略
+4. 修改 `MacDictationCaptureCoordinator` 的协调逻辑
+5. 添加或更新单元测试
+6. 添加或更新基于属性的测试
+7. 进行集成测试验证
+
+---
+
+## 与其他模块的集成
+
+### 权限管理模块
+
+- 依赖 `MacPermissionsCoordinating` 检查权限状态
+- 调用 `requestAutoPasteAccess()` 请求权限
+- 权限缺失时自动降级，不阻塞输出
+
+### 语音识别模块
+
+- 接收识别完成的文本结果
+- 不关心识别过程的细节
+- 假设传入的文本已经过验证
+
+### UI 模块
+
+- 在输出失败时可能显示面板
+- 通过 `showPanel` 回调通知 UI
+- UI 决策由 `CaptureSettings.shouldRevealPanelOnCapture` 控制
+
+---
+
+## 性能考虑
+
+### 剪切板操作
+
+- 剪切板读写是同步操作，通常很快（< 10ms）
+- 大量数据可能导致延迟，但语音识别文本通常不大
+- 不需要特殊的性能优化
+
+### 文本注入
+
+- 激活目标应用：180ms 延迟
+- 模拟按键：< 1ms
+- 验证延迟：60ms + 180ms
+- 总延迟：约 420ms，用户可接受
+
+### 剪切板恢复
+
+- 延迟 800ms 执行，不阻塞主流程
+- 使用 Task 异步执行，不影响性能
+- 失败时静默处理，不影响用户体验
+
+---
+
+## 安全考虑
+
+### 剪切板内容
+
+- 剪切板内容可能包含敏感信息
+- 不记录剪切板内容到日志
+- 不上传剪切板内容到服务器
+
+### 权限
+
+- 需要 Accessibility 或 PostEvent 权限
+- 权限请求由权限管理模块统一处理
+- 权限缺失时提供清晰的提示
+
+### 目标应用
+
+- 不验证目标应用的身份
+- 信任用户当前焦点的应用
+- 不限制可以注入的应用类型
+
+---
+
+## 未来扩展
+
+以下功能可能在未来版本中考虑：
+
+1. **富文本支持**：支持格式化文本的输出
+2. **输出历史**：记录最近的输出内容
+3. **自定义快捷键**：允许用户自定义注入快捷键
+4. **应用白名单/黑名单**：控制哪些应用可以使用文本注入
+5. **输出模板**：支持文本输出前的格式化模板
+6. **多剪切板支持**：与第三方剪切板管理工具集成
+
+---
+
+## 参考资料
+
+- [macOS Accessibility API](https://developer.apple.com/documentation/applicationservices/axuielement)
+- [NSPasteboard Documentation](https://developer.apple.com/documentation/appkit/nspasteboard)
+- [CGEvent Documentation](https://developer.apple.com/documentation/coregraphics/cgevent)
+- Stet 权限管理模块设计文档

--- a/apps/mac/.kiro/specs/text-output-handling/requirements.md
+++ b/apps/mac/.kiro/specs/text-output-handling/requirements.md
@@ -1,0 +1,189 @@
+# 需求文档：文本输出处理
+
+## 概述
+
+本文档定义了 Stet 在 macOS 上完成语音识别后的文本输出处理功能需求。
+
+当用户完成语音输入并获得识别结果后，Stet 需要将识别出的文本传递给用户。该功能提供两种输出方式：
+
+1. 将文本拷贝到系统剪切板
+2. 将文本直接注入到用户当前活动的输入框
+
+系统根据输出时的当前焦点自动选择合适的输出方式。这是 Stet 语音输入工作流的最后一个关键环节。
+
+---
+
+## 术语表
+
+- **文本输出处理系统**（Text_Output_Handler）：负责将识别文本传递给用户的系统组件
+- **剪切板输出**（Clipboard_Output）：将识别文本拷贝到 macOS 系统剪切板的输出方式
+- **文本注入输出**（Text_Injection_Output）：将识别文本直接插入到用户当前输入框的输出方式
+- **识别文本**（Recognized_Text）：语音识别服务返回的最终文本结果
+- **活跃输入框**（Active_Input_Field）：用户当前正在使用的文本输入区域，通常表现为光标闪烁
+
+---
+
+## 核心原则
+
+- 文本输出是语音输入工作流的最后一步，必须可靠执行
+- 系统应该基于输出时的当前焦点自动选择输出方式，无需用户干预
+- 有活跃输入框时优先使用文本注入，提供最流畅的输入体验
+- 无活跃输入框时使用剪切板输出，保证文本不丢失
+- 文本注入失败时应该自动降级到剪切板输出，保证文本不丢失
+- 输出操作应该静默执行，成功时不打断用户
+- 输出失败时应该提供清晰的错误信息和恢复路径
+
+---
+
+## 假设与依赖
+
+本模块的设计基于以下假设：
+
+1. **上游超时控制**：语音识别服务或管道编排层已经处理了请求超时、取消和重试逻辑。当识别结果传递到文本输出处理模块时，该结果是有效的且应该被处理的。
+
+2. **识别结果有效性**：传递给文本输出处理模块的识别文本已经过验证，是最终确认的结果。
+
+3. **输出路由决策**：上游管道编排层已经完成了输出路由决策。如果用户触发了特殊热键（如 Agent 模式热键），识别结果会被路由到其他处理流程（如转发给 Agent），不会进入文本输出处理模块。本模块只处理需要输出给用户的识别结果。
+
+4. **权限管理**：辅助功能权限（用于文本注入和输入框检测）的申请和管理由权限管理模块负责，本模块只负责检查权限状态。
+
+5. **系统辅助功能 API**：macOS 系统提供可靠的辅助功能 API 用于检测活跃输入框和执行文本注入。
+
+---
+
+## 需求
+
+### 需求 1：自动输出模式检测
+
+**用户故事：** 作为用户，我希望系统能够自动判断当前场景并选择合适的输出方式，无需手动配置，让输入过程更流畅。
+
+**验收标准：**
+
+1. WHEN 语音识别完成，THE Text_Output_Handler SHALL 自动检测当前是否存在活跃的输入框
+2. WHEN 检测到活跃的输入框（光标闪烁），THE Text_Output_Handler SHALL 使用文本注入输出模式
+3. WHEN 未检测到活跃的输入框，THE Text_Output_Handler SHALL 使用剪切板输出模式
+4. THE Text_Output_Handler SHALL 在每次输出前重新检测输入框状态，不依赖缓存的状态
+5. THE 活跃输入框检测 SHALL 基于系统辅助功能 API 提供的焦点信息
+
+---
+
+### 需求 2：剪切板输出
+
+**用户故事：** 作为用户，当没有活跃输入框时，我希望能够将识别文本拷贝到剪切板，以便我可以手动粘贴到任何应用中。
+
+**验收标准：**
+
+1. WHEN 未检测到活跃输入框，THE Text_Output_Handler SHALL 将 Recognized_Text 拷贝到系统剪切板
+2. WHEN 文本成功拷贝到剪切板，THE Text_Output_Handler SHALL 不主动清空或再次覆盖该剪切板内容，直到用户或其他应用执行新的剪切板写入操作
+3. THE Text_Output_Handler SHALL 支持拷贝包含多行文本的 Recognized_Text
+4. THE Text_Output_Handler SHALL 支持拷贝包含特殊字符和 Unicode 字符的 Recognized_Text
+
+---
+
+### 需求 3：文本注入输出
+
+**用户故事：** 作为用户，当检测到活跃输入框时，我希望能够将识别文本直接注入到当前输入框，以便快速完成输入而无需手动粘贴。
+
+**验收标准：**
+
+1. WHEN 检测到活跃输入框，THE Text_Output_Handler SHALL 将 Recognized_Text 注入到 Active_Input_Field
+2. THE Text_Output_Handler SHALL 在注入文本前验证文本注入权限是否可用
+3. THE Text_Output_Handler SHALL 支持注入包含多行文本的 Recognized_Text
+4. THE Text_Output_Handler SHALL 支持注入包含特殊字符和 Unicode 字符的 Recognized_Text
+5. THE Text_Output_Handler SHALL 在注入完成后将 Active_Input_Field 的插入点保留在已注入文本之后
+
+---
+
+### 需求 4：剪切板保护
+
+**用户故事：** 作为用户，当系统使用文本注入方式输出时，我希望我原有的剪切板内容不被覆盖，以便我可以继续使用之前复制的内容。
+
+**验收标准：**
+
+1. WHEN 使用文本注入输出模式，THE Text_Output_Handler SHALL 以 best effort 方式在注入前保存用户当前的剪切板内容
+2. WHEN 文本注入完成后，THE Text_Output_Handler SHALL 以 best effort 方式恢复用户原有的剪切板内容
+3. THE 剪切板保护机制 SHALL 至少支持文本类型的剪切板内容；对于其他类型内容，恢复行为为 best effort
+4. WHEN 剪切板恢复失败，THE Text_Output_Handler SHALL 记录错误日志但不影响文本注入的执行
+5. THE 剪切板保存和恢复操作 SHALL 作为文本注入流程的一部分执行，但不保证对系统剪切板的原子性
+
+---
+
+### 需求 5：输出失败处理
+
+**用户故事：** 作为用户，当文本输出失败时，我希望收到清晰的错误提示和恢复建议，以便我能够解决问题并重试。
+
+**验收标准：**
+
+1. WHEN 剪切板拷贝失败，THE Text_Output_Handler SHALL 记录错误日志并向用户显示错误消息
+2. WHEN 文本注入失败 AND 原因是缺少文本注入权限，THE Text_Output_Handler SHALL 向用户显示权限缺失提示
+3. WHEN 文本注入失败 AND 原因是无法找到 Active_Input_Field，THE Text_Output_Handler SHALL 向用户显示相应的错误消息
+4. WHEN 剪切板输出也失败时，THE Text_Output_Handler SHALL 提供重试选项或恢复建议
+5. IF 文本注入失败，THEN THE Text_Output_Handler SHALL 自动降级到剪切板输出
+
+---
+
+### 需求 6：空文本处理
+
+**用户故事：** 作为用户，当语音识别没有产生任何文本时，我希望系统能够合理处理，不执行无意义的输出操作。
+
+**验收标准：**
+
+1. WHEN Recognized_Text 为空字符串或仅包含空白字符，THE Text_Output_Handler SHALL 不执行输出操作
+2. WHEN Recognized_Text 为空，THE Text_Output_Handler SHALL 向用户提供提示说明未识别到有效文本
+3. THE Text_Output_Handler SHALL 将空白字符串和 null 值视为空文本
+4. WHEN 识别结果为空，THE Text_Output_Handler SHALL 记录相应的日志信息
+
+---
+
+### 需求 7：文本格式保持
+
+**用户故事：** 作为用户，我希望输出的文本能够保持识别结果的原始格式，包括换行、空格和标点符号。
+
+**验收标准：**
+
+1. THE Text_Output_Handler SHALL 保持 Recognized_Text 中的所有换行符
+2. THE Text_Output_Handler SHALL 保持 Recognized_Text 中的所有空格和制表符
+3. THE Text_Output_Handler SHALL 保持 Recognized_Text 中的所有标点符号
+4. THE Text_Output_Handler SHALL 不对 Recognized_Text 进行额外的格式化或修改
+5. WHEN 输出到剪切板或发起文本注入时，THE Text_Output_Handler SHALL 以原始文本内容进行输出；目标应用后续对文本的处理不属于本模块范围
+
+---
+
+## 非功能性需求
+
+### 可用性
+
+- 自动输出模式检测应该准确可靠，减少用户的认知负担
+- 错误消息应该提供具体的问题描述和解决建议
+- 输出操作应该支持键盘导航和辅助功能
+
+### 可靠性
+
+- 剪切板操作应该处理系统剪切板被其他应用占用的情况
+- 文本注入应该处理目标应用不响应的情况
+- 输出失败应该有明确的错误处理和恢复机制
+- 系统应该记录所有输出操作的结果用于问题诊断
+
+### 兼容性
+
+- 该功能应该支持 macOS 26 及更高版本
+- 文本注入应该与现有的辅助功能权限系统集成
+- 剪切板操作应该与 macOS 通用剪切板（Universal Clipboard）兼容
+- 该功能应该与应用程序现有的 SwiftUI 和 AppKit 集成点协同工作
+
+---
+
+## 不在范围内
+
+以下内容明确不包含在本规范中：
+
+- 文本输出前的自动格式化或美化
+- 文本输出历史记录功能
+- 多剪切板管理
+- 文本输出的撤销/重做功能
+- 输出文本的自动翻译
+- 输出文本的自动纠错
+- 富文本格式支持（如粗体、斜体、颜色）
+- 输出文本的加密或安全保护
+- 输出操作的遥测或分析数据收集
+- 第三方剪切板管理工具的集成

--- a/apps/mac/.kiro/specs/text-output-handling/tasks.md
+++ b/apps/mac/.kiro/specs/text-output-handling/tasks.md
@@ -1,0 +1,158 @@
+# Implementation Plan: Text Output Handling
+
+## Overview
+
+This implementation plan tracks the work required to deliver the macOS text output handling flow for Stet. The current architecture already has the core path in place: clipboard-backed auto-paste, best-effort pasteboard restoration, and fallback to clipboard when text injection verification fails. The remaining work is mainly in failure surfacing, stronger correctness guarantees, and broader test coverage.
+
+The plan is organized in two layers:
+- Foundation tasks that are already implemented and should remain stable
+- Remaining tasks needed to fully satisfy the requirements and target design
+
+---
+
+## Tasks
+
+- [x] 1. Establish core text output orchestration
+  - [x] 1.1 Implement capture completion coordination in `apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift`
+    - Coordinate clipboard copy, auto-paste attempt, pasteboard protection, and completion outcomes
+    - Support `CaptureSettings` with `shouldCopyToClipboard`, `shouldAutoPaste`, and `shouldRevealPanelOnCapture`
+    - Handle successful paste, failed paste, and no-output branches
+    - _Requirements: 1.1, 1.2, 2.1, 3.1, 4.1, 5.5_
+
+  - [x] 1.2 Implement clipboard-backed injection flow in `apps/mac/Stet/Core/TextInput/TextInjectionService.swift`
+    - Simulate `Cmd+V` into the target application
+    - Capture focused-element snapshots before and after paste
+    - Verify paste success by detecting focused-element mutation
+    - Support selection replacement via `replaceSelectedText`
+    - _Requirements: 1.5, 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 1.3 Implement system clipboard writing in `apps/mac/Stet/Core/Clipboard/ClipboardService.swift`
+    - Write plain text to the general pasteboard
+    - Mark transient clipboard content for temporary override flows
+    - Tag source bundle identifier for diagnostics
+    - _Requirements: 2.1, 2.3, 2.4, 4.1_
+
+  - [x] 1.4 Implement best-effort pasteboard restoration in `apps/mac/Stet/Core/Clipboard/PasteboardRestoreCoordinator.swift`
+    - Capture the original pasteboard snapshot before temporary override
+    - Restore after a delayed success path if the pasteboard still matches the temporary snapshot
+    - Restore immediately on paste failure
+    - Preserve multi-item and multi-type pasteboard payloads on a best-effort basis
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 1.5 Add empty-text guards in `apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift`, `apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift`, and `apps/mac/Stet/Core/TextInput/TextInjectionService.swift`
+    - Skip output for empty or whitespace-only text
+    - Return an empty-transcription failure at the workflow boundary where applicable
+    - Prevent empty replacement attempts
+    - _Requirements: 6.1, 6.3, 6.4_
+
+- [x] 2. Lock in fallback behavior with tests
+  - [x] 2.1 Add coordinator coverage in `apps/mac/StetTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift`
+    - Verify clipboard-only output
+    - Verify transient copy + successful auto-paste
+    - Verify failed auto-paste falls back to permanent clipboard copy
+    - Verify empty text does not trigger output
+    - _Requirements: 2.1, 3.1, 5.5, 6.1_
+
+  - [x] 2.2 Add workflow coverage in `apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift`
+    - Verify dictation completion uses the coordinator path
+    - Verify failed dictation completion falls back to clipboard copy
+    - Verify failed selection replacement falls back to clipboard copy
+    - Verify empty completion text maps to `.emptyTranscription`
+    - _Requirements: 3.1, 5.5, 6.1, 6.2_
+
+- [x] 3. Surface output failures explicitly to the user
+  - [x] 3.1 Introduce an output-specific failure surface in `apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift`, `apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift`, and `apps/mac/Stet/Features/Dictation/DictationFailure.swift`
+    - Distinguish between clipboard write failure, permission failure, paste verification failure, and empty-text no-op
+    - Stop overloading generic success/fallback paths for cases that should produce actionable UI
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [x] 3.2 Make clipboard writes observable in `apps/mac/Stet/Core/Clipboard/ClipboardService.swift`
+    - Change the clipboard write API to report success or failure instead of being fire-and-forget
+    - Plumb failures back to the coordinator
+    - Add logging for clipboard write failures without logging sensitive clipboard contents
+    - _Requirements: 5.1, 5.4, Reliability_
+
+  - [x] 3.3 Add user-facing recovery messaging in `apps/mac/Stet/App/Workflows/MacAppSessionController.swift` and `apps/mac/Stet/Features/Dictation/DictationViewModel.swift`
+    - Show clear guidance when input-control permissions are missing
+    - Show a distinct message when paste verification fails but clipboard fallback succeeds
+    - Preserve the current non-disruptive success path when fallback succeeds silently
+    - _Requirements: 5.2, 5.3, 5.4_
+
+- [x] 4. Strengthen text injection correctness
+  - [x] 4.1 Replace the raw `Bool` paste result with a richer verified outcome in `apps/mac/Stet/Core/TextInput/TextInjectionService.swift`
+    - Distinguish event-posted, verification-unavailable, verification-failed, and verified-success cases
+    - Avoid treating “could not verify” and “verified failed” as the same condition
+    - _Requirements: 1.5, 3.2, 5.3_
+
+  - [x] 4.2 Improve focused-element verification coverage in `apps/mac/Stet/Core/TextInput/TextInjectionService.swift`
+    - Support more editable control variations where `kAXValue`, `kAXSelectedText`, or `kAXSelectedTextRange` are incomplete
+    - Keep the verification path best-effort rather than introducing fake preflight detection
+    - _Requirements: 1.5, 3.1, 3.4, Compatibility_
+
+  - [x] 4.3 Validate cursor and selection postconditions in `apps/mac/Stet/Core/TextInput/TextInjectionService.swift`
+    - Add explicit checks for the caret ending after inserted text when AX range data is available
+    - Define best-effort behavior when the target app does not expose sufficient selection metadata
+    - _Requirements: 3.5_
+
+- [x] 5. Improve pasteboard protection diagnostics
+  - [x] 5.1 Add restore-path logging in `apps/mac/Stet/Core/Clipboard/PasteboardRestoreCoordinator.swift`
+    - Log skipped restores when the temporary snapshot no longer matches
+    - Log restore failures without recording clipboard payload contents
+    - Keep restoration best-effort and non-blocking
+    - _Requirements: 4.4, Reliability_
+
+  - [x] 5.2 Add unit tests for restore edge cases in `apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift`
+    - Verify restore is skipped when the clipboard changes externally
+    - Verify restore preserves multi-item payloads where possible
+    - Verify immediate restore on failure still clears pending state
+    - _Requirements: 4.2, 4.3, 4.4_
+
+- [ ] 6. Expand correctness and integration tests
+  - [ ] 6.1 Add integration coverage for runtime output failures in `apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift` and `apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift`
+    - Verify permission-missing flows request access and preserve the transcript
+    - Verify panel reveal behavior stays consistent after fallback
+    - Verify output completion state is correct for dictation and selection-replacement workflows
+    - _Requirements: 5.2, 5.3, 5.5_
+
+  - [ ]* 6.2 Add property-based tests for clipboard output integrity in `apps/mac/StetTests/Core/Clipboard/ClipboardServicePropertyTests.swift`
+    - Validate round-trip integrity for multiline, Unicode, and punctuation-heavy text
+    - _Requirements: 2.3, 2.4, 7.1, 7.2, 7.3_
+
+  - [ ]* 6.3 Add property-based tests for pasteboard restoration in `apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorPropertyTests.swift`
+    - Validate that unchanged temporary clipboard contents restore to the original snapshot
+    - Validate that modified clipboard contents are not overwritten
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]* 6.4 Add property-based tests for text output no-op behavior in `apps/mac/StetTests/App/Workflows/MacDictationCaptureCoordinatorPropertyTests.swift`
+    - Validate empty and whitespace-only text never triggers system write side effects
+    - _Requirements: 6.1, 6.3_
+
+- [x] 7. Align specification documents
+  - [x] 7.1 Update `apps/mac/.kiro/specs/text-output-handling/requirements.md`
+    - Tighten the product contract around automatic routing, best-effort clipboard protection, and automatic fallback
+    - Remove over-strong guarantees that the system cannot actually make
+    - _Requirements: Documentation alignment_
+
+  - [x] 7.2 Update `apps/mac/.kiro/specs/text-output-handling/design.md`
+    - Reframe the design around optimistic paste, focused-element verification, and clipboard fallback
+    - Correct interface listings and file structure descriptions
+    - Mark the document as the target implementation rather than a snapshot of current code
+    - _Requirements: Documentation alignment_
+
+- [ ] 8. Final verification checkpoint
+  - [x] 8.1 Run focused macOS test validation for text output handling
+    - Re-run `MacDictationCaptureCoordinatorTests`
+    - Re-run `MacDictationWorkflowControllerTests`
+    - Re-run clipboard and text-input unit tests after any remaining refactors
+    - _Requirements: Cross-cutting validation_
+
+  - [ ] 8.2 Confirm requirements-to-implementation traceability
+    - Ensure each remaining unchecked requirement has at least one concrete implementation task and one test task
+    - Update this plan if the design or requirements shift again
+    - _Requirements: Process quality_
+
+## Notes
+
+- Tasks marked with `*` are optional property-based tests and can be deferred for MVP.
+- The current codebase already satisfies the main happy path: temporary clipboard override, verified auto-paste attempt, and automatic clipboard fallback.
+- The main remaining gaps are explicit failure surfacing, stronger verification semantics, and broader automated coverage.

--- a/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
+++ b/apps/mac/Stet/App/Workflows/MacAppSessionController.swift
@@ -598,6 +598,7 @@
 
         private func bindState() {
             workflowController.dictationViewModel.$state
+                .dropFirst()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] state in
                     self?.handleDictationStateChange(state)
@@ -682,9 +683,14 @@
                     workflow: completedWorkflow,
                     showTransientPanel: showTransientPanel
                 )
+                let recoveredTextPreserved = if case .failed(let failure) = outcome {
+                    failure.preservesRecoveredTextInClipboard
+                } else {
+                    false
+                }
                 Task {
                     await DictationRuntimeProbe.shared.markResultHandled(
-                        clipboardPending: outcome == .clipboardPending,
+                        clipboardPending: outcome == .clipboardPending || recoveredTextPreserved,
                         textLength: text.count
                     )
                 }
@@ -701,6 +707,15 @@
                         showTransientPanel()
                     }
                     workflowController.dictationViewModel.send(.clipboardPending(text))
+                case .failed(let failure):
+                    if failure.preservesRecoveredTextInClipboard {
+                        if !isPanelVisible {
+                            showTransientPanel()
+                        }
+                        workflowController.dictationViewModel.send(.clipboardPending(text))
+                    } else {
+                        workflowController.dictationViewModel.send(.transcriptionFailed(failure))
+                    }
                 }
             }
         }
@@ -805,7 +820,11 @@
         }
 
         private func commitPendingCopy(_ text: String) {
-            workflowController.copyPendingResultToClipboard(text)
+            let copied = workflowController.copyPendingResultToClipboard(text)
+            guard copied else {
+                return
+            }
+
             hidePanel()
             workflowController.dictationViewModel.send(.resetTapped)
             Task {
@@ -846,6 +865,10 @@
                     let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
                     firstSuccessPreviewTextState = trimmedText.isEmpty ? nil : trimmedText
                     firstSuccessFailureMessageState = nil
+                } else if case .clipboardPending(let text) = state {
+                    let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    firstSuccessPreviewTextState = trimmedText.isEmpty ? nil : trimmedText
+                    firstSuccessFailureMessageState = nil
                 } else if case .error(let failure) = state {
                     firstSuccessFailureCount += 1
                     firstSuccessFailureMessageState = inferredFirstSuccessFailureMessage(for: failure)
@@ -879,6 +902,10 @@
         }
 
         private func inferredFirstSuccessFailureMessage(for failure: DictationFailure) -> String {
+            if failure == .autoPastePermissionMissing {
+                return "Unable to paste automatically, please grant Input Monitoring or Accessibility access."
+            }
+
             switch failure.classification {
             case .authentication:
                 return "Connection unavailable, please re-verify your login status."
@@ -893,6 +920,8 @@
                 return "Unable to access microphone, please check system permissions."
             case .noSpeech:
                 return "No voice input detected, please try again."
+            case .output:
+                return "Text output failed, but your transcription is available."
             case .service, .state, .unknown:
                 return "Dictation failed, please try again."
             }

--- a/apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -7,6 +7,7 @@
         enum CompletionOutcome: Equatable {
             case completed
             case clipboardPending
+            case failed(DictationFailure)
         }
 
         struct CaptureSettings {
@@ -39,6 +40,11 @@
             settings: CaptureSettings,
             showPanel: @escaping @MainActor () -> Void
         ) async -> CompletionOutcome {
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                await DictationLatencyProbe.shared.record(.systemWriteSkipped, note: "empty_text")
+                return .completed
+            }
+
             let shouldRestoreClipboardAfterSuccessfulPaste =
                 settings.shouldAutoPaste && !settings.shouldCopyToClipboard
 
@@ -49,38 +55,93 @@
             }
 
             if settings.shouldCopyToClipboard || settings.shouldAutoPaste {
-                clipboardService.copy(
+                let clipboardSuccess = clipboardService.copy(
                     text,
                     transient: settings.shouldAutoPaste && !settings.shouldCopyToClipboard
                 )
+                if !clipboardSuccess {
+                    await DictationLatencyProbe.shared.record(
+                        .systemWriteFailed, note: "clipboard_write_failed")
+                    return .failed(.clipboardWriteFailed)
+                }
             }
 
             if settings.shouldAutoPaste {
-                let didPaste = await textInjectionService.pasteClipboard(into: targetApplication)
+                if !textInjectionService.isAvailable {
+                    if shouldRestoreClipboardAfterSuccessfulPaste {
+                        pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                    }
 
-                if didPaste {
+                    if !settings.shouldCopyToClipboard {
+                        let fallbackSuccess = clipboardService.copy(text, transient: false)
+                        if !fallbackSuccess {
+                            await DictationLatencyProbe.shared.record(
+                                .systemWriteFailed, note: "clipboard_fallback_failed")
+                            return .failed(.clipboardWriteFailed)
+                        }
+                    }
+
+                    textInjectionService.requestAccessIfNeeded()
+                    if settings.shouldRevealPanelOnCapture {
+                        showPanel()
+                    }
+
+                    await DictationLatencyProbe.shared.record(
+                        .systemWriteFailed, note: "auto_paste_permission_missing")
+                    return .failed(.autoPastePermissionMissing)
+                }
+
+                let pasteOutcome = await textInjectionService.pasteClipboard(into: targetApplication)
+
+                switch pasteOutcome {
+                case .verifiedSuccess:
                     if shouldRestoreClipboardAfterSuccessfulPaste {
                         pasteboardRestoreCoordinator.scheduleRestoreIfNeeded(on: pasteboard)
                     }
                     await DictationLatencyProbe.shared.record(.systemWriteCompleted)
                     return .completed
-                } else {
+
+                case .eventPostedVerificationUnavailable, .verificationFailed, .eventPostFailed:
                     if shouldRestoreClipboardAfterSuccessfulPaste {
                         pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
                     }
+
+                    if !settings.shouldCopyToClipboard {
+                        let fallbackSuccess = clipboardService.copy(text, transient: false)
+                        if !fallbackSuccess {
+                            await DictationLatencyProbe.shared.record(
+                                .systemWriteFailed, note: "clipboard_fallback_failed")
+                            return .failed(.clipboardWriteFailed)
+                        }
+                    }
+
+                    let failure: DictationFailure
+                    let failureNote: String
+
+                    switch pasteOutcome {
+                    case .eventPostedVerificationUnavailable:
+                        failure = .pasteVerificationUnavailable
+                        failureNote = "paste_verification_unavailable"
+                    case .verificationFailed:
+                        failure = .pasteVerificationFailed
+                        failureNote = "paste_verification_failed"
+                    case .eventPostFailed:
+                        failure = .pasteVerificationFailed
+                        failureNote = "paste_event_post_failed"
+                    case .verifiedSuccess:
+                        failure = .pasteVerificationFailed
+                        failureNote = "unexpected"
+                    }
+
+                    if settings.shouldRevealPanelOnCapture {
+                        showPanel()
+                    }
+
                     await DictationLatencyProbe.shared.record(
-                        .systemWriteFailed, note: "paste_failed")
-                }
+                        .systemWriteFailed, note: failureNote)
 
-                if !didPaste && !textInjectionService.isAvailable {
-                    textInjectionService.requestAccessIfNeeded()
+                    return .failed(failure)
                 }
-
-                if settings.shouldRevealPanelOnCapture && !didPaste {
-                    showPanel()
-                }
-
-                return settings.shouldCopyToClipboard ? .completed : .clipboardPending
             } else if settings.shouldRevealPanelOnCapture {
                 await DictationLatencyProbe.shared.record(
                     .systemWriteSkipped, note: "auto_paste_disabled")
@@ -93,9 +154,12 @@
             return settings.shouldCopyToClipboard ? .completed : .clipboardPending
         }
 
-        func copyToClipboard(_ text: String) {
+        func copyToClipboard(_ text: String) -> Bool {
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return true
+            }
             pasteboardRestoreCoordinator.discardPendingRestore()
-            clipboardService.copy(text, transient: false)
+            return clipboardService.copy(text, transient: false)
         }
     }
 #endif

--- a/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
+++ b/apps/mac/Stet/App/Workflows/MacDictationWorkflowController.swift
@@ -225,6 +225,10 @@
             Task {
                 await DictationRuntimeProbe.shared.markAction("handleCompletedResult workflow=\(workflow)")
             }
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                await DictationLatencyProbe.shared.record(.systemWriteSkipped, note: "empty_text")
+                return .failed(.emptyTranscription)
+            }
             if workflow.isSelectionReplacement {
                 return await handleSelectedTextReplacementResult(text: text, showTransientPanel: showTransientPanel)
             }
@@ -237,11 +241,11 @@
             )
         }
 
-        func copyPendingResultToClipboard(_ text: String) {
+        func copyPendingResultToClipboard(_ text: String) -> Bool {
             Task {
                 await DictationRuntimeProbe.shared.markAction("copyPendingResultToClipboard")
             }
-            captureCoordinator.copyToClipboard(text)
+            return captureCoordinator.copyToClipboard(text)
         }
 
         private func handleSelectedTextReplacementResult(
@@ -249,30 +253,64 @@
             showTransientPanel: @escaping @MainActor () -> Void
         ) async -> CompletionOutcome {
             let keepResultInClipboard = captureSettings.shouldCopyToClipboard
-            let didReplaceSelection = await textInjectionService.replaceSelectedText(
+            let replacementOutcome = await textInjectionService.replaceSelectedText(
                 text,
                 into: lastTargetApplication,
                 keepResultInClipboard: keepResultInClipboard
             )
 
-            if didReplaceSelection {
+            if replacementOutcome == .replaced {
                 await DictationLatencyProbe.shared.record(.systemWriteCompleted)
                 return .completed
             } else {
                 await DictationLatencyProbe.shared.record(.systemWriteFailed, note: "replace_selected_text_failed")
             }
 
-            if !didReplaceSelection {
-                if !textInjectionService.isAvailable {
+            switch replacementOutcome {
+            case .replaced:
+                return .completed
+
+            case .clipboardWriteFailed:
+                return .failed(.clipboardWriteFailed)
+
+            case .injectionFailed(let injectionOutcome):
+                if injectionOutcome == .eventPostFailed && !textInjectionService.isAvailable {
                     textInjectionService.requestAccessIfNeeded()
+
+                    if !keepResultInClipboard {
+                        let clipboardSuccess = captureCoordinator.copyToClipboard(text)
+                        if !clipboardSuccess {
+                            return .failed(.clipboardWriteFailed)
+                        }
+                    }
+
+                    if captureSettings.shouldRevealPanelOnCapture {
+                        showTransientPanel()
+                    }
+
+                    return .failed(.autoPastePermissionMissing)
+                }
+
+                if !keepResultInClipboard {
+                    let clipboardSuccess = captureCoordinator.copyToClipboard(text)
+                    if !clipboardSuccess {
+                        return .failed(.clipboardWriteFailed)
+                    }
                 }
 
                 if captureSettings.shouldRevealPanelOnCapture {
                     showTransientPanel()
                 }
-            }
 
-            return keepResultInClipboard ? .completed : .clipboardPending
+                switch injectionOutcome {
+                case .eventPostedVerificationUnavailable:
+                    return .failed(.pasteVerificationUnavailable)
+                case .verificationFailed, .eventPostFailed:
+                    return .failed(.pasteVerificationFailed)
+                case .verifiedSuccess:
+                    return .completed
+                }
+            }
         }
 
         private func refreshTargetApplication(allowingCurrentAppTarget: Bool) {

--- a/apps/mac/Stet/Core/Clipboard/ClipboardService.swift
+++ b/apps/mac/Stet/Core/Clipboard/ClipboardService.swift
@@ -8,11 +8,13 @@ import Foundation
 
 @MainActor
 protocol ClipboardService {
-    func copy(_ text: String, transient: Bool)
+    @discardableResult
+    func copy(_ text: String, transient: Bool) -> Bool
 }
 
 extension ClipboardService {
-    func copy(_ text: String) {
+    @discardableResult
+    func copy(_ text: String) -> Bool {
         copy(text, transient: false)
     }
 }
@@ -30,18 +32,38 @@ final class SystemClipboardService: ClipboardService {
         }
     #endif
 
-    func copy(_ text: String, transient: Bool) {
+    @discardableResult
+    func copy(_ text: String, transient: Bool) -> Bool {
         #if os(macOS)
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
-            if let bundleIdentifier = Bundle.main.bundleIdentifier {
-                pasteboard.setString(bundleIdentifier, forType: Self.sourceType)
-            }
-            if transient {
-                pasteboard.setData(Data(), forType: Self.transientType)
+            do {
+                pasteboard.clearContents()
+
+                guard pasteboard.setString(text, forType: .string) else {
+                    AppLogger.error(
+                        "Failed to write text to clipboard (setString returned false)",
+                        category: .general
+                    )
+                    return false
+                }
+
+                if let bundleIdentifier = Bundle.main.bundleIdentifier {
+                    _ = pasteboard.setString(bundleIdentifier, forType: Self.sourceType)
+                }
+                if transient {
+                    _ = pasteboard.setData(Data(), forType: Self.transientType)
+                }
+
+                return true
+            } catch {
+                AppLogger.error(
+                    "Failed to write text to clipboard: \(error.localizedDescription)",
+                    category: .general
+                )
+                return false
             }
         #elseif canImport(UIKit)
             UIPasteboard.general.string = text
+            return true
         #endif
     }
 }

--- a/apps/mac/Stet/Core/Clipboard/PasteboardRestoreCoordinator.swift
+++ b/apps/mac/Stet/Core/Clipboard/PasteboardRestoreCoordinator.swift
@@ -42,6 +42,10 @@
                 }
 
                 guard temporarySnapshot.matches(pasteboard) else {
+                    AppLogger.info(
+                        "Pasteboard restore skipped: temporary snapshot no longer matches current pasteboard",
+                        category: .dictation
+                    )
                     return
                 }
 
@@ -105,7 +109,18 @@
             }
 
             if !restoredItems.isEmpty {
-                pasteboard.writeObjects(restoredItems)
+                let success = pasteboard.writeObjects(restoredItems)
+                if !success {
+                    AppLogger.warning(
+                        "Pasteboard restore failed: unable to write restored items to pasteboard",
+                        category: .dictation
+                    )
+                }
+            } else if !items.isEmpty {
+                AppLogger.warning(
+                    "Pasteboard restore failed: no items could be restored from snapshot",
+                    category: .dictation
+                )
             }
         }
     }

--- a/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
+++ b/apps/mac/Stet/Core/TextInput/TextInjectionService.swift
@@ -14,6 +14,30 @@
     }
 
     @MainActor
+    enum TextInjectionOutcome: Equatable {
+        case verifiedSuccess
+        case eventPostedVerificationUnavailable
+        case verificationFailed
+        case eventPostFailed
+
+        var didSucceed: Bool {
+            switch self {
+            case .verifiedSuccess:
+                return true
+            case .eventPostedVerificationUnavailable, .verificationFailed, .eventPostFailed:
+                return false
+            }
+        }
+    }
+
+    @MainActor
+    enum TextReplacementOutcome: Equatable {
+        case replaced
+        case clipboardWriteFailed
+        case injectionFailed(TextInjectionOutcome)
+    }
+
+    @MainActor
     protocol TextInjectionService {
         var accessState: TextInjectionAccessState { get }
         var isAvailable: Bool { get }
@@ -21,13 +45,13 @@
         func requestAccess()
         func requestAccessIfNeeded()
         func openAccessibilitySettings()
-        func pasteClipboard(into application: NSRunningApplication?) async -> Bool
+        func pasteClipboard(into application: NSRunningApplication?) async -> TextInjectionOutcome
         func selectedText() -> String?
         func replaceSelectedText(
             _ text: String,
             into application: NSRunningApplication?,
             keepResultInClipboard: Bool
-        ) async -> Bool
+        ) async -> TextReplacementOutcome
     }
 
     @MainActor
@@ -46,15 +70,36 @@
             let value: String?
             let selectedText: String?
             let selectionRange: SelectionRange?
+            let numberOfCharacters: Int?
 
             var canVerifyPaste: Bool {
-                value != nil || selectedText != nil || selectionRange != nil
+                value != nil || selectedText != nil || selectionRange != nil || numberOfCharacters != nil
             }
 
             func indicatesMutation(comparedTo previous: Self) -> Bool {
-                value != previous.value
-                    || selectedText != previous.selectedText
-                    || selectionRange != previous.selectionRange
+                if let value, let previousValue = previous.value, value != previousValue {
+                    return true
+                }
+                if let selectedText, let previousSelectedText = previous.selectedText,
+                    selectedText != previousSelectedText
+                {
+                    return true
+                }
+                if let selectionRange, let previousSelectionRange = previous.selectionRange,
+                    selectionRange != previousSelectionRange
+                {
+                    return true
+                }
+                if let numberOfCharacters, let previousCount = previous.numberOfCharacters,
+                    numberOfCharacters != previousCount
+                {
+                    return true
+                }
+
+                return (value != nil) != (previous.value != nil)
+                    || (selectedText != nil) != (previous.selectedText != nil)
+                    || (selectionRange != nil) != (previous.selectionRange != nil)
+                    || (numberOfCharacters != nil) != (previous.numberOfCharacters != nil)
             }
         }
 
@@ -112,9 +157,9 @@
             NSWorkspace.shared.open(url)
         }
 
-        func pasteClipboard(into application: NSRunningApplication?) async -> Bool {
+        func pasteClipboard(into application: NSRunningApplication?) async -> TextInjectionOutcome {
             guard accessState.canSimulateInput else {
-                return false
+                return .eventPostFailed
             }
 
             let snapshotBeforePaste = focusedElementSnapshot()
@@ -129,21 +174,21 @@
 
             try? await Task.sleep(for: .milliseconds(60))
             guard simulateCommandKey(KeyCode.paste) else {
-                return false
+                return .eventPostFailed
             }
 
-            // Posting Command+V only tells us the event was emitted, not that the target accepted it.
             guard let snapshotBeforePaste, snapshotBeforePaste.canVerifyPaste else {
-                return false
+                return .eventPostedVerificationUnavailable
             }
 
             try? await Task.sleep(for: .milliseconds(180))
 
             guard let snapshotAfterPaste = focusedElementSnapshot() else {
-                return false
+                return .eventPostedVerificationUnavailable
             }
 
             return snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste)
+                ? .verifiedSuccess : .verificationFailed
         }
 
         func selectedText() -> String? {
@@ -160,8 +205,8 @@
             _ text: String,
             into application: NSRunningApplication?,
             keepResultInClipboard: Bool
-        ) async -> Bool {
-            guard !text.isEmpty else { return false }
+        ) async -> TextReplacementOutcome {
+            guard !text.isEmpty else { return .injectionFailed(.verificationFailed) }
 
             if keepResultInClipboard {
                 pasteboardRestoreCoordinator.discardPendingRestore()
@@ -169,23 +214,33 @@
                 pasteboardRestoreCoordinator.prepareForTemporaryOverride(on: pasteboard)
             }
 
-            clipboardService.copy(text, transient: !keepResultInClipboard)
-            let didPaste = await pasteClipboard(into: application)
-
-            guard didPaste else {
+            let clipboardWriteSucceeded = clipboardService.copy(
+                text,
+                transient: !keepResultInClipboard
+            )
+            guard clipboardWriteSucceeded else {
                 if !keepResultInClipboard {
                     pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
                 }
-                return false
+                return .clipboardWriteFailed
+            }
+
+            let outcome = await pasteClipboard(into: application)
+
+            guard outcome.didSucceed else {
+                if !keepResultInClipboard {
+                    pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                }
+                return .injectionFailed(outcome)
             }
 
             guard !keepResultInClipboard else {
-                return didPaste
+                return .replaced
             }
 
             pasteboardRestoreCoordinator.scheduleRestoreIfNeeded(on: pasteboard)
 
-            return didPaste
+            return .replaced
         }
 
         private func selectedTextFromAXFocusedElement() -> String? {
@@ -284,7 +339,8 @@
                 value: stringAttribute(kAXValueAttribute as CFString, from: focusedElement),
                 selectedText: stringAttribute(
                     kAXSelectedTextAttribute as CFString, from: focusedElement),
-                selectionRange: selectedRange(from: focusedElement)
+                selectionRange: selectedRange(from: focusedElement),
+                numberOfCharacters: numberOfCharacters(from: focusedElement)
             )
         }
 
@@ -354,6 +410,24 @@
             }
 
             return SelectionRange(location: range.location, length: range.length)
+        }
+
+        private func numberOfCharacters(from element: AXUIElement) -> Int? {
+            var valueRef: CFTypeRef?
+            let status = AXUIElementCopyAttributeValue(
+                element,
+                kAXNumberOfCharactersAttribute as CFString,
+                &valueRef
+            )
+
+            guard status == .success,
+                let valueRef,
+                let number = valueRef as? NSNumber
+            else {
+                return nil
+            }
+
+            return number.intValue
         }
 
         private func requestMissingAccesses(trigger: String) {

--- a/apps/mac/Stet/Features/Dictation/DictationFailure.swift
+++ b/apps/mac/Stet/Features/Dictation/DictationFailure.swift
@@ -7,6 +7,7 @@ enum DictationFailure: Equatable, Sendable {
         case authentication
         case network
         case noSpeech
+        case output
         case service
         case state
         case unknown
@@ -28,6 +29,10 @@ enum DictationFailure: Equatable, Sendable {
     case relayAuthenticationRequired
     case relayInvocation(statusCode: Int?, message: String, requestID: String?)
     case network(code: URLError.Code, message: String)
+    case clipboardWriteFailed
+    case autoPastePermissionMissing
+    case pasteVerificationUnavailable
+    case pasteVerificationFailed
     case unknown(message: String)
 
     var classification: Classification {
@@ -44,6 +49,10 @@ enum DictationFailure: Equatable, Sendable {
             return .noSpeech
         case .alreadyRecording, .notRecording:
             return .state
+        case .clipboardWriteFailed, .pasteVerificationUnavailable, .pasteVerificationFailed:
+            return .output
+        case .autoPastePermissionMissing:
+            return .permissions
         case .missingProviderConfiguration, .missingAPIKey, .invalidBaseURL, .unsupportedProviderCombination:
             return .configuration
         case .providerAPI(_, let statusCode, _):
@@ -96,6 +105,12 @@ enum DictationFailure: Equatable, Sendable {
             return "Managed Relay request failed"
         case .network:
             return "Network problem"
+        case .clipboardWriteFailed:
+            return "Clipboard write failed"
+        case .autoPastePermissionMissing:
+            return "Input control permission required"
+        case .pasteVerificationUnavailable, .pasteVerificationFailed:
+            return "Text copied to clipboard"
         case .unknown:
             return "Something went wrong"
         }
@@ -144,8 +159,25 @@ enum DictationFailure: Equatable, Sendable {
             ).localizedDescription
         case .network(_, let message):
             return message
+        case .clipboardWriteFailed:
+            return "Failed to write text to clipboard. Please try again or paste manually."
+        case .autoPastePermissionMissing:
+            return "Stet needs Input Monitoring or Accessibility permission to paste text automatically. Text has been copied to clipboard."
+        case .pasteVerificationUnavailable:
+            return "Stet could not verify the paste because the target app did not expose enough text metadata. Text has been copied to clipboard."
+        case .pasteVerificationFailed:
+            return "Could not verify text was pasted successfully. Text has been copied to clipboard as a fallback."
         case .unknown(let message):
             return message
+        }
+    }
+
+    var preservesRecoveredTextInClipboard: Bool {
+        switch self {
+        case .autoPastePermissionMissing, .pasteVerificationUnavailable, .pasteVerificationFailed:
+            return true
+        default:
+            return false
         }
     }
 

--- a/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -164,7 +164,9 @@
             session: MacAppSessionController,
             workflow: MacDictationWorkflowController,
             shell: FakeShellPresenter,
-            permissionGate: FakePermissionGatePresenter
+            permissionGate: FakePermissionGatePresenter,
+            clipboardService: TestClipboardService,
+            textInjectionService: TestTextInjectionService
         ) {
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(true, forKey: MacPreferences.onboardingCompleted)
@@ -209,7 +211,14 @@
                 hotkeyRegistrar: hotkeyRegistrar
             )
 
-            return (session: session, workflow: workflow, shell: shell, permissionGate: permissionGate)
+            return (
+                session: session,
+                workflow: workflow,
+                shell: shell,
+                permissionGate: permissionGate,
+                clipboardService: clipboardService,
+                textInjectionService: textInjectionService
+            )
         }
 
         @Test func cancelActiveCaptureHidesPanelAndResetsWorkflowState() {
@@ -264,6 +273,43 @@
                 await TestSupport.eventually {
                     subject.shell.showTransientPanelCallCount == 1
                 })
+            #expect(subject.shell.isPanelVisible)
+        }
+
+        @Test func pendingCopyFailureKeepsPanelVisibleAndPreservesTranscript() async {
+            let subject = makeSubject()
+            let presentationModel = FakePresentationModel()
+            subject.session.activate(presentationModel: presentationModel, showInDock: false)
+            subject.workflow.dictationViewModel.send(.clipboardPending("needs copy"))
+            subject.shell.showTransientPanel(appModel: presentationModel)
+            subject.clipboardService.shouldFailCopy = true
+
+            #expect(await TestSupport.eventually {
+                subject.workflow.dictationViewModel.state == .clipboardPending("needs copy")
+            })
+            #expect(subject.shell.isPanelVisible)
+
+            subject.session.performPrimaryAction()
+
+            #expect(await TestSupport.eventually {
+                subject.workflow.dictationViewModel.state == .clipboardPending("needs copy")
+            })
+            #expect(subject.shell.hidePanelCallCount == 0)
+            #expect(subject.shell.isPanelVisible)
+        }
+
+        @Test func verificationFailureFallsBackToClipboardPendingSurface() async {
+            let subject = makeSubject()
+            let presentationModel = FakePresentationModel()
+            subject.session.activate(presentationModel: presentationModel, showInDock: false)
+            subject.textInjectionService.pasteOutcome = .verificationFailed
+
+            subject.workflow.dictationViewModel.send(.transcriptionSucceeded("transcript"))
+
+            #expect(await TestSupport.eventually {
+                subject.workflow.dictationViewModel.state == .clipboardPending("transcript")
+            })
+            #expect(subject.clipboardService.copiedTexts == ["transcript", "transcript"])
             #expect(subject.shell.isPanelVisible)
         }
     }

--- a/apps/mac/StetTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -113,7 +113,7 @@
                 showPanel: { revealCount += 1 }
             )
 
-            #expect(outcome == .completed)
+            #expect(outcome == .failed(.autoPastePermissionMissing))
             #expect(clipboard.copiedTexts == ["hello"])
             #expect(clipboard.transientFlags == [false])
             #expect(textInjection.didRequestAccessIfNeeded)
@@ -146,7 +146,9 @@
                 showPanel: { revealCount += 1 }
             )
 
-            #expect(outcome == .clipboardPending)
+            #expect(outcome == .failed(.autoPastePermissionMissing))
+            #expect(clipboard.copiedTexts == ["hello", "hello"])
+            #expect(clipboard.transientFlags == [true, false])
             #expect(textInjection.didRequestAccessIfNeeded)
             #expect(revealCount == 1)
         }
@@ -191,6 +193,34 @@
             #expect(clipboard.transientFlags == [false])
         }
 
+        @Test func completedCaptureTreatsVerificationUnavailableAsDistinctFailure() async {
+            let clipboard = TestClipboardService()
+            let textInjection = TestTextInjectionService()
+            textInjection.pasteOutcome = .eventPostedVerificationUnavailable
+            let coordinator = MacDictationCaptureCoordinator(
+                clipboardService: clipboard,
+                textInjectionService: textInjection
+            )
+            var revealCount = 0
+
+            let outcome = await coordinator.handleCompletedCapture(
+                text: "hello",
+                targetApplication: nil,
+                settings: .init(
+                    shouldCopyToClipboard: false,
+                    shouldAutoPaste: true,
+                    shouldRevealPanelOnCapture: false
+                ),
+                showPanel: { revealCount += 1 }
+            )
+
+            #expect(outcome == .failed(.pasteVerificationUnavailable))
+            #expect(clipboard.copiedTexts == ["hello", "hello"])
+            #expect(clipboard.transientFlags == [true, false])
+            #expect(textInjection.pasteTargets.count == 1)
+            #expect(revealCount == 0)
+        }
+
         @Test func completedCaptureSkipsClipboardWhenCopyAndPasteAreDisabled() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
@@ -211,6 +241,30 @@
             )
 
             #expect(outcome == .clipboardPending)
+            #expect(clipboard.copiedTexts.isEmpty)
+            #expect(textInjection.pasteTargets.isEmpty)
+        }
+
+        @Test func completedCaptureSkipsEmptyText() async {
+            let clipboard = TestClipboardService()
+            let textInjection = TestTextInjectionService()
+            let coordinator = MacDictationCaptureCoordinator(
+                clipboardService: clipboard,
+                textInjectionService: textInjection
+            )
+
+            let outcome = await coordinator.handleCompletedCapture(
+                text: " \n\t ",
+                targetApplication: nil,
+                settings: .init(
+                    shouldCopyToClipboard: true,
+                    shouldAutoPaste: true,
+                    shouldRevealPanelOnCapture: true
+                ),
+                showPanel: {}
+            )
+
+            #expect(outcome == .completed)
             #expect(clipboard.copiedTexts.isEmpty)
             #expect(textInjection.pasteTargets.isEmpty)
         }

--- a/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/apps/mac/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -246,7 +246,7 @@
             #expect(showPanelCount == 0)
         }
 
-        @Test func failedSelectionReplacementRequestsAccessWithoutRevealingPanel() async {
+        @Test func failedSelectionReplacementFallsBackToClipboardCopy() async {
             let textInjectionService = TestTextInjectionService()
             textInjectionService.isAvailable = false
             textInjectionService.accessState = .init(
@@ -264,9 +264,67 @@
                 showPanelCount += 1
             }
 
-            #expect(outcome == .clipboardPending)
+            #expect(outcome == .failed(.autoPastePermissionMissing))
+            #expect(subject.clipboard.copiedTexts == ["rewritten"])
             #expect(subject.textInjectionService.replacementTexts == ["rewritten"])
             #expect(subject.textInjectionService.didRequestAccessIfNeeded)
+            #expect(showPanelCount == 0)
+        }
+
+        @Test func verificationUnavailableFallsBackToClipboardWithDistinctFailure() async {
+            let textInjectionService = TestTextInjectionService()
+            textInjectionService.pasteOutcome = .eventPostedVerificationUnavailable
+            let subject = makeController(textInjectionService: textInjectionService)
+            var showPanelCount = 0
+
+            let outcome = await subject.controller.handleCompletedResult(
+                text: "hello",
+                workflow: .dictation
+            ) {
+                showPanelCount += 1
+            }
+
+            #expect(outcome == .failed(.pasteVerificationUnavailable))
+            #expect(subject.clipboard.copiedTexts == ["hello", "hello"])
+            #expect(subject.textInjectionService.pasteTargets.count == 1)
+            #expect(subject.textInjectionService.didRequestAccessIfNeeded == false)
+            #expect(showPanelCount == 0)
+        }
+
+        @Test func selectionReplacementClipboardWriteFailureSurfacesExplicitFailure() async {
+            let textInjectionService = TestTextInjectionService()
+            textInjectionService.replacementOutcome = .clipboardWriteFailed
+            let subject = makeController(textInjectionService: textInjectionService)
+            var showPanelCount = 0
+
+            let outcome = await subject.controller.handleCompletedResult(
+                text: "rewritten",
+                workflow: .rewriteFromSelection(sourceText: "hello")
+            ) {
+                showPanelCount += 1
+            }
+
+            #expect(outcome == .failed(.clipboardWriteFailed))
+            #expect(subject.textInjectionService.replacementTexts == ["rewritten"])
+            #expect(subject.textInjectionService.didRequestAccessIfNeeded == false)
+            #expect(showPanelCount == 0)
+        }
+
+        @Test func emptyCompletionTextReturnsEmptyTranscriptionFailure() async {
+            let subject = makeController()
+            var showPanelCount = 0
+
+            let outcome = await subject.controller.handleCompletedResult(
+                text: "  \n ",
+                workflow: .dictation
+            ) {
+                showPanelCount += 1
+            }
+
+            #expect(outcome == .failed(.emptyTranscription))
+            #expect(subject.clipboard.copiedTexts.isEmpty)
+            #expect(subject.textInjectionService.pasteTargets.isEmpty)
+            #expect(subject.textInjectionService.replacementTexts.isEmpty)
             #expect(showPanelCount == 0)
         }
 
@@ -297,8 +355,19 @@
         @Test func copyPendingResultToClipboardForwardsText() {
             let subject = makeController()
 
-            subject.controller.copyPendingResultToClipboard("needs-review")
+            let success = subject.controller.copyPendingResultToClipboard("needs-review")
 
+            #expect(success)
+            #expect(subject.clipboard.copiedTexts == ["needs-review"])
+        }
+
+        @Test func copyPendingResultToClipboardReturnsFailureWhenClipboardWriteFails() {
+            let subject = makeController()
+            subject.clipboard.shouldFailCopy = true
+
+            let success = subject.controller.copyPendingResultToClipboard("needs-review")
+
+            #expect(!success)
             #expect(subject.clipboard.copiedTexts == ["needs-review"])
         }
 

--- a/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/apps/mac/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -95,5 +95,112 @@
 
             #expect(await restoresOriginalClipboardEventually(pasteboard))
         }
+
+        @Test func restoreSkippedWhenClipboardChangesExternally() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            pasteboard.setString("original", forType: .string)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("temporary")
+            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+
+            pasteboard.clearContents()
+            pasteboard.setString("external-change", forType: .string)
+
+            try? await Task.sleep(for: .milliseconds(80))
+
+            #expect(pasteboard.string(forType: .string) == "external-change")
+        }
+
+        @Test func restorePreservesMultiItemPayloads() async {
+            let pasteboard = makePasteboard()
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            let item1 = NSPasteboardItem()
+            item1.setString("text1", forType: .string)
+            item1.setString("https://example.com", forType: .URL)
+
+            let item2 = NSPasteboardItem()
+            item2.setString("text2", forType: .string)
+
+            pasteboard.writeObjects([item1, item2])
+            #expect((pasteboard.pasteboardItems ?? []).count == 2)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            pasteboard.clearContents()
+            pasteboard.setString("temporary", forType: .string)
+            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+
+            #expect(
+                await TestSupport.eventually(timeout: restorationTimeout) {
+                    let items = pasteboard.pasteboardItems ?? []
+                    return items.count == 2
+                        && items[0].string(forType: .string) == "text1"
+                        && items[0].string(forType: .URL) == "https://example.com"
+                        && items[1].string(forType: .string) == "text2"
+                })
+        }
+
+        @Test func immediateRestoreOnFailureClearsPendingState() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            pasteboard.setString("original", forType: .string)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("temporary")
+            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+
+            coordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+
+            #expect(pasteboard.string(forType: .string) == "original")
+
+            clipboard.copy("after-immediate-restore")
+            try? await Task.sleep(for: .milliseconds(80))
+
+            #expect(pasteboard.string(forType: .string) == "after-immediate-restore")
+        }
+
+        @Test func restoreHandlesEmptyClipboardGracefully() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("temporary")
+            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+
+            try? await Task.sleep(for: .milliseconds(80))
+
+            #expect(pasteboard.string(forType: .string) == nil)
+            #expect((pasteboard.pasteboardItems ?? []).isEmpty)
+        }
+
+        @Test func multiplePrepareCallsPreserveFirstSnapshot() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            pasteboard.setString("original", forType: .string)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("first-temporary")
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("second-temporary")
+            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+
+            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        }
     }
 #endif

--- a/apps/mac/StetTests/Support/TestSupport.swift
+++ b/apps/mac/StetTests/Support/TestSupport.swift
@@ -124,6 +124,7 @@ final class TestSecretStore: DictationSecretStore, @unchecked Sendable {
 @MainActor
 final class TestClipboardService: ClipboardService {
     private(set) var copyOperations: [(text: String, transient: Bool)] = []
+    var shouldFailCopy = false
 
     var copiedTexts: [String] {
         copyOperations.map(\.text)
@@ -133,8 +134,10 @@ final class TestClipboardService: ClipboardService {
         copyOperations.map(\.transient)
     }
 
-    func copy(_ text: String, transient: Bool) {
+    @discardableResult
+    func copy(_ text: String, transient: Bool) -> Bool {
         copyOperations.append((text, transient))
+        return !shouldFailCopy
     }
 }
 
@@ -145,6 +148,8 @@ final class TestTextInjectionService: TextInjectionService {
     var didRequestAccessIfNeeded = false
     var didOpenAccessibilitySettings = false
     var pasteResult = true
+    var pasteOutcome: TextInjectionOutcome = .verifiedSuccess
+    var replacementOutcome: TextReplacementOutcome = .replaced
     var selectedTextValue: String?
     var accessState = TextInjectionAccessState(
         hasAccessibilityAccess: true,
@@ -165,9 +170,9 @@ final class TestTextInjectionService: TextInjectionService {
         didOpenAccessibilitySettings = true
     }
 
-    func pasteClipboard(into application: NSRunningApplication?) async -> Bool {
+    func pasteClipboard(into application: NSRunningApplication?) async -> TextInjectionOutcome {
         pasteTargets.append(application?.bundleIdentifier)
-        return pasteResult
+        return pasteResult ? pasteOutcome : .verificationFailed
     }
 
     func selectedText() -> String? {
@@ -178,10 +183,14 @@ final class TestTextInjectionService: TextInjectionService {
         _ text: String,
         into application: NSRunningApplication?,
         keepResultInClipboard: Bool
-    ) async -> Bool {
+    ) async -> TextReplacementOutcome {
         replacementTexts.append(text)
         pasteTargets.append(application?.bundleIdentifier)
-        return pasteResult
+        guard pasteResult else {
+            let failure: TextInjectionOutcome = isAvailable ? .verificationFailed : .eventPostFailed
+            return .injectionFailed(failure)
+        }
+        return replacementOutcome
     }
 }
 


### PR DESCRIPTION
## Summary
- restore the archived macOS text-output handling spec docs under `apps/mac/.kiro/specs/text-output-handling`
- reintroduce clipboard write validation, richer text-injection outcomes, and explicit output failure handling across the dictation workflow
- add focused coverage for clipboard fallback, pasteboard restoration diagnostics, and session-level pending-copy behavior

## Testing
- xcodebuild test -project apps/mac/Stet.xcodeproj -scheme Stet -destination 'platform=macOS' -only-testing:StetTests/MacDictationCaptureCoordinatorTests -only-testing:StetTests/MacDictationWorkflowControllerTests -only-testing:StetTests/MacAppSessionControllerActionTests -only-testing:StetTests/PasteboardRestoreCoordinatorTests -only-testing:StetTests/ClipboardServiceTests