### PR TITLE
Add macOS release candidate workflow

### DIFF
--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -1,0 +1,134 @@
+name: macOS Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Branch, tag, or commit SHA to build
+        required: false
+        default: main
+        type: string
+      release_tag:
+        description: Release label used to name the artifact, for example v0.1.0-rc1
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-release-candidate-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  release-candidate:
+    name: Build Signed And Notarized Release Candidate
+    runs-on: macos-26
+    environment: release-candidate
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+      ARCHIVE_CODE_SIGN_STYLE: Manual
+      ARCHIVE_PROVISIONING_PROFILE_SPECIFIER: ${{ vars.ARCHIVE_PROVISIONING_PROFILE_SPECIFIER }}
+      DEVELOPER_ID_APPLICATION: ${{ vars.DEVELOPER_ID_APPLICATION }}
+      DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+      DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+      GENERATE_SPARKLE_APPCAST: "0"
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_TAG: ${{ inputs.release_tag }}
+      NOTARY_PROFILE: stet-notary
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Set Up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Set Up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
+      - name: Show Tool Versions
+        run: |
+          xcodebuild -version
+          node --version
+          npm --version
+          gh --version
+
+      - name: Import Developer ID Certificate
+        run: |
+          CERT_PATH="$RUNNER_TEMP/developer-id-application.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/release-candidate.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          LOGIN_KEYCHAIN="$(security login-keychain -d user | tr -d '"')"
+
+          if [[ -z "$DEVELOPER_ID_APPLICATION_P12_BASE64" ]]; then
+            echo "Missing DEVELOPER_ID_APPLICATION_P12_BASE64 secret."
+            exit 1
+          fi
+
+          if [[ -z "$DEVELOPER_ID_APPLICATION_P12_PASSWORD" ]]; then
+            echo "Missing DEVELOPER_ID_APPLICATION_P12_PASSWORD secret."
+            exit 1
+          fi
+
+          echo "$DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 -D > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$DEVELOPER_ID_APPLICATION_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/productbuild \
+            -T /usr/bin/productsign \
+            -T /usr/bin/security \
+            -T /usr/bin/xcodebuild
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "$LOGIN_KEYCHAIN"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          {
+            echo "RUNNER_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+            echo "RUNNER_KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
+          } >> "$GITHUB_ENV"
+
+      - name: Store Notarytool Credentials
+        run: ./scripts/setup-notarytool-profile.sh
+
+      - name: Build Release Candidate
+        run: npm run mac:release:github
+
+      - name: Upload Release Candidate Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-candidate-${{ inputs.release_tag }}
+          path: |
+            dist/github-release/${{ inputs.release_tag }}
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Clean Up Temporary Keychain
+        if: always()
+        run: |
+          if [[ -n "${RUNNER_KEYCHAIN_PATH:-}" ]]; then
+            security delete-keychain "$RUNNER_KEYCHAIN_PATH" || true
+          fi


### PR DESCRIPTION
## Summary
- add a manual macOS release-candidate workflow
- build, sign, notarize, and upload artifacts without publishing a GitHub Release
- keep the existing CI workflow unchanged

## Notes
- this workflow is intended to be triggered manually via workflow_dispatch
- it requires the release-candidate environment secrets to be configured before the first run
