### PR TITLE
[codex] Fix text output verification timing

### DIFF
--- a/StetTests/Core/TextInput/SystemTextInjectionServiceTests.swift
+++ b/StetTests/Core/TextInput/SystemTextInjectionServiceTests.swift
@@ -1,0 +1,97 @@
+#if os(macOS)
+    import AppKit
+    import Foundation
+    import Testing
+
+    @testable import Stet
+
+    @MainActor
+    @Suite("System Text Injection Service", .serialized)
+    struct SystemTextInjectionServiceTests {
+        @Test func pasteCapturesVerificationSnapshotAfterTargetActivation() async throws {
+            let service = SystemTextInjectionService(clipboardService: TestClipboardService())
+            let targetApplication = try #require(Self.activationCandidateApplication())
+            let beforePaste = Self.makeSnapshot(
+                value: "before",
+                selectionLocation: 6,
+                numberOfCharacters: 6
+            )
+            let afterPaste = Self.makeSnapshot(
+                value: "before hello",
+                selectionLocation: 12,
+                numberOfCharacters: 12
+            )
+            var didActivateTarget = false
+            var snapshotSequence = [beforePaste, afterPaste]
+
+            let outcome = await service.performPasteClipboard(
+                into: targetApplication,
+                accessState: .init(hasAccessibilityAccess: true, hasPostEventAccess: true),
+                activateApplication: { _ in
+                    didActivateTarget = true
+                },
+                snapshotProvider: {
+                    guard didActivateTarget else { return nil }
+                    guard !snapshotSequence.isEmpty else { return afterPaste }
+                    return snapshotSequence.removeFirst()
+                },
+                simulatePasteCommand: { true },
+                sleep: { _ in },
+                activationDelay: .milliseconds(0),
+                prePasteDelay: .milliseconds(0),
+                verificationPollInterval: .milliseconds(0),
+                verificationAttempts: 1
+            )
+
+            #expect(outcome == .verifiedSuccess)
+        }
+
+        @Test func pasteVerificationRetriesBeforeFailing() async {
+            let service = SystemTextInjectionService(clipboardService: TestClipboardService())
+            let beforePaste = Self.makeSnapshot(
+                value: "before",
+                selectionLocation: 6,
+                numberOfCharacters: 6
+            )
+            let unchanged = beforePaste
+            let mutated = Self.makeSnapshot(
+                value: "before hello",
+                selectionLocation: 12,
+                numberOfCharacters: 12
+            )
+            var snapshots = [unchanged, unchanged, mutated]
+
+            let outcome = await service.verifyPasteOutcome(
+                comparedTo: beforePaste,
+                snapshotProvider: {
+                    guard !snapshots.isEmpty else { return mutated }
+                    return snapshots.removeFirst()
+                },
+                sleep: { _ in },
+                pollInterval: .milliseconds(0),
+                attempts: 3
+            )
+
+            #expect(outcome == .verifiedSuccess)
+        }
+
+        private static func makeSnapshot(
+            value: String?,
+            selectionLocation: Int,
+            numberOfCharacters: Int
+        ) -> SystemTextInjectionService.FocusedElementSnapshot {
+            .init(
+                value: value,
+                selectedText: nil,
+                selectionRange: .init(location: selectionLocation, length: 0),
+                numberOfCharacters: numberOfCharacters
+            )
+        }
+
+        private static func activationCandidateApplication() -> NSRunningApplication? {
+            NSWorkspace.shared.runningApplications.first {
+                !$0.isTerminated && $0.bundleIdentifier != Bundle.main.bundleIdentifier
+            }
+        }
+    }
+#endif

--- a/specs/006-text-output-handling/contracts/TextInjectionService.md
+++ b/specs/006-text-output-handling/contracts/TextInjectionService.md
@@ -59,11 +59,13 @@ protocol TextInjectionService {
 
 - The service MUST treat simulated input as permission-gated.
 - The service MUST distinguish verified success from unverifiable or failed paste attempts.
+- The service MUST evaluate paste verification against the target application's focused element after target-app activation has been given a chance to settle.
+- The service SHOULD use a bounded verification window rather than a single immediate metadata read when inferring paste success.
 - The service SHOULD return best-effort results when the target app does not expose enough metadata for full verification.
 - The service MUST not promise that an input field is detected ahead of time.
 - The service MUST allow callers to preserve the result in clipboard when a replacement or paste path needs recovery support.
 
 ## Notes
 
-- The concrete implementation may use accessibility focus data, simulated key events, and clipboard snapshotting to infer whether the paste or replacement succeeded.
+- The concrete implementation may use accessibility focus data, simulated key events, target-app activation, bounded verification polling, and clipboard snapshotting to infer whether the paste or replacement succeeded.
 - Those mechanics are implementation details and are not part of the public contract surface.

--- a/specs/006-text-output-handling/data-model.md
+++ b/specs/006-text-output-handling/data-model.md
@@ -32,6 +32,7 @@ Represents the resolved outcome of a text-output attempt.
 
 **Important Behavior**:
 - `completed` means the workflow no longer needs to keep the capture result in an active pending state.
+- For automatic output, `completed` means the input-injection layer observed a verifiable mutation within its bounded post-paste verification window.
 - `clipboardPending(text)` keeps the text available without claiming the output succeeded.
 
 ### TextInjectionAccessState
@@ -76,7 +77,7 @@ Represents the user-visible failure categories the output pipeline can emit.
 
 - `MacDictationWorkflowController` produces `TextOutputRequest`-like inputs for the output pipeline and consumes `TextOutputResult`.
 - `ClipboardService` writes the textual payload that the workflow wants to preserve or deliver.
-- `TextInjectionService` uses `TextInjectionAccessState` to decide whether the system can attempt input simulation.
+- `TextInjectionService` uses `TextInjectionAccessState` to decide whether the system can attempt input simulation, reactivates the target app before taking its verification baseline, and classifies paste success or failure after a bounded metadata-polling window.
 - `PasteboardRestoreCoordinator` keeps a best-effort `ClipboardSnapshot` so temporary overrides can be restored after a successful injection.
 - `MacAppSessionController` turns `TextOutputResult` into the visible dictation panel state.
 
@@ -86,11 +87,16 @@ Represents the user-visible failure categories the output pipeline can emit.
 
 ```text
 pending text
+  -> target app activated
+  -> pre-paste focus snapshot
   -> attempt clipboard write
   -> attempt text injection
+  -> bounded verification polling
   -> completed
 
 pending text
+  -> target app activated
+  -> pre-paste focus snapshot
   -> clipboard write succeeds
   -> injection unavailable or unverified
   -> clipboard-pending or failure state with recovered text preserved

--- a/specs/006-text-output-handling/plan.md
+++ b/specs/006-text-output-handling/plan.md
@@ -5,9 +5,9 @@
 
 ## Summary
 
-This plan documents the current design of Stet's macOS text output handling flow. The feature delivers recognized text through the existing dictation and rewrite workflows, uses clipboard-backed automatic output, verifies whether paste succeeded, and falls back to clipboard-preserved recovery when automatic output is unavailable or unverified.
+This plan documents the current design of Stet's macOS text output handling flow. The feature delivers recognized text through the existing dictation and rewrite workflows, uses clipboard-backed automatic output, activates the target app before collecting verification metadata, verifies whether paste succeeded through bounded post-paste polling, and falls back to clipboard-preserved recovery when automatic output is unavailable or unverified.
 
-This is a documentation pass, not an implementation pass. The purpose of the plan is to explain how the current codebase is structured so that `spec.md`, `data-model.md`, and `contracts/` stay aligned with the implementation that currently ships in this branch.
+This is a documentation-alignment pass. The purpose of the plan is to explain how the current codebase is structured so that `spec.md`, `data-model.md`, and `contracts/` stay aligned with the implementation that currently ships in this branch.
 
 ## Technical Context
 
@@ -31,7 +31,7 @@ This is a documentation pass, not an implementation pass. The purpose of the pla
 **Performance Goals**: Output should feel immediate to the user, and clipboard restoration should remain best effort without blocking the main interaction flow  
 **Constraints**:
 - Documentation must reflect the current implementation exactly
-- No code changes are part of this documentation pass
+- This document describes the implementation that exists in the branch; it is not proposing a separate task list or future redesign
 - Current implementation takes precedence over the legacy `.kiro` draft when they differ
 - `plan.md` must describe design, not a task list
 
@@ -96,6 +96,9 @@ StetTests/App/Workflows/
 StetTests/Core/Clipboard/
 ├── ClipboardServiceTests.swift
 └── PasteboardRestoreCoordinatorTests.swift
+
+StetTests/Core/TextInput/
+└── SystemTextInjectionServiceTests.swift
 ```
 
 **Structure Decision**: The documentation for this feature lives entirely under `specs/006-text-output-handling/`, and the source references are the existing workflow, clipboard, input-injection, and UI-state files that already implement the feature.
@@ -124,9 +127,13 @@ Dictation completion and rewrite-from-selection both flow through the same clipb
 
 The current implementation distinguishes clipboard write failure, missing input-control permission, paste-verification unavailable, and paste-verification failed. That classification is important to preserve in the docs because the UI can show different recovery guidance depending on which branch occurred.
 
-### 6. TextInjectionService Coverage Is Indirect
+### 6. Paste Verification Is Evaluated Against the Reactivated Target App
 
-The current branch does not include a dedicated `TextInjectionService` test file. Its behavior is exercised indirectly through the workflow and capture coordinator tests, so the documentation should avoid claiming a deeper unit-test coverage level than the repository currently provides.
+The current implementation does not capture the verification baseline from whichever app happens to be frontmost when the workflow finishes. Instead, `TextInjectionService` reactivates the target application, waits briefly for focus to settle, collects the focused-element snapshot, posts the paste event, and then polls focused-element metadata for a bounded interval before deciding whether the paste was verified.
+
+### 7. TextInjectionService Coverage Is Both Direct and Indirect
+
+The current branch now includes a dedicated `SystemTextInjectionServiceTests.swift` file for paste-verification timing and activation ordering, while the workflow and capture coordinator tests continue to exercise the same behavior indirectly through the higher-level output paths.
 
 ## Complexity Tracking
 

--- a/specs/006-text-output-handling/spec.md
+++ b/specs/006-text-output-handling/spec.md
@@ -19,6 +19,7 @@ As a user, when dictation or rewrite completes, I want the resulting text delive
 
 1. **Given** a supported target app is captured for the workflow, **When** the text output flow completes successfully, **Then** the text appears in that target app and the workflow completes.
 2. **Given** the output flow can verify the paste, **When** the paste succeeds, **Then** the system treats the output as completed rather than pending.
+3. **Given** the target app updates its focus metadata slightly after the paste event is posted, **When** the bounded verification window still observes the mutation, **Then** the system treats the output as completed rather than falling back to clipboard-pending recovery.
 
 ---
 
@@ -82,6 +83,7 @@ As a user, when transcription produces no usable text, I want the system to avoi
 ### Edge Cases
 
 - What happens when automatic text injection is unavailable because the system lacks input-control permissions?
+- What happens when the target app's focus metadata updates slightly after the paste event is posted?
 - What happens when the target app does not expose enough focus metadata to verify a paste?
 - What happens when clipboard writing fails during the fallback path?
 - What happens when the clipboard changes externally before a delayed restore runs?
@@ -92,7 +94,7 @@ As a user, when transcription produces no usable text, I want the system to avoi
 ### Functional Requirements
 
 - **FR-001**: The system MUST deliver completed dictation and rewrite text through the current output workflow without requiring manual paste when automatic output is enabled by the workflow.
-- **FR-002**: The system MUST attempt text injection into the workflow target app and MUST treat the result as unconfirmed unless the available focus metadata indicates success.
+- **FR-002**: The system MUST attempt text injection into the workflow target app, MUST verify against the reactivated target app's available focus metadata within a bounded post-paste window, and MUST treat the result as unconfirmed unless that metadata indicates success.
 - **FR-003**: The system MUST preserve the text in clipboard when automatic text injection cannot proceed because required permissions are missing.
 - **FR-004**: The system MUST preserve the text in clipboard when injection fails or cannot be verified, and MUST surface a distinct output failure state for that condition.
 - **FR-005**: The system MUST use best-effort clipboard restoration when automatic output temporarily overrides clipboard contents.

--- a/stet/Core/TextInput/TextInjectionService.swift
+++ b/stet/Core/TextInput/TextInjectionService.swift
@@ -61,12 +61,12 @@
             static let paste: CGKeyCode = 9
         }
 
-        private struct SelectionRange: Equatable {
+        struct SelectionRange: Equatable {
             let location: Int
             let length: Int
         }
 
-        private struct FocusedElementSnapshot: Equatable {
+        struct FocusedElementSnapshot: Equatable {
             let value: String?
             let selectedText: String?
             let selectionRange: SelectionRange?
@@ -158,37 +158,22 @@
         }
 
         func pasteClipboard(into application: NSRunningApplication?) async -> TextInjectionOutcome {
-            guard accessState.canSimulateInput else {
-                return .eventPostFailed
-            }
-
-            let snapshotBeforePaste = focusedElementSnapshot()
-
-            if let application,
-                !application.isTerminated,
-                application.bundleIdentifier != Bundle.main.bundleIdentifier
-            {
-                _ = application.activate()
-                try? await Task.sleep(for: .milliseconds(180))
-            }
-
-            try? await Task.sleep(for: .milliseconds(60))
-            guard simulateCommandKey(KeyCode.paste) else {
-                return .eventPostFailed
-            }
-
-            guard let snapshotBeforePaste, snapshotBeforePaste.canVerifyPaste else {
-                return .eventPostedVerificationUnavailable
-            }
-
-            try? await Task.sleep(for: .milliseconds(180))
-
-            guard let snapshotAfterPaste = focusedElementSnapshot() else {
-                return .eventPostedVerificationUnavailable
-            }
-
-            return snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste)
-                ? .verifiedSuccess : .verificationFailed
+            await performPasteClipboard(
+                into: application,
+                accessState: accessState,
+                activateApplication: { application in
+                    _ = application.activate()
+                },
+                snapshotProvider: { [weak self] in
+                    self?.focusedElementSnapshot()
+                },
+                simulatePasteCommand: { [weak self] in
+                    self?.simulateCommandKey(KeyCode.paste) ?? false
+                },
+                sleep: { duration in
+                    try? await Task.sleep(for: duration)
+                }
+            )
         }
 
         func selectedText() -> String? {
@@ -326,6 +311,84 @@
             keyDown.post(tap: .cghidEventTap)
             keyUp.post(tap: .cghidEventTap)
             return true
+        }
+
+        func performPasteClipboard(
+            into application: NSRunningApplication?,
+            accessState: TextInjectionAccessState,
+            activateApplication: @MainActor (NSRunningApplication) -> Void,
+            snapshotProvider: @MainActor () -> FocusedElementSnapshot?,
+            simulatePasteCommand: @MainActor () -> Bool,
+            sleep: @escaping @Sendable (Duration) async -> Void,
+            activationDelay: Duration = .milliseconds(180),
+            prePasteDelay: Duration = .milliseconds(60),
+            verificationPollInterval: Duration = .milliseconds(120),
+            verificationAttempts: Int = 4
+        ) async -> TextInjectionOutcome {
+            guard accessState.canSimulateInput else {
+                return .eventPostFailed
+            }
+
+            if let application,
+                !application.isTerminated,
+                application.bundleIdentifier != Bundle.main.bundleIdentifier
+            {
+                activateApplication(application)
+                await sleep(activationDelay)
+            }
+
+            await sleep(prePasteDelay)
+            let snapshotBeforePaste = snapshotProvider()
+
+            guard simulatePasteCommand() else {
+                return .eventPostFailed
+            }
+
+            guard let snapshotBeforePaste, snapshotBeforePaste.canVerifyPaste else {
+                return .eventPostedVerificationUnavailable
+            }
+
+            return await verifyPasteOutcome(
+                comparedTo: snapshotBeforePaste,
+                snapshotProvider: snapshotProvider,
+                sleep: sleep,
+                pollInterval: verificationPollInterval,
+                attempts: verificationAttempts
+            )
+        }
+
+        func verifyPasteOutcome(
+            comparedTo snapshotBeforePaste: FocusedElementSnapshot,
+            snapshotProvider: @MainActor () -> FocusedElementSnapshot?,
+            sleep: @escaping @Sendable (Duration) async -> Void,
+            pollInterval: Duration = .milliseconds(120),
+            attempts: Int = 4
+        ) async -> TextInjectionOutcome {
+            guard snapshotBeforePaste.canVerifyPaste else {
+                return .eventPostedVerificationUnavailable
+            }
+
+            let retryCount = max(1, attempts)
+            var observedVerifiableSnapshot = false
+
+            for _ in 0..<retryCount {
+                await sleep(pollInterval)
+
+                guard let snapshotAfterPaste = snapshotProvider() else {
+                    continue
+                }
+
+                observedVerifiableSnapshot =
+                    observedVerifiableSnapshot || snapshotAfterPaste.canVerifyPaste
+
+                if snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste) {
+                    return .verifiedSuccess
+                }
+            }
+
+            return observedVerifiableSnapshot
+                ? .verificationFailed
+                : .eventPostedVerificationUnavailable
         }
 
         private func focusedElementSnapshot() -> FocusedElementSnapshot? {

--- a/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
+++ b/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
@@ -8,6 +8,10 @@
 
         @State private var contentVisible = false
 
+        private var surfaceShape: RoundedRectangle {
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+        }
+
         var body: some View {
             VStack(spacing: 8) {
                 Text(text)
@@ -37,10 +41,7 @@
                 .buttonStyle(.plain)
             }
             .frame(width: layout.panelSize.width, height: layout.panelSize.height, alignment: .center)
-            .background {
-                RoundedRectangle(cornerRadius: 28, style: .continuous)
-                    .glassEffect(.regular)
-            }
+            .glassEffect(in: surfaceShape)
             .opacity(contentVisible ? 1 : 0)
             .offset(y: contentVisible ? 0 : 8)
             .scaleEffect(contentVisible ? 1 : 0.985)

--- a/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
+++ b/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
@@ -38,13 +38,8 @@
             }
             .frame(width: layout.panelSize.width, height: layout.panelSize.height, alignment: .center)
             .background {
-                RoundedRectangle(cornerRadius: 30, style: .continuous)
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
                     .glassEffect(.regular)
-                    .shadow(
-                        color: .black.opacity(0.22),
-                        radius: 18,
-                        y: 10
-                    )
             }
             .opacity(contentVisible ? 1 : 0)
             .offset(y: contentVisible ? 0 : 8)


### PR DESCRIPTION
## Summary
- fix macOS text output verification so paste success is measured against the reactivated target app instead of a stale pre-activation snapshot
- add bounded post-paste polling to avoid falling back to clipboard recovery when the target app updates accessibility metadata slightly later
- align the `006-text-output-handling` spec, plan, data model, and `TextInjectionService` contract with the current implementation

## Root Cause
The text injection path could capture its verification baseline before the target app had been reactivated and only checked for metadata mutation once after posting the paste event. In practice this could misclassify a successful paste as unverified, which surfaced the clipboard-pending animation even though the text had already been inserted.

## Impact
- reduces false clipboard fallback UI after successful automatic text output
- keeps the existing fallback path for genuinely unverifiable or failed paste attempts
- documents the current verification behavior so the `006` feature docs match the shipping branch

## Validation
- `xcodebuild test -project Stet.xcodeproj -scheme Stet -destination 'platform=macOS' -only-testing:StetTests/SystemTextInjectionServiceTests -only-testing:StetTests/MacDictationCaptureCoordinatorTests -only-testing:StetTests/MacDictationWorkflowControllerTests`
- `xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' build`
