### PR TITLE
Handle VS Code paste verification blind spots

### DIFF
--- a/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -184,7 +184,8 @@
             let dictationViewModel = DictationViewModel(speechService: speechService)
             let captureCoordinator = MacDictationCaptureCoordinator(
                 clipboardService: clipboardService,
-                textInjectionService: textInjectionService
+                textInjectionService: textInjectionService,
+                frontmostBundleIdentifierProvider: { nil }
             )
             let workflow = MacDictationWorkflowController(
                 dictationViewModel: dictationViewModel,
@@ -315,6 +316,65 @@
                 })
             #expect(subject.clipboardService.copiedTexts == ["transcript", "transcript"])
             #expect(subject.shell.isPanelVisible)
+        }
+
+        @Test func vsCodeVerificationUnavailableCompletesWithoutClipboardPendingSurface() async {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set(true, forKey: MacPreferences.onboardingCompleted)
+            defaults.set(false, forKey: MacPreferences.interactionSoundsEnabled)
+            let speechService = ControllableSpeechService()
+            let textInjectionService = TestTextInjectionService()
+            textInjectionService.pasteOutcome = .eventPostedVerificationUnavailable
+            let clipboardService = TestClipboardService()
+            let mediaPlaybackController = FakeMediaPlaybackController()
+            let settingsStore = DictationSettingsStore(
+                defaults: defaults,
+                secretStore: TestSecretStore()
+            )
+            let dictationViewModel = DictationViewModel(speechService: speechService)
+            let captureCoordinator = MacDictationCaptureCoordinator(
+                clipboardService: clipboardService,
+                textInjectionService: textInjectionService,
+                frontmostBundleIdentifierProvider: { "com.microsoft.VSCode" }
+            )
+            let workflow = MacDictationWorkflowController(
+                dictationViewModel: dictationViewModel,
+                captureCoordinator: captureCoordinator,
+                mediaPlaybackController: mediaPlaybackController,
+                settingsStore: settingsStore,
+                interactionSoundPlayer: InteractionSoundPlayer(),
+                mediaResumeDelay: .zero
+            )
+            let permissionManager = MacPermissionManager(textInjectionService: textInjectionService)
+            let shell = FakeShellPresenter()
+            let permissionGate = FakePermissionGatePresenter()
+            let hotkeyRegistrar = FakeHotkeyRegistrar()
+            let appBranchMonitor = AppBranchMonitor(
+                workspace: TestAppBranchWorkspace(),
+                callbackQueue: DispatchQueue(label: "com.stet.tests.sessioncontroller.action.appbranch")
+            )
+
+            let session = MacAppSessionController(
+                workflowController: workflow,
+                shellPresentationController: shell,
+                permissionGateController: permissionGate,
+                permissionManager: permissionManager,
+                appBranchMonitor: appBranchMonitor,
+                hotkeyRegistrar: hotkeyRegistrar
+            )
+            let presentationModel = FakePresentationModel()
+            session.activate(presentationModel: presentationModel, showInDock: false)
+
+            workflow.dictationViewModel.send(.transcriptionSucceeded("transcript"))
+
+            #expect(
+                await TestSupport.eventually {
+                    workflow.dictationViewModel.state == .idle
+                })
+            #expect(clipboardService.copiedTexts == ["transcript"])
+            #expect(textInjectionService.didRequestAccessIfNeeded == false)
+            #expect(shell.isPanelVisible == false)
+            #expect(shell.showTransientPanelCallCount == 0)
         }
     }
 

--- a/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
+++ b/StetTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
@@ -147,7 +147,8 @@
             let clipboardService = TestClipboardService()
             let captureCoordinator = MacDictationCaptureCoordinator(
                 clipboardService: clipboardService,
-                textInjectionService: textInjectionService
+                textInjectionService: textInjectionService,
+                frontmostBundleIdentifierProvider: { nil }
             )
             let settingsStore = DictationSettingsStore(
                 defaults: defaults,

--- a/StetTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/StetTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -7,13 +7,22 @@
     @MainActor
     @Suite("Mac Dictation Capture Coordinator", .serialized)
     struct MacDictationCaptureCoordinatorTests {
+        private func makeCoordinator(
+            clipboard: TestClipboardService,
+            textInjection: TestTextInjectionService,
+            frontmostBundleIdentifier: String? = nil
+        ) -> MacDictationCaptureCoordinator {
+            MacDictationCaptureCoordinator(
+                clipboardService: clipboard,
+                textInjectionService: textInjection,
+                frontmostBundleIdentifierProvider: { frontmostBundleIdentifier }
+            )
+        }
+
         @Test func completedCaptureCopiesTextWithoutAutoPaste() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
 
             let outcome = await coordinator.handleCompletedCapture(
                 text: "hello",
@@ -36,10 +45,7 @@
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
             textInjection.pasteResult = true
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -64,10 +70,7 @@
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
             textInjection.pasteResult = true
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -96,10 +99,7 @@
             let textInjection = TestTextInjectionService()
             textInjection.isAvailable = false
             textInjection.pasteResult = false
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -129,10 +129,7 @@
                 hasPostEventAccess: false
             )
             textInjection.pasteResult = false
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -156,10 +153,7 @@
         @Test func completedCaptureRevealsPanelWhenAutoPasteDisabled() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -182,10 +176,7 @@
         @Test func copyToClipboardCopiesText() {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
 
             coordinator.copyToClipboard("snippet")
 
@@ -197,10 +188,7 @@
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
             textInjection.pasteOutcome = .eventPostedVerificationUnavailable
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
             var revealCount = 0
 
             let outcome = await coordinator.handleCompletedCapture(
@@ -221,13 +209,65 @@
             #expect(revealCount == 0)
         }
 
+        @Test func vsCodeVerificationUnavailableCompletesWithoutFallbackOrPanel() async {
+            let clipboard = TestClipboardService()
+            let textInjection = TestTextInjectionService()
+            textInjection.pasteOutcome = .eventPostedVerificationUnavailable
+            let coordinator = makeCoordinator(
+                clipboard: clipboard,
+                textInjection: textInjection,
+                frontmostBundleIdentifier: "com.microsoft.VSCode"
+            )
+            var revealCount = 0
+
+            let outcome = await coordinator.handleCompletedCapture(
+                text: "hello",
+                targetApplication: nil,
+                settings: .init(
+                    shouldCopyToClipboard: false,
+                    shouldAutoPaste: true,
+                    shouldRevealPanelOnCapture: true
+                ),
+                showPanel: { revealCount += 1 }
+            )
+
+            #expect(outcome == .completed)
+            #expect(clipboard.copiedTexts == ["hello"])
+            #expect(clipboard.transientFlags == [true])
+            #expect(textInjection.pasteTargets.count == 1)
+            #expect(textInjection.didRequestAccessIfNeeded == false)
+            #expect(revealCount == 0)
+        }
+
+        @Test func verificationUnavailableRequestsMissingAccessibilityAccess() async {
+            let clipboard = TestClipboardService()
+            let textInjection = TestTextInjectionService()
+            textInjection.accessState = .init(
+                hasAccessibilityAccess: false,
+                hasPostEventAccess: true
+            )
+            textInjection.pasteOutcome = .eventPostedVerificationUnavailable
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
+
+            let outcome = await coordinator.handleCompletedCapture(
+                text: "hello",
+                targetApplication: nil,
+                settings: .init(
+                    shouldCopyToClipboard: false,
+                    shouldAutoPaste: true,
+                    shouldRevealPanelOnCapture: false
+                ),
+                showPanel: {}
+            )
+
+            #expect(outcome == .failed(.pasteVerificationUnavailable))
+            #expect(textInjection.didRequestAccessIfNeeded)
+        }
+
         @Test func completedCaptureSkipsClipboardWhenCopyAndPasteAreDisabled() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
 
             let outcome = await coordinator.handleCompletedCapture(
                 text: "hello",
@@ -248,10 +288,7 @@
         @Test func completedCaptureSkipsEmptyText() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()
-            let coordinator = MacDictationCaptureCoordinator(
-                clipboardService: clipboard,
-                textInjectionService: textInjection
-            )
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
 
             let outcome = await coordinator.handleCompletedCapture(
                 text: " \n\t ",

--- a/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/StetTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -86,6 +86,7 @@
             mediaPlaybackController: TestMediaPlaybackController? = nil,
             systemAudioMuting: TestSystemAudioMuting? = nil,
             interactionSoundPlayer: TestInteractionSoundPlayer? = nil,
+            frontmostBundleIdentifier: String? = nil,
             mediaResumeDelay: Duration = .zero
         ) -> (
             controller: MacDictationWorkflowController,
@@ -116,7 +117,8 @@
             let clipboard = TestClipboardService()
             let captureCoordinator = MacDictationCaptureCoordinator(
                 clipboardService: clipboard,
-                textInjectionService: textInjectionService
+                textInjectionService: textInjectionService,
+                frontmostBundleIdentifierProvider: { frontmostBundleIdentifier }
             )
 
             let controller = MacDictationWorkflowController(

--- a/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/StetTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -58,6 +58,49 @@
             #expect(pasteboard.string(forType: .string) == "user-copy")
         }
 
+        @Test func delayOverrideKeepsTemporaryClipboardUntilOverrideExpires() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            pasteboard.setString("original", forType: .string)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("temporary")
+            coordinator.scheduleRestoreIfNeeded(
+                on: pasteboard,
+                delayOverride: .milliseconds(120)
+            )
+
+            try? await Task.sleep(for: .milliseconds(70))
+            #expect(pasteboard.string(forType: .string) == "temporary")
+            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        }
+
+        @Test func delayOverrideStillSkipsRestoreAfterExternalClipboardChange() async {
+            let pasteboard = makePasteboard()
+            let clipboard = SystemClipboardService(pasteboard: pasteboard)
+            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
+
+            pasteboard.clearContents()
+            pasteboard.setString("original", forType: .string)
+
+            coordinator.prepareForTemporaryOverride(on: pasteboard)
+            clipboard.copy("temporary")
+            coordinator.scheduleRestoreIfNeeded(
+                on: pasteboard,
+                delayOverride: .milliseconds(120)
+            )
+
+            try? await Task.sleep(for: .milliseconds(60))
+            clipboard.copy("user-copy")
+
+            try? await Task.sleep(for: .milliseconds(100))
+
+            #expect(pasteboard.string(forType: .string) == "user-copy")
+        }
+
         @Test func discardPendingRestoreKeepsLatestClipboardValue() async {
             let pasteboard = makePasteboard()
             let clipboard = SystemClipboardService(pasteboard: pasteboard)

--- a/StetTests/Core/TextInput/SystemTextInjectionServiceTests.swift
+++ b/StetTests/Core/TextInput/SystemTextInjectionServiceTests.swift
@@ -75,6 +75,57 @@
             #expect(outcome == .verifiedSuccess)
         }
 
+        @Test func pasteWaitsForVerifiableBaselineBeforeDeclaringVerificationUnavailable() async {
+            let service = SystemTextInjectionService(clipboardService: TestClipboardService())
+            let beforePaste = Self.makeSnapshot(
+                value: "before",
+                selectionLocation: 6,
+                numberOfCharacters: 6
+            )
+            let afterPaste = Self.makeSnapshot(
+                value: "before hello",
+                selectionLocation: 12,
+                numberOfCharacters: 12
+            )
+            var didSimulatePaste = false
+            var prePasteSnapshots: [SystemTextInjectionService.FocusedElementSnapshot?] = [
+                nil,
+                nil,
+                beforePaste,
+            ]
+            var postPasteSnapshots: [SystemTextInjectionService.FocusedElementSnapshot?] = [
+                afterPaste
+            ]
+
+            let outcome = await service.performPasteClipboard(
+                into: nil,
+                accessState: .init(hasAccessibilityAccess: true, hasPostEventAccess: true),
+                activateApplication: { _ in },
+                snapshotProvider: {
+                    if didSimulatePaste {
+                        guard !postPasteSnapshots.isEmpty else { return afterPaste }
+                        return postPasteSnapshots.removeFirst()
+                    }
+
+                    guard !prePasteSnapshots.isEmpty else { return beforePaste }
+                    return prePasteSnapshots.removeFirst()
+                },
+                simulatePasteCommand: {
+                    didSimulatePaste = true
+                    return true
+                },
+                sleep: { _ in },
+                activationDelay: .milliseconds(0),
+                prePasteDelay: .milliseconds(0),
+                verificationBaselinePollInterval: .milliseconds(0),
+                verificationBaselineAttempts: 3,
+                verificationPollInterval: .milliseconds(0),
+                verificationAttempts: 1
+            )
+
+            #expect(outcome == .verifiedSuccess)
+        }
+
         private static func makeSnapshot(
             value: String?,
             selectionLocation: Int,

--- a/StetTests/Support/TestSupport.swift
+++ b/StetTests/Support/TestSupport.swift
@@ -163,7 +163,7 @@ final class TestTextInjectionService: TextInjectionService {
     }
 
     func requestAccessIfNeeded() {
-        didRequestAccessIfNeeded = true
+        didRequestAccessIfNeeded = !isAvailable || !accessState.hasAccessibilityAccess
     }
 
     func openAccessibilitySettings() {

--- a/specs/006-text-output-handling/plan.md
+++ b/specs/006-text-output-handling/plan.md
@@ -7,7 +7,7 @@
 
 This plan documents the current design of Stet's macOS text output handling flow. The feature delivers recognized text through the existing dictation and rewrite workflows, uses clipboard-backed automatic output, activates the target app before collecting verification metadata, verifies whether paste succeeded through bounded post-paste polling, and falls back to clipboard-preserved recovery when automatic output is unavailable or unverified.
 
-This is a documentation-alignment pass. The purpose of the plan is to explain how the current codebase is structured so that `spec.md`, `data-model.md`, and `contracts/` stay aligned with the implementation that currently ships in this branch.
+This plan remains grounded in the current implementation, but it now also records the approved scoped design addition needed to align the feature with the updated spec: explicit optimistic delivery for verification-blind target apps. The first implementation pass is intentionally narrow and is limited to VS Code rather than a generic unverifiable-success policy.
 
 ## Technical Context
 
@@ -34,6 +34,9 @@ This is a documentation-alignment pass. The purpose of the plan is to explain ho
 - This document describes the implementation that exists in the branch; it is not proposing a separate task list or future redesign
 - Current implementation takes precedence over the legacy `.kiro` draft when they differ
 - `plan.md` must describe design, not a task list
+- The approved design delta must stay inside the explicit optimistic-delivery scope defined by `spec.md`
+- The first implementation pass must be limited to `com.microsoft.VSCode`
+- No editor extension, no global "verification unavailable means success" rule, and no unrelated output-flow cleanup are in scope
 
 ## Constitution Check
 
@@ -134,6 +137,92 @@ The current implementation does not capture the verification baseline from which
 ### 7. TextInjectionService Coverage Is Both Direct and Indirect
 
 The current branch now includes a dedicated `SystemTextInjectionServiceTests.swift` file for paste-verification timing and activation ordering, while the workflow and capture coordinator tests continue to exercise the same behavior indirectly through the higher-level output paths.
+
+## Scoped Design Addition
+
+The following design addition is intentionally incremental. It does not replace the current implementation notes above; it defines the smallest approved change needed to eliminate false clipboard-recovery UI in VS Code without broadening the feature beyond the newly approved spec.
+
+### 1. Product Goal
+
+When Stet posts `Cmd+V` successfully into VS Code but cannot verify the paste through accessibility metadata, the product should avoid surfacing `clipboardPending` or other failure UI immediately. At the same time, it must avoid silent text loss if the paste did not actually land.
+
+### 2. Design Boundary
+
+- The optimistic-delivery path applies only to explicitly profiled target apps.
+- The first implementation pass includes only `com.microsoft.VSCode`.
+- Non-profiled apps keep the current behavior exactly: unverifiable paste remains a failure that preserves text in clipboard and surfaces recovery UI.
+- No changes are proposed to rewrite-specific selection replacement semantics beyond the shared output path behavior.
+
+### 3. Output Decision Model
+
+The existing `TextInjectionOutcome` contract remains in place. In particular, `.eventPostedVerificationUnavailable` continues to mean that the paste event was posted but the generic verification path could not confirm success.
+
+The approved design change happens in the workflow layer:
+
+1. Resolve an internal `TargetAppOutputProfile` from the workflow's `targetApplication` when available.
+2. If the workflow has no explicit target app, fall back to the frontmost application observed immediately before the paste attempt.
+3. If the resolved profile is `optimisticVerificationBlind` and the injection result is `.eventPostedVerificationUnavailable`, treat the output as an optimistic completion rather than a visible failure.
+4. If the profile is absent, preserve the current fallback and failure behavior.
+
+This keeps the `TextInjectionService` contract stable while containing app-specific policy in the output workflow.
+
+### 4. Clipboard Recovery Window
+
+The optimistic-delivery path does not introduce a new UI state. Instead, it changes clipboard timing:
+
+- Stet still writes the result into the clipboard before posting `Cmd+V`.
+- On the optimistic-delivery path, it does not immediately restore the user's previous clipboard contents.
+- Instead, it keeps the delivered text recoverable in clipboard for a short recovery window of 10 seconds.
+- After that window, the existing best-effort restore logic runs and restores the original clipboard only if the clipboard has not changed externally.
+
+This is the main mitigation against the false-success risk. If VS Code failed to accept the paste, the user can still paste manually during the recovery window.
+
+### 5. Component-Level Design
+
+#### `Stet/Core/TextInput/TextInjectionService.swift`
+
+- Keep the public `TextInjectionOutcome` contract unchanged.
+- Continue bounded verification polling for all apps.
+- Continue returning `.eventPostedVerificationUnavailable` when the paste event is posted but the focused-element baseline or follow-up snapshots are unavailable.
+- No VS Code-specific policy should be embedded here.
+
+#### `Stet/App/Workflows/MacDictationCaptureCoordinator.swift`
+
+- Add the internal target-app profile resolution step before interpreting the paste result.
+- Reclassify `.eventPostedVerificationUnavailable` as completed only when the resolved target-app profile is optimistic-verification-blind.
+- Skip fallback clipboard copy and skip visible failure/panel behavior for that profiled path.
+- Request permission remediation only for the existing missing-permission path, not for the profiled optimistic case.
+
+#### `Stet/Core/Clipboard/PasteboardRestoreCoordinator.swift`
+
+- Extend restore scheduling so the output workflow can request a longer restore delay for the optimistic-delivery path.
+- Reuse the existing snapshot-match guard so delayed restoration still avoids overwriting newer clipboard content.
+
+#### `Stet/App/Workflows/MacAppSessionController.swift`
+
+- No new session or panel states are required.
+- The session controller should continue mapping `completed`, `clipboardPending`, and `failed` exactly as it does now.
+- The feature change should therefore be expressed by producing `completed` more selectively in the capture coordinator, not by introducing a new panel state.
+
+### 6. Validation Scope
+
+Automated coverage should focus on four behaviors:
+
+- VS Code profile: `.eventPostedVerificationUnavailable` resolves to completed and does not surface `clipboardPending`
+- VS Code profile: the clipboard result remains recoverable during the 10-second recovery window
+- Generic app path: `.eventPostedVerificationUnavailable` still falls back to clipboard-preserved recovery
+- Clipboard restore path: delayed restore still respects external clipboard changes
+
+Manual validation should confirm the intended UX in both VS Code and a non-profiled app such as TextEdit so the scope boundary is visible in product behavior.
+
+### 7. Risks and Mitigations
+
+- **Risk**: VS Code paste truly fails and the product does not surface recovery UI.
+  **Mitigation**: limit the optimistic path to the explicit VS Code profile, require a successfully posted paste event, and keep the transcript recoverable in clipboard for 10 seconds.
+- **Risk**: The delayed restore window overwrites newer clipboard data.
+  **Mitigation**: retain the existing snapshot-match guard in `PasteboardRestoreCoordinator`.
+- **Risk**: The feature expands into a general app-profile system.
+  **Mitigation**: keep the first pass to a single explicit bundle identifier and avoid generalized routing or user-facing configuration.
 
 ## Complexity Tracking
 

--- a/specs/006-text-output-handling/spec.md
+++ b/specs/006-text-output-handling/spec.md
@@ -23,7 +23,23 @@ As a user, when dictation or rewrite completes, I want the resulting text delive
 
 ---
 
-### User Story 2 - Preserve text when automatic output cannot complete (Priority: P1)
+### User Story 2 - Avoid false recovery UI in verification-blind apps (Priority: P1)
+
+As a user, when I dictate into a target app that accepts paste input but does not reliably expose verifiable focus metadata, I want Stet to avoid interrupting me with clipboard recovery UI if the paste likely already succeeded.
+
+**Why this priority**: False failure UI breaks trust in the product during common editor workflows and creates unnecessary recovery friction even when delivery likely succeeded.
+
+**Independent Test**: Complete automatic output in a profiled target app with unreliable verification metadata and verify that successful paste posting does not surface clipboard-pending UI while the text remains briefly recoverable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the target app is on an explicit optimistic-delivery profile because it frequently accepts paste input without exposing verifiable focus metadata, **When** Stet posts the paste command successfully and no contradictory failure signal is observed, **Then** Stet treats the output as completed rather than immediately surfacing clipboard-pending UI.
+2. **Given** Stet resolves output through this optimistic-delivery path, **When** the user manually pastes within the short recovery window, **Then** the delivered text is still available from clipboard.
+3. **Given** the short recovery window expires without external clipboard changes, **When** the restore attempt runs, **Then** the user's prior clipboard content is restored on a best-effort basis.
+
+---
+
+### User Story 3 - Preserve text when automatic output cannot complete (Priority: P1)
 
 As a user, when the system cannot complete automatic text injection, I want the text preserved in clipboard so I can recover it without re-dictating.
 
@@ -34,11 +50,11 @@ As a user, when the system cannot complete automatic text injection, I want the 
 **Acceptance Scenarios**:
 
 1. **Given** automatic text injection is unavailable because required permissions are missing, **When** the workflow completes, **Then** the text remains in clipboard and the workflow surfaces a permission-related failure.
-2. **Given** the system cannot verify that the paste succeeded, **When** output is handled, **Then** the text remains in clipboard and the workflow surfaces a distinct verification failure.
+2. **Given** the system cannot verify that the paste succeeded in a target app that is not on an optimistic-delivery profile, **When** output is handled, **Then** the text remains in clipboard and the workflow surfaces a distinct verification failure.
 
 ---
 
-### User Story 3 - Replace selected text during rewrite workflows (Priority: P2)
+### User Story 4 - Replace selected text during rewrite workflows (Priority: P2)
 
 As a user, when I rewrite selected text, I want the selection replaced with the rewritten result so I can keep editing in place.
 
@@ -53,7 +69,7 @@ As a user, when I rewrite selected text, I want the selection replaced with the 
 
 ---
 
-### User Story 4 - Restore the original clipboard after temporary output (Priority: P2)
+### User Story 5 - Restore the original clipboard after temporary output (Priority: P2)
 
 As a user, when the system uses clipboard as a temporary bridge for automatic output, I want my previous clipboard content restored on success.
 
@@ -68,7 +84,7 @@ As a user, when the system uses clipboard as a temporary bridge for automatic ou
 
 ---
 
-### User Story 5 - Ignore empty output (Priority: P3)
+### User Story 6 - Ignore empty output (Priority: P3)
 
 As a user, when transcription produces no usable text, I want the system to avoid pointless clipboard or paste activity.
 
@@ -85,8 +101,10 @@ As a user, when transcription produces no usable text, I want the system to avoi
 - What happens when automatic text injection is unavailable because the system lacks input-control permissions?
 - What happens when the target app's focus metadata updates slightly after the paste event is posted?
 - What happens when the target app does not expose enough focus metadata to verify a paste?
+- What happens when the target app is explicitly profiled for optimistic delivery because it frequently accepts paste input without exposing verifiable focus metadata?
 - What happens when clipboard writing fails during the fallback path?
 - What happens when the clipboard changes externally before a delayed restore runs?
+- What happens when optimistic delivery appears successful but the user immediately needs the text again?
 - What happens when rewrite output is empty or whitespace only?
 
 ## Requirements *(mandatory)*
@@ -96,13 +114,17 @@ As a user, when transcription produces no usable text, I want the system to avoi
 - **FR-001**: The system MUST deliver completed dictation and rewrite text through the current output workflow without requiring manual paste when automatic output is enabled by the workflow.
 - **FR-002**: The system MUST attempt text injection into the workflow target app, MUST verify against the reactivated target app's available focus metadata within a bounded post-paste window, and MUST treat the result as unconfirmed unless that metadata indicates success.
 - **FR-003**: The system MUST preserve the text in clipboard when automatic text injection cannot proceed because required permissions are missing.
-- **FR-004**: The system MUST preserve the text in clipboard when injection fails or cannot be verified, and MUST surface a distinct output failure state for that condition.
+- **FR-004**: The system MUST preserve the text in clipboard when injection fails or cannot be verified in a target app that is not explicitly profiled for optimistic delivery, and MUST surface a distinct output failure state for that condition.
 - **FR-005**: The system MUST use best-effort clipboard restoration when automatic output temporarily overrides clipboard contents.
 - **FR-006**: The system MUST support rewrite-from-selection flows by replacing the selected text when possible and preserving the rewritten text in clipboard when the workflow requires fallback recovery.
 - **FR-007**: The system MUST treat empty or whitespace-only output text as a no-op and MUST not write it to clipboard or inject it into the target app.
 - **FR-008**: The system MUST preserve the source text content and formatting as provided by the transcription or rewrite result.
 - **FR-009**: The system MUST expose distinguishable output states for completed output, clipboard-pending output, and output failures.
 - **FR-010**: The system MUST surface clipboard-write failure, permission failure, and paste-verification failure as separate failure conditions.
+- **FR-011**: The system MUST support an explicit target-app profile for apps that frequently accept paste input without exposing reliable verification metadata.
+- **FR-012**: For target apps on that optimistic-delivery profile, if the paste command is posted successfully and no contradictory failure signal is observed, the system MUST resolve output as completed rather than immediately surfacing clipboard-pending UI.
+- **FR-013**: In that optimistic-delivery path, the system MUST keep the delivered text recoverable from clipboard for a short recovery window before attempting clipboard restoration.
+- **FR-014**: The system MUST limit optimistic delivery behavior to explicitly profiled target apps and MUST NOT apply it to generic unverified paste outcomes.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -111,6 +133,8 @@ As a user, when transcription produces no usable text, I want the system to avoi
 - **TextInjectionAccessState**: Represents the current ability to simulate input through accessibility and post-event access.
 - **ClipboardSnapshot**: Represents the clipboard state captured before a temporary override so it can be restored best effort later.
 - **TextOutputFailure**: Represents the user-visible output failure categories that the UI can distinguish.
+- **TargetAppOutputProfile**: Represents product-defined output handling rules for target apps whose paste behavior cannot be evaluated reliably through the generic verification path.
+- **OutputRecoveryWindow**: Represents the short interval during which optimistic-delivery text remains recoverable from clipboard before clipboard restoration is attempted.
 
 ## Success Criteria *(mandatory)*
 
@@ -121,6 +145,7 @@ As a user, when transcription produces no usable text, I want the system to avoi
 - **SC-003**: Temporary clipboard override flows restore prior clipboard content on success without overwriting a newer external clipboard update.
 - **SC-004**: Empty or whitespace-only output produces zero clipboard writes and zero injection attempts.
 - **SC-005**: The UI can distinguish permission failures, clipboard-write failures, and paste-verification failures from each other.
+- **SC-006**: In target apps on the optimistic-delivery profile, automatic output no longer surfaces clipboard-pending UI solely because verification metadata is unavailable, while the delivered text remains manually recoverable during the short recovery window.
 
 ## Assumptions
 
@@ -129,3 +154,4 @@ As a user, when transcription produces no usable text, I want the system to avoi
 - Legacy `mac.copyToClipboardOnCapture`, `mac.autoPasteOnCapture`, and `mac.revealPanelOnCapture` keys are migration artifacts, not current user-facing controls in this branch.
 - The workflow may request or open system input-control permissions, but permission grant decisions remain controlled by the operating system.
 - The target application is the app captured by the workflow, not a separate user-selected destination model.
+- Some editor-style target apps, including VS Code, may require an explicit optimistic-delivery profile because their accessibility metadata is insufficient for reliable generic paste verification.

--- a/stet/App/Workflows/MacAppSessionController.swift
+++ b/stet/App/Workflows/MacAppSessionController.swift
@@ -699,8 +699,25 @@
                     )
                 }
 
-                guard !Task.isCancelled else { return }
-                guard case .result = dictationState else { return }
+                guard !Task.isCancelled else {
+                    AppLogger.info(
+                        "OutputTrace stage=session_result_mapping_skipped reason=task_cancelled outcome=\(completionOutcomeLabel(outcome))",
+                        category: .perfTrace
+                    )
+                    return
+                }
+                guard case .result = dictationState else {
+                    AppLogger.info(
+                        "OutputTrace stage=session_result_mapping_skipped reason=state_changed currentState=\(stateLabel(dictationState)) outcome=\(completionOutcomeLabel(outcome))",
+                        category: .perfTrace
+                    )
+                    return
+                }
+
+                AppLogger.info(
+                    "OutputTrace stage=session_result_mapping_apply outcome=\(completionOutcomeLabel(outcome)) recoveredTextPreserved=\(recoveredTextPreserved) panelVisible=\(isPanelVisible)",
+                    category: .perfTrace
+                )
 
                 switch outcome {
                 case .completed:
@@ -967,6 +984,34 @@
                 return "clipboardPending"
             case .error:
                 return "error"
+            }
+        }
+
+        private func completionOutcomeLabel(
+            _ outcome: MacDictationCaptureCoordinator.CompletionOutcome
+        ) -> String {
+            switch outcome {
+            case .completed:
+                return "completed"
+            case .clipboardPending:
+                return "clipboardPending"
+            case .failed(let failure):
+                return "failed:\(failureLabel(failure))"
+            }
+        }
+
+        private func failureLabel(_ failure: DictationFailure) -> String {
+            switch failure {
+            case .clipboardWriteFailed:
+                return "clipboardWriteFailed"
+            case .autoPastePermissionMissing:
+                return "autoPastePermissionMissing"
+            case .pasteVerificationUnavailable:
+                return "pasteVerificationUnavailable"
+            case .pasteVerificationFailed:
+                return "pasteVerificationFailed"
+            default:
+                return "other"
             }
         }
 

--- a/stet/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/stet/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -92,7 +92,11 @@
                         "success=\(clipboardSuccess) transient=\(isTransientCopy) pasteboardChangeCount=\(pasteboard.changeCount)"
                 )
                 if !clipboardSuccess {
-                    emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
+                    emitOutputTrace(
+                        traceID,
+                        stage: "completion",
+                        details: "outcome=failed failure=clipboardWriteFailed"
+                    )
                     await DictationLatencyProbe.shared.record(
                         .systemWriteFailed, note: "clipboard_write_failed")
                     return .failed(.clipboardWriteFailed)
@@ -117,10 +121,15 @@
                         emitOutputTrace(
                             traceID,
                             stage: "fallback_clipboard_copy",
-                            details: "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
+                            details:
+                                "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
                         )
                         if !fallbackSuccess {
-                            emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
+                            emitOutputTrace(
+                                traceID,
+                                stage: "completion",
+                                details: "outcome=failed failure=clipboardWriteFailed"
+                            )
                             await DictationLatencyProbe.shared.record(
                                 .systemWriteFailed, note: "clipboard_fallback_failed")
                             return .failed(.clipboardWriteFailed)
@@ -134,7 +143,11 @@
 
                     await DictationLatencyProbe.shared.record(
                         .systemWriteFailed, note: "auto_paste_permission_missing")
-                    emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=autoPastePermissionMissing")
+                    emitOutputTrace(
+                        traceID,
+                        stage: "completion",
+                        details: "outcome=failed failure=autoPastePermissionMissing"
+                    )
                     return .failed(.autoPastePermissionMissing)
                 }
 
@@ -189,10 +202,15 @@
                         emitOutputTrace(
                             traceID,
                             stage: "fallback_clipboard_copy",
-                            details: "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
+                            details:
+                                "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
                         )
                         if !fallbackSuccess {
-                            emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
+                            emitOutputTrace(
+                                traceID,
+                                stage: "completion",
+                                details: "outcome=failed failure=clipboardWriteFailed"
+                            )
                             await DictationLatencyProbe.shared.record(
                                 .systemWriteFailed, note: "clipboard_fallback_failed")
                             return .failed(.clipboardWriteFailed)

--- a/stet/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/stet/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -4,6 +4,10 @@
 
     @MainActor
     final class MacDictationCaptureCoordinator {
+        private enum TargetAppOutputProfile: Equatable {
+            case optimisticVerificationBlind(recoveryWindow: Duration)
+        }
+
         enum CompletionOutcome: Equatable {
             case completed
             case clipboardPending
@@ -20,18 +24,23 @@
         private let textInjectionService: any TextInjectionService
         private let pasteboard: NSPasteboard
         private let pasteboardRestoreCoordinator: PasteboardRestoreCoordinator
+        private let frontmostBundleIdentifierProvider: @MainActor () -> String?
 
         init(
             clipboardService: any ClipboardService,
             textInjectionService: any TextInjectionService,
             pasteboard: NSPasteboard = .general,
-            pasteboardRestoreCoordinator: PasteboardRestoreCoordinator? = nil
+            pasteboardRestoreCoordinator: PasteboardRestoreCoordinator? = nil,
+            frontmostBundleIdentifierProvider: @escaping @MainActor () -> String? = {
+                NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+            }
         ) {
             self.clipboardService = clipboardService
             self.textInjectionService = textInjectionService
             self.pasteboard = pasteboard
             self.pasteboardRestoreCoordinator =
                 pasteboardRestoreCoordinator ?? PasteboardRestoreCoordinator()
+            self.frontmostBundleIdentifierProvider = frontmostBundleIdentifierProvider
         }
 
         func handleCompletedCapture(
@@ -40,7 +49,16 @@
             settings: CaptureSettings,
             showPanel: @escaping @MainActor () -> Void
         ) async -> CompletionOutcome {
+            let traceID = makeOutputTraceID()
+            emitOutputTrace(
+                traceID,
+                stage: "begin",
+                details:
+                    "textLength=\(text.count) target=\(applicationSummary(targetApplication)) shouldCopyToClipboard=\(settings.shouldCopyToClipboard) shouldAutoPaste=\(settings.shouldAutoPaste) shouldRevealPanel=\(settings.shouldRevealPanelOnCapture)"
+            )
+
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                emitOutputTrace(traceID, stage: "completion", details: "outcome=completed reason=empty_text")
                 await DictationLatencyProbe.shared.record(.systemWriteSkipped, note: "empty_text")
                 return .completed
             }
@@ -54,12 +72,27 @@
                 pasteboardRestoreCoordinator.discardPendingRestore()
             }
 
+            emitOutputTrace(
+                traceID,
+                stage: "clipboard_strategy",
+                details:
+                    "shouldRestoreAfterSuccessfulPaste=\(shouldRestoreClipboardAfterSuccessfulPaste) pasteboardChangeCount=\(pasteboard.changeCount)"
+            )
+
             if settings.shouldCopyToClipboard || settings.shouldAutoPaste {
+                let isTransientCopy = settings.shouldAutoPaste && !settings.shouldCopyToClipboard
                 let clipboardSuccess = clipboardService.copy(
                     text,
-                    transient: settings.shouldAutoPaste && !settings.shouldCopyToClipboard
+                    transient: isTransientCopy
+                )
+                emitOutputTrace(
+                    traceID,
+                    stage: "initial_clipboard_copy",
+                    details:
+                        "success=\(clipboardSuccess) transient=\(isTransientCopy) pasteboardChangeCount=\(pasteboard.changeCount)"
                 )
                 if !clipboardSuccess {
+                    emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
                     await DictationLatencyProbe.shared.record(
                         .systemWriteFailed, note: "clipboard_write_failed")
                     return .failed(.clipboardWriteFailed)
@@ -68,13 +101,26 @@
 
             if settings.shouldAutoPaste {
                 if !textInjectionService.isAvailable {
+                    let accessState = textInjectionService.accessState
+                    emitOutputTrace(
+                        traceID,
+                        stage: "auto_paste_unavailable",
+                        details:
+                            "accessibility=\(accessState.hasAccessibilityAccess) postEvent=\(accessState.hasPostEventAccess)"
+                    )
                     if shouldRestoreClipboardAfterSuccessfulPaste {
                         pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
                     }
 
                     if !settings.shouldCopyToClipboard {
                         let fallbackSuccess = clipboardService.copy(text, transient: false)
+                        emitOutputTrace(
+                            traceID,
+                            stage: "fallback_clipboard_copy",
+                            details: "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
+                        )
                         if !fallbackSuccess {
+                            emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
                             await DictationLatencyProbe.shared.record(
                                 .systemWriteFailed, note: "clipboard_fallback_failed")
                             return .failed(.clipboardWriteFailed)
@@ -88,10 +134,41 @@
 
                     await DictationLatencyProbe.shared.record(
                         .systemWriteFailed, note: "auto_paste_permission_missing")
+                    emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=autoPastePermissionMissing")
                     return .failed(.autoPastePermissionMissing)
                 }
 
                 let pasteOutcome = await textInjectionService.pasteClipboard(into: targetApplication)
+                let targetAppProfile = resolveTargetAppOutputProfile(targetApplication: targetApplication)
+                emitOutputTrace(
+                    traceID,
+                    stage: "text_injection_outcome",
+                    details:
+                        "outcome=\(textInjectionOutcomeLabel(pasteOutcome)) profile=\(targetAppProfileLabel(targetAppProfile))"
+                )
+
+                if case .eventPostedVerificationUnavailable = pasteOutcome,
+                    case let .optimisticVerificationBlind(recoveryWindow)? = targetAppProfile
+                {
+                    if shouldRestoreClipboardAfterSuccessfulPaste {
+                        pasteboardRestoreCoordinator.scheduleRestoreIfNeeded(
+                            on: pasteboard,
+                            delayOverride: recoveryWindow
+                        )
+                    }
+
+                    await DictationLatencyProbe.shared.record(
+                        .systemWriteCompleted,
+                        note: "optimistic_verification_blind"
+                    )
+                    emitOutputTrace(
+                        traceID,
+                        stage: "completion",
+                        details:
+                            "outcome=completed reason=optimistic_verification_blind profile=\(targetAppProfileLabel(targetAppProfile))"
+                    )
+                    return .completed
+                }
 
                 switch pasteOutcome {
                 case .verifiedSuccess:
@@ -99,6 +176,7 @@
                         pasteboardRestoreCoordinator.scheduleRestoreIfNeeded(on: pasteboard)
                     }
                     await DictationLatencyProbe.shared.record(.systemWriteCompleted)
+                    emitOutputTrace(traceID, stage: "completion", details: "outcome=completed")
                     return .completed
 
                 case .eventPostedVerificationUnavailable, .verificationFailed, .eventPostFailed:
@@ -108,7 +186,13 @@
 
                     if !settings.shouldCopyToClipboard {
                         let fallbackSuccess = clipboardService.copy(text, transient: false)
+                        emitOutputTrace(
+                            traceID,
+                            stage: "fallback_clipboard_copy",
+                            details: "success=\(fallbackSuccess) transient=false pasteboardChangeCount=\(pasteboard.changeCount)"
+                        )
                         if !fallbackSuccess {
+                            emitOutputTrace(traceID, stage: "completion", details: "outcome=failed failure=clipboardWriteFailed")
                             await DictationLatencyProbe.shared.record(
                                 .systemWriteFailed, note: "clipboard_fallback_failed")
                             return .failed(.clipboardWriteFailed)
@@ -120,6 +204,7 @@
 
                     switch pasteOutcome {
                     case .eventPostedVerificationUnavailable:
+                        textInjectionService.requestAccessIfNeeded()
                         failure = .pasteVerificationUnavailable
                         failureNote = "paste_verification_unavailable"
                     case .verificationFailed:
@@ -140,6 +225,11 @@
                     await DictationLatencyProbe.shared.record(
                         .systemWriteFailed, note: failureNote)
 
+                    emitOutputTrace(
+                        traceID,
+                        stage: "completion",
+                        details: "outcome=failed failure=\(failureLabel(failure))"
+                    )
                     return .failed(failure)
                 }
             } else if settings.shouldRevealPanelOnCapture {
@@ -151,7 +241,13 @@
                     .systemWriteSkipped, note: "auto_paste_disabled")
             }
 
-            return settings.shouldCopyToClipboard ? .completed : .clipboardPending
+            let outcome: CompletionOutcome = settings.shouldCopyToClipboard ? .completed : .clipboardPending
+            emitOutputTrace(
+                traceID,
+                stage: "completion",
+                details: "outcome=\(completionOutcomeLabel(outcome))"
+            )
+            return outcome
         }
 
         func copyToClipboard(_ text: String) -> Bool {
@@ -160,6 +256,90 @@
             }
             pasteboardRestoreCoordinator.discardPendingRestore()
             return clipboardService.copy(text, transient: false)
+        }
+
+        private func makeOutputTraceID() -> String {
+            String(UUID().uuidString.prefix(8))
+        }
+
+        private func emitOutputTrace(_ traceID: String, stage: String, details: String? = nil) {
+            let detailsSuffix = details.map { " \($0)" } ?? ""
+            AppLogger.info(
+                "OutputTrace id=\(traceID) stage=\(stage)\(detailsSuffix)",
+                category: .perfTrace
+            )
+        }
+
+        private func applicationSummary(_ application: NSRunningApplication?) -> String {
+            guard let application else { return "nil" }
+            let bundleIdentifier = application.bundleIdentifier ?? "unknown"
+            return "\(bundleIdentifier)(pid=\(application.processIdentifier))"
+        }
+
+        private func textInjectionOutcomeLabel(_ outcome: TextInjectionOutcome) -> String {
+            switch outcome {
+            case .verifiedSuccess:
+                return "verifiedSuccess"
+            case .eventPostedVerificationUnavailable:
+                return "eventPostedVerificationUnavailable"
+            case .verificationFailed:
+                return "verificationFailed"
+            case .eventPostFailed:
+                return "eventPostFailed"
+            }
+        }
+
+        private func completionOutcomeLabel(_ outcome: CompletionOutcome) -> String {
+            switch outcome {
+            case .completed:
+                return "completed"
+            case .clipboardPending:
+                return "clipboardPending"
+            case .failed(let failure):
+                return "failed:\(failureLabel(failure))"
+            }
+        }
+
+        private func failureLabel(_ failure: DictationFailure) -> String {
+            switch failure {
+            case .clipboardWriteFailed:
+                return "clipboardWriteFailed"
+            case .autoPastePermissionMissing:
+                return "autoPastePermissionMissing"
+            case .pasteVerificationUnavailable:
+                return "pasteVerificationUnavailable"
+            case .pasteVerificationFailed:
+                return "pasteVerificationFailed"
+            default:
+                return "other"
+            }
+        }
+
+        private func resolveTargetAppOutputProfile(targetApplication: NSRunningApplication?)
+            -> TargetAppOutputProfile?
+        {
+            let bundleIdentifier =
+                targetApplication?.bundleIdentifier
+                ?? frontmostBundleIdentifierProvider()
+            return outputProfile(for: bundleIdentifier)
+        }
+
+        private func outputProfile(for bundleIdentifier: String?) -> TargetAppOutputProfile? {
+            switch bundleIdentifier {
+            case "com.microsoft.VSCode":
+                return .optimisticVerificationBlind(recoveryWindow: .seconds(10))
+            default:
+                return nil
+            }
+        }
+
+        private func targetAppProfileLabel(_ profile: TargetAppOutputProfile?) -> String {
+            switch profile {
+            case .optimisticVerificationBlind:
+                return "optimisticVerificationBlind"
+            case nil:
+                return "none"
+            }
         }
     }
 #endif

--- a/stet/Core/Clipboard/ClipboardService.swift
+++ b/stet/Core/Clipboard/ClipboardService.swift
@@ -35,35 +35,53 @@ final class SystemClipboardService: ClipboardService {
     @discardableResult
     func copy(_ text: String, transient: Bool) -> Bool {
         #if os(macOS)
-            do {
-                pasteboard.clearContents()
+            let changeCountBefore = pasteboard.changeCount
+            emitClipboardTrace(
+                stage: "copy_begin",
+                details:
+                    "transient=\(transient) textLength=\(text.count) changeCountBefore=\(changeCountBefore)"
+            )
 
-                guard pasteboard.setString(text, forType: .string) else {
-                    AppLogger.error(
-                        "Failed to write text to clipboard (setString returned false)",
-                        category: .general
-                    )
-                    return false
-                }
+            pasteboard.clearContents()
 
-                if let bundleIdentifier = Bundle.main.bundleIdentifier {
-                    _ = pasteboard.setString(bundleIdentifier, forType: Self.sourceType)
-                }
-                if transient {
-                    _ = pasteboard.setData(Data(), forType: Self.transientType)
-                }
-
-                return true
-            } catch {
+            guard pasteboard.setString(text, forType: .string) else {
                 AppLogger.error(
-                    "Failed to write text to clipboard: \(error.localizedDescription)",
+                    "Failed to write text to clipboard (setString returned false)",
                     category: .general
+                )
+                emitClipboardTrace(
+                    stage: "copy_end",
+                    details:
+                        "success=false transient=\(transient) textLength=\(text.count) changeCountBefore=\(changeCountBefore) changeCountAfter=\(pasteboard.changeCount)"
                 )
                 return false
             }
+
+            if let bundleIdentifier = Bundle.main.bundleIdentifier {
+                _ = pasteboard.setString(bundleIdentifier, forType: Self.sourceType)
+            }
+            if transient {
+                _ = pasteboard.setData(Data(), forType: Self.transientType)
+            }
+
+            emitClipboardTrace(
+                stage: "copy_end",
+                details:
+                    "success=true transient=\(transient) textLength=\(text.count) changeCountBefore=\(changeCountBefore) changeCountAfter=\(pasteboard.changeCount)"
+            )
+            return true
         #elseif canImport(UIKit)
             UIPasteboard.general.string = text
             return true
         #endif
     }
+
+    #if os(macOS)
+        private func emitClipboardTrace(stage: String, details: String) {
+            AppLogger.info(
+                "ClipboardTrace stage=\(stage) \(details)",
+                category: .perfTrace
+            )
+        }
+    #endif
 }

--- a/stet/Core/Clipboard/PasteboardRestoreCoordinator.swift
+++ b/stet/Core/Clipboard/PasteboardRestoreCoordinator.swift
@@ -17,23 +17,51 @@
         }
 
         func prepareForTemporaryOverride(on pasteboard: NSPasteboard) {
-            if pendingOriginalSnapshot == nil {
+            let capturedFreshSnapshot = pendingOriginalSnapshot == nil
+            if capturedFreshSnapshot {
                 pendingOriginalSnapshot = PasteboardSnapshot.capture(from: pasteboard)
             }
 
             pendingRestoreTask?.cancel()
             pendingRestoreTask = nil
+            emitPasteboardTrace(
+                stage: "prepare",
+                pasteboard: pasteboard,
+                details:
+                    "capturedFreshSnapshot=\(capturedFreshSnapshot) originalItemCount=\(pendingOriginalSnapshot?.itemCount ?? 0)"
+            )
         }
 
         func scheduleRestoreIfNeeded(on pasteboard: NSPasteboard) {
-            guard let snapshot = pendingOriginalSnapshot else { return }
+            scheduleRestoreIfNeeded(on: pasteboard, delayOverride: nil)
+        }
 
+        func scheduleRestoreIfNeeded(
+            on pasteboard: NSPasteboard,
+            delayOverride: Duration?
+        ) {
+            guard let snapshot = pendingOriginalSnapshot else {
+                emitPasteboardTrace(
+                    stage: "schedule_restore_skipped",
+                    pasteboard: pasteboard,
+                    details: "reason=no_pending_original_snapshot"
+                )
+                return
+            }
+
+            let effectiveDelay = delayOverride ?? restoreDelay
             let temporarySnapshot = PasteboardSnapshot.capture(from: pasteboard)
+            emitPasteboardTrace(
+                stage: "schedule_restore",
+                pasteboard: pasteboard,
+                details:
+                    "delayMs=\(durationMilliseconds(effectiveDelay)) originalItemCount=\(snapshot.itemCount) temporaryItemCount=\(temporarySnapshot.itemCount)"
+            )
             pendingRestoreTask?.cancel()
             pendingRestoreTask = Task { @MainActor [weak self] in
                 guard let self else { return }
 
-                try? await Task.sleep(for: self.restoreDelay)
+                try? await Task.sleep(for: effectiveDelay)
                 guard !Task.isCancelled else { return }
 
                 defer {
@@ -46,31 +74,82 @@
                         "Pasteboard restore skipped: temporary snapshot no longer matches current pasteboard",
                         category: .dictation
                     )
+                    emitPasteboardTrace(
+                        stage: "restore_skipped_mismatch",
+                        pasteboard: pasteboard,
+                        details:
+                            "temporaryItemCount=\(temporarySnapshot.itemCount) currentItemCount=\(PasteboardSnapshot.capture(from: pasteboard).itemCount)"
+                    )
                     return
                 }
 
                 snapshot.restore(to: pasteboard)
+                emitPasteboardTrace(
+                    stage: "restore_applied",
+                    pasteboard: pasteboard,
+                    details: "restoredItemCount=\(snapshot.itemCount)"
+                )
             }
         }
 
         func restoreImmediatelyIfNeeded(on pasteboard: NSPasteboard) {
-            guard let snapshot = pendingOriginalSnapshot else { return }
+            guard let snapshot = pendingOriginalSnapshot else {
+                emitPasteboardTrace(
+                    stage: "restore_immediate_skipped",
+                    pasteboard: pasteboard,
+                    details: "reason=no_pending_original_snapshot"
+                )
+                return
+            }
 
             pendingRestoreTask?.cancel()
             pendingRestoreTask = nil
             pendingOriginalSnapshot = nil
             snapshot.restore(to: pasteboard)
+            emitPasteboardTrace(
+                stage: "restore_immediate",
+                pasteboard: pasteboard,
+                details: "restoredItemCount=\(snapshot.itemCount)"
+            )
         }
 
         func discardPendingRestore() {
             pendingRestoreTask?.cancel()
             pendingRestoreTask = nil
             pendingOriginalSnapshot = nil
+            AppLogger.info(
+                "PasteboardTrace stage=discard_pending",
+                category: .perfTrace
+            )
+        }
+
+        private func emitPasteboardTrace(
+            stage: String,
+            pasteboard: NSPasteboard,
+            details: String? = nil
+        ) {
+            let detailsSuffix = details.map { " \($0)" } ?? ""
+            AppLogger.info(
+                "PasteboardTrace stage=\(stage) changeCount=\(pasteboard.changeCount) pendingOriginalSnapshot=\(pendingOriginalSnapshot != nil)\(detailsSuffix)",
+                category: .perfTrace
+            )
+        }
+
+        private func durationMilliseconds(_ duration: Duration) -> String {
+            let components = duration.components
+            let milliseconds =
+                (Double(components.seconds) * 1_000)
+                + (Double(components.attoseconds) / 1_000_000_000_000_000)
+            return String(format: "%.1f", milliseconds)
         }
     }
 
     struct PasteboardSnapshot {
         private let items: [[NSPasteboard.PasteboardType: Data]]
+
+        var itemCount: Int {
+            items.count
+        }
 
         static func capture(from pasteboard: NSPasteboard) -> Self {
             let items = (pasteboard.pasteboardItems ?? []).map { item in

--- a/stet/Core/TextInput/TextInjectionService.swift
+++ b/stet/Core/TextInput/TextInjectionService.swift
@@ -494,7 +494,8 @@
                 }
             }
 
-            let outcome: TextInjectionOutcome = observedVerifiableSnapshot
+            let outcome: TextInjectionOutcome =
+                observedVerifiableSnapshot
                 ? .verificationFailed
                 : .eventPostedVerificationUnavailable
             emitTextInjectionTrace(

--- a/stet/Core/TextInput/TextInjectionService.swift
+++ b/stet/Core/TextInput/TextInjectionService.swift
@@ -76,6 +76,17 @@
                 value != nil || selectedText != nil || selectionRange != nil || numberOfCharacters != nil
             }
 
+            var traceSummary: String {
+                let valueLength = value.map { String($0.count) } ?? "nil"
+                let selectedTextLength = selectedText.map { String($0.count) } ?? "nil"
+                let selectionRangeSummary =
+                    selectionRange.map { "\($0.location):\($0.length)" } ?? "nil"
+                let characterCount = numberOfCharacters.map(String.init) ?? "nil"
+
+                return
+                    "valueLen=\(valueLength) selectedLen=\(selectedTextLength) range=\(selectionRangeSummary) chars=\(characterCount)"
+            }
+
             func indicatesMutation(comparedTo previous: Self) -> Bool {
                 if let value, let previousValue = previous.value, value != previousValue {
                     return true
@@ -136,7 +147,13 @@
         }
 
         func requestAccessIfNeeded() {
-            guard !isAvailable, !didPromptForMissingAccessThisSession else {
+            let state = accessState
+            let needsVerificationAccess = !state.hasAccessibilityAccess
+
+            guard
+                (!state.canSimulateInput || needsVerificationAccess),
+                !didPromptForMissingAccessThisSession
+            else {
                 return
             }
 
@@ -322,10 +339,25 @@
             sleep: @escaping @Sendable (Duration) async -> Void,
             activationDelay: Duration = .milliseconds(180),
             prePasteDelay: Duration = .milliseconds(60),
+            verificationBaselinePollInterval: Duration = .milliseconds(60),
+            verificationBaselineAttempts: Int = 4,
             verificationPollInterval: Duration = .milliseconds(120),
             verificationAttempts: Int = 4
         ) async -> TextInjectionOutcome {
+            let traceID = makeTextInjectionTraceID()
+            emitTextInjectionTrace(
+                traceID,
+                stage: "begin",
+                details:
+                    "target=\(applicationSummary(application)) frontmost=\(frontmostApplicationSummary()) accessibility=\(accessState.hasAccessibilityAccess) postEvent=\(accessState.hasPostEventAccess)"
+            )
+
             guard accessState.canSimulateInput else {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "outcome",
+                    details: "outcome=\(outcomeLabel(.eventPostFailed)) reason=no_input_access"
+                )
                 return .eventPostFailed
             }
 
@@ -333,18 +365,60 @@
                 !application.isTerminated,
                 application.bundleIdentifier != Bundle.main.bundleIdentifier
             {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "activate_target",
+                    details:
+                        "target=\(applicationSummary(application)) frontmostBefore=\(frontmostApplicationSummary()) delayMs=\(durationMilliseconds(activationDelay))"
+                )
                 activateApplication(application)
                 await sleep(activationDelay)
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "activate_target_settled",
+                    details: "frontmostAfter=\(frontmostApplicationSummary())"
+                )
             }
 
             await sleep(prePasteDelay)
-            let snapshotBeforePaste = snapshotProvider()
+            emitTextInjectionTrace(
+                traceID,
+                stage: "baseline_capture_start",
+                details:
+                    "attempts=\(max(1, verificationBaselineAttempts)) pollMs=\(durationMilliseconds(verificationBaselinePollInterval)) frontmost=\(frontmostApplicationSummary())"
+            )
+            let snapshotBeforePaste = await captureVerificationBaseline(
+                snapshotProvider: snapshotProvider,
+                sleep: sleep,
+                pollInterval: verificationBaselinePollInterval,
+                attempts: verificationBaselineAttempts,
+                traceID: traceID
+            )
 
-            guard simulatePasteCommand() else {
+            let pasteCommandPosted = simulatePasteCommand()
+            emitTextInjectionTrace(
+                traceID,
+                stage: "paste_command",
+                details:
+                    "success=\(pasteCommandPosted) baseline=\(snapshotBeforePaste?.traceSummary ?? "nil") frontmost=\(frontmostApplicationSummary())"
+            )
+
+            guard pasteCommandPosted else {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "outcome",
+                    details: "outcome=\(outcomeLabel(.eventPostFailed))"
+                )
                 return .eventPostFailed
             }
 
             guard let snapshotBeforePaste, snapshotBeforePaste.canVerifyPaste else {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "outcome",
+                    details:
+                        "outcome=\(outcomeLabel(.eventPostedVerificationUnavailable)) reason=missing_verifiable_baseline frontmost=\(frontmostApplicationSummary())"
+                )
                 return .eventPostedVerificationUnavailable
             }
 
@@ -353,7 +427,8 @@
                 snapshotProvider: snapshotProvider,
                 sleep: sleep,
                 pollInterval: verificationPollInterval,
-                attempts: verificationAttempts
+                attempts: verificationAttempts,
+                traceID: traceID
             )
         }
 
@@ -362,33 +437,105 @@
             snapshotProvider: @MainActor () -> FocusedElementSnapshot?,
             sleep: @escaping @Sendable (Duration) async -> Void,
             pollInterval: Duration = .milliseconds(120),
-            attempts: Int = 4
+            attempts: Int = 4,
+            traceID: String? = nil
         ) async -> TextInjectionOutcome {
             guard snapshotBeforePaste.canVerifyPaste else {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "outcome",
+                    details:
+                        "outcome=\(outcomeLabel(.eventPostedVerificationUnavailable)) reason=baseline_not_verifiable"
+                )
                 return .eventPostedVerificationUnavailable
             }
 
             let retryCount = max(1, attempts)
             var observedVerifiableSnapshot = false
+            emitTextInjectionTrace(
+                traceID,
+                stage: "verification_start",
+                details:
+                    "attempts=\(retryCount) pollMs=\(durationMilliseconds(pollInterval)) baseline=\(snapshotBeforePaste.traceSummary)"
+            )
 
-            for _ in 0..<retryCount {
+            for attempt in 0..<retryCount {
                 await sleep(pollInterval)
 
                 guard let snapshotAfterPaste = snapshotProvider() else {
+                    emitTextInjectionTrace(
+                        traceID,
+                        stage: "verification_poll",
+                        details:
+                            "attempt=\(attempt + 1)/\(retryCount) snapshot=nil frontmost=\(frontmostApplicationSummary())"
+                    )
                     continue
                 }
 
                 observedVerifiableSnapshot =
                     observedVerifiableSnapshot || snapshotAfterPaste.canVerifyPaste
+                let didMutate = snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste)
 
-                if snapshotAfterPaste.indicatesMutation(comparedTo: snapshotBeforePaste) {
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "verification_poll",
+                    details:
+                        "attempt=\(attempt + 1)/\(retryCount) snapshot=\(snapshotAfterPaste.traceSummary) verifiable=\(snapshotAfterPaste.canVerifyPaste) mutated=\(didMutate) frontmost=\(frontmostApplicationSummary())"
+                )
+
+                if didMutate {
+                    emitTextInjectionTrace(
+                        traceID,
+                        stage: "outcome",
+                        details:
+                            "outcome=\(outcomeLabel(.verifiedSuccess)) attempt=\(attempt + 1)"
+                    )
                     return .verifiedSuccess
                 }
             }
 
-            return observedVerifiableSnapshot
+            let outcome: TextInjectionOutcome = observedVerifiableSnapshot
                 ? .verificationFailed
                 : .eventPostedVerificationUnavailable
+            emitTextInjectionTrace(
+                traceID,
+                stage: "outcome",
+                details:
+                    "outcome=\(outcomeLabel(outcome)) observedVerifiableSnapshot=\(observedVerifiableSnapshot)"
+            )
+            return outcome
+        }
+
+        private func captureVerificationBaseline(
+            snapshotProvider: @MainActor () -> FocusedElementSnapshot?,
+            sleep: @escaping @Sendable (Duration) async -> Void,
+            pollInterval: Duration,
+            attempts: Int,
+            traceID: String? = nil
+        ) async -> FocusedElementSnapshot? {
+            let retryCount = max(1, attempts)
+
+            for attempt in 0..<retryCount {
+                let snapshot = snapshotProvider()
+                emitTextInjectionTrace(
+                    traceID,
+                    stage: "baseline_capture_attempt",
+                    details:
+                        "attempt=\(attempt + 1)/\(retryCount) snapshot=\(snapshot?.traceSummary ?? "nil") frontmost=\(frontmostApplicationSummary())"
+                )
+
+                if let snapshot, snapshot.canVerifyPaste {
+                    return snapshot
+                }
+
+                guard attempt + 1 < retryCount else {
+                    break
+                }
+
+                await sleep(pollInterval)
+            }
+
+            return nil
         }
 
         private func focusedElementSnapshot() -> FocusedElementSnapshot? {
@@ -511,6 +658,50 @@
                     ] as CFDictionary
                 _ = AXIsProcessTrustedWithOptions(options)
             }
+        }
+
+        private func makeTextInjectionTraceID() -> String {
+            String(UUID().uuidString.prefix(8))
+        }
+
+        private func emitTextInjectionTrace(_ traceID: String?, stage: String, details: String? = nil) {
+            guard let traceID else { return }
+            let detailsSuffix = details.map { " \($0)" } ?? ""
+            AppLogger.info(
+                "TextInjectionTrace id=\(traceID) stage=\(stage)\(detailsSuffix)",
+                category: .perfTrace
+            )
+        }
+
+        private func applicationSummary(_ application: NSRunningApplication?) -> String {
+            guard let application else { return "nil" }
+            let bundleIdentifier = application.bundleIdentifier ?? "unknown"
+            return "\(bundleIdentifier)(pid=\(application.processIdentifier))"
+        }
+
+        private func frontmostApplicationSummary() -> String {
+            applicationSummary(NSWorkspace.shared.frontmostApplication)
+        }
+
+        private func outcomeLabel(_ outcome: TextInjectionOutcome) -> String {
+            switch outcome {
+            case .verifiedSuccess:
+                return "verifiedSuccess"
+            case .eventPostedVerificationUnavailable:
+                return "eventPostedVerificationUnavailable"
+            case .verificationFailed:
+                return "verificationFailed"
+            case .eventPostFailed:
+                return "eventPostFailed"
+            }
+        }
+
+        private func durationMilliseconds(_ duration: Duration) -> String {
+            let components = duration.components
+            let milliseconds =
+                (Double(components.seconds) * 1_000)
+                + (Double(components.attoseconds) / 1_000_000_000_000_000)
+            return String(format: "%.1f", milliseconds)
         }
 
     }

--- a/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
+++ b/stet/Features/MacShell/DictationPanel/MacDictationClipboardSurface.swift
@@ -16,7 +16,7 @@
             VStack(spacing: 8) {
                 Text(text)
                     .font(.system(size: 15, weight: .medium, design: .rounded))
-                    .foregroundStyle(.white.opacity(0.96))
+                    .foregroundStyle(.black.opacity(0.92))
                     .multilineTextAlignment(.center)
                     .lineSpacing(2)
                     .padding(.horizontal, 24)


### PR DESCRIPTION
## Summary
- treat VS Code as a scoped verification-blind target for optimistic paste completion
- keep the temporary clipboard contents available for a 10 second recovery window before restoring the original pasteboard
- improve paste verification diagnostics, focused tests, and clipboard panel readability

## Why
VS Code can accept the paste event while failing accessibility-based verification. That caused false clipboard recovery fallbacks even when text had already been inserted successfully.

## Impact
- VS Code no longer shows the clipboard recovery surface when paste is sent successfully but verification is unavailable
- non-profiled apps keep the existing failure and clipboard fallback behavior
- users still have a short manual recovery window if VS Code misses the insertion

## Validation
- `xcodebuild test -project Stet.xcodeproj -scheme Stet -destination 'platform=macOS' -only-testing:StetTests/MacDictationCaptureCoordinatorTests -only-testing:StetTests/PasteboardRestoreCoordinatorTests -only-testing:StetTests/MacAppSessionControllerActionTests -only-testing:StetTests/MacDictationWorkflowControllerTests -only-testing:StetTests/MacAppSessionControllerSettingsTests -only-testing:StetTests/SystemTextInjectionServiceTests`
- manual validation in VS Code confirmed the recovery panel no longer appears after a successful insertion