### PR TITLE
fix(mac): make dictation hotkey tap-to-talk only

### DIFF
--- a/StetMac/App/Lifecycle/MacAppContracts.swift
+++ b/StetMac/App/Lifecycle/MacAppContracts.swift
@@ -117,7 +117,6 @@
     protocol MacDictationHotkeyRegistering {
         func clearDictationHandlers()
         func registerDictationKeyDown(_ handler: @escaping () -> Void)
-        func registerDictationKeyUp(_ handler: @escaping () -> Void)
     }
 #endif
 

--- a/StetMac/App/Workflows/KeyboardShortcutsHotkeyRegistrar.swift
+++ b/StetMac/App/Workflows/KeyboardShortcutsHotkeyRegistrar.swift
@@ -14,13 +14,5 @@
                 }
             }
         }
-
-        func registerDictationKeyUp(_ handler: @escaping () -> Void) {
-            KeyboardShortcuts.onKeyUp(for: .dictationHotkey) {
-                Task { @MainActor in
-                    handler()
-                }
-            }
-        }
     }
 #endif

--- a/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
@@ -38,23 +38,12 @@
         }
 
         func handleHotkeyPressed() {
-            let action = hotkeyInteraction.handleKeyDown(
-                for: dictationState,
-                now: ProcessInfo.processInfo.systemUptime
-            )
+            let action = hotkeyInteraction.handleKeyDown(for: dictationState)
             if action == .startCapture {
                 Task {
                     await DictationStartupProbe.shared.begin(trigger: .hotkey)
                 }
             }
-            performHotkeyAction(action)
-        }
-
-        func handleHotkeyReleased() {
-            let action = hotkeyInteraction.handleKeyUp(
-                for: dictationState,
-                now: ProcessInfo.processInfo.systemUptime
-            )
             performHotkeyAction(action)
         }
 
@@ -88,7 +77,6 @@
         func handleStateTransitionObservation(for state: DictationState) {
             let previousState = previousDictationState
             previousDictationState = state
-            hotkeyInteraction.sync(with: state)
             Task {
                 await DictationRuntimeProbe.shared.markStateTransition(from: previousState, to: state)
                 if state == .idle, previousState != .idle {
@@ -196,9 +184,6 @@
             hotkeyRegistrar.clearDictationHandlers()
             hotkeyRegistrar.registerDictationKeyDown { [weak self] in
                 self?.handleHotkeyPressed()
-            }
-            hotkeyRegistrar.registerDictationKeyUp { [weak self] in
-                self?.handleHotkeyReleased()
             }
         }
 

--- a/StetMac/App/Workflows/MacAppSessionController+Interface.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Interface.swift
@@ -17,7 +17,6 @@
         }
 
         func cancelActiveCapture() {
-            hotkeyInteraction.reset()
             workflowController.cancelActiveCapture()
             hidePanel()
         }

--- a/StetMac/App/Workflows/MacAppSessionController.swift
+++ b/StetMac/App/Workflows/MacAppSessionController.swift
@@ -31,7 +31,7 @@
         let hotkeyRegistrar: any MacDictationHotkeyRegistering
         var cancellables = Set<AnyCancellable>()
         var completionHandlingTask: Task<Void, Never>?
-        var hotkeyInteraction = MacDictationHotkeyInteraction()
+        let hotkeyInteraction = MacDictationHotkeyInteraction()
         var previousDictationState: DictationState = .idle
         weak var presentationModel: (any MacAppPresentationModeling)?
         var onboardingStepState: MacOnboardingStep

--- a/StetMac/App/Workflows/MacDictationHotkeyInteraction.swift
+++ b/StetMac/App/Workflows/MacDictationHotkeyInteraction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct MacDictationHotkeyInteraction {
     enum Action: Equatable {
         case none
@@ -7,69 +5,14 @@ struct MacDictationHotkeyInteraction {
         case stopCapture
     }
 
-    enum State: Equatable {
-        case idle
-        case pressCandidate(startedAt: TimeInterval)
-        case latchedListening
-        case suppressNextKeyUp
-    }
-
-    var holdThreshold: TimeInterval = 0.35
-    private(set) var state: State = .idle
-
-    mutating func handleKeyDown(
-        for dictationState: DictationState,
-        now: TimeInterval
-    ) -> Action {
+    func handleKeyDown(for dictationState: DictationState) -> Action {
         switch dictationState {
         case .starting, .listening:
-            switch state {
-            case .pressCandidate, .suppressNextKeyUp:
-                return .none
-            case .idle, .latchedListening:
-                state = .suppressNextKeyUp
-                return .stopCapture
-            }
+            .stopCapture
         case .idle, .result, .error:
-            guard case .idle = state else { return .none }
-            state = .pressCandidate(startedAt: now)
-            return .startCapture
-        case .clipboardPending:
-            return .none
-        case .processing:
-            return .none
+            .startCapture
+        case .clipboardPending, .processing:
+            .none
         }
-    }
-
-    mutating func handleKeyUp(
-        for dictationState: DictationState,
-        now: TimeInterval
-    ) -> Action {
-        switch state {
-        case .idle, .latchedListening:
-            return .none
-        case .suppressNextKeyUp:
-            state = .idle
-            return .none
-        case .pressCandidate(let startedAt):
-            let didHoldPastThreshold = (now - startedAt) >= holdThreshold
-
-            if didHoldPastThreshold, dictationState.isCaptureInFlight {
-                state = .idle
-                return .stopCapture
-            }
-
-            state = dictationState.isCaptureInFlight ? .latchedListening : .idle
-            return .none
-        }
-    }
-
-    mutating func sync(with dictationState: DictationState) {
-        guard !dictationState.isCaptureInFlight else { return }
-        state = .idle
-    }
-
-    mutating func reset() {
-        state = .idle
     }
 }

--- a/StetMac/Features/Onboarding/OnboardingView.swift
+++ b/StetMac/Features/Onboarding/OnboardingView.swift
@@ -232,11 +232,11 @@
                 return "Choose the shortcut you want to use for dictation."
             case .firstSuccess:
                 return
-                    "Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup."
+                    "Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup."
             case .appearance:
                 return "Browse themes on the right, then apply and finish."
             case .done:
-                return "Hold your shortcut and start speaking anywhere you can type text."
+                return "Press your shortcut and start speaking anywhere you can type text."
             }
         }
     }

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Wählen Sie Ihren bevorzugten KI-Anbieter für die Transkription und Bereinigung.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Gewähren Sie Mikrofon- und Eingabesteuerungsberechtigungen, damit Stet Text aufzeichnen und in Ihre Apps eingeben kann.";
 "Choose the shortcut you want to use for dictation." = "Wählen Sie den Kurzbefehl, den Sie für das Diktat verwenden möchten.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Halten Sie den Kurzbefehl gedrückt und sprechen Sie natürlich. Wir bewahren Ihre Absicht bei und führen die notwendige Bereinigung durch.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Drücken Sie den Kurzbefehl und sprechen Sie natürlich. Wir bewahren Ihre Absicht bei und führen die notwendige Bereinigung durch.";
 "Browse themes on the right, then apply and finish." = "Durchsuchen Sie die Designs auf der rechten Seite, wenden Sie sie an und schließen Sie ab.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Halten Sie Ihren Kurzbefehl gedrückt und beginnen Sie überall dort zu sprechen, wo Sie Text eingeben können.";
+"Press your shortcut and start speaking anywhere you can type text." = "Drücken Sie Ihren Kurzbefehl und beginnen Sie überall dort zu sprechen, wo Sie Text eingeben können.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Laden Sie das Modell herunter, um Ihre Stimme lokal zu verarbeiten";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -169,9 +169,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Select your preferred AI provider to handle transcription and cleanup.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Grant microphone and input control permissions so Stet can record and type text back into your apps.";
 "Choose the shortcut you want to use for dictation." = "Choose the shortcut you want to use for dictation.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup.";
 "Browse themes on the right, then apply and finish." = "Browse themes on the right, then apply and finish.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Hold your shortcut and start speaking anywhere you can type text.";
+"Press your shortcut and start speaking anywhere you can type text." = "Press your shortcut and start speaking anywhere you can type text.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Download the model to process your voice locally";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Selecciona tu proveedor de IA preferido para manejar la transcripción y la limpieza.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Otorga permisos de micrófono y control de entrada para que Stet pueda grabar y escribir texto en tus aplicaciones.";
 "Choose the shortcut you want to use for dictation." = "Elige el atajo que quieres usar para el dictado.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Mantén presionado el atajo y habla con naturalidad. Conservaremos tu intención mientras realizamos la limpieza necesaria.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Pulsa el atajo y habla con naturalidad. Conservaremos tu intención mientras realizamos la limpieza necesaria.";
 "Browse themes on the right, then apply and finish." = "Explora los temas a la derecha, luego aplícalo y termina.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Mantén presionado tu atajo y empieza a hablar en cualquier lugar donde puedas escribir texto.";
+"Press your shortcut and start speaking anywhere you can type text." = "Pulsa tu atajo y empieza a hablar en cualquier lugar donde puedas escribir texto.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Descarga el modelo para procesar tu voz localmente";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Sélectionnez votre fournisseur d'IA préféré pour gérer la transcription et le nettoyage.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Accordez les autorisations de microphone et de contrôle de saisie pour que Stet puisse enregistrer et insérer du texte dans vos applications.";
 "Choose the shortcut you want to use for dictation." = "Choisissez le raccourci que vous souhaitez utiliser pour la dictée.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Maintenez le raccourci et parlez naturellement. Nous préserverons votre intention tout en effectuant les corrections nécessaires.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Appuyez sur le raccourci et parlez naturellement. Nous préserverons votre intention tout en effectuant les corrections nécessaires.";
 "Browse themes on the right, then apply and finish." = "Parcourez les thèmes à droite, puis appliquez et terminez.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Maintenez votre raccourci et commencez à parler partout où vous pouvez écrire du texte.";
+"Press your shortcut and start speaking anywhere you can type text." = "Appuyez sur votre raccourci et commencez à parler partout où vous pouvez écrire du texte.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Téléchargez le modèle pour traiter votre voix localement";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Seleziona il tuo provider AI preferito per gestire la trascrizione e la pulizia.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Concedi le autorizzazioni al microfono e al controllo dell'input affinché Stet possa registrare e inserire il testo nelle tue app.";
 "Choose the shortcut you want to use for dictation." = "Scegli la scorciatoia che desideri utilizzare per la dettatura.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Tieni premuta la scorciatoia e parla in modo naturale. Conserveremo le tue intenzioni eseguendo la pulizia necessaria.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Premi la scorciatoia e parla in modo naturale. Conserveremo le tue intenzioni eseguendo la pulizia necessaria.";
 "Browse themes on the right, then apply and finish." = "Esplora i temi sulla destra, poi applica e termina.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Tieni premuta la tua scorciatoia e inizia a parlare ovunque tu possa inserire del testo.";
+"Press your shortcut and start speaking anywhere you can type text." = "Premi la tua scorciatoia e inizia a parlare ovunque tu possa inserire del testo.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Scarica il modello per elaborare la tua voce localmente";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "文字起こしとテキストの整理を処理するAIプロバイダーを選択してください。";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Stetが録音し、アプリにテキストを入力できるように、マイクと入力制御の権限を付与してください。";
 "Choose the shortcut you want to use for dictation." = "音声入力に使用するショートカットを選択してください。";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "ショートカットを押したまま自然に話してください。意図を保ちつつ必要な整理を行います。";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "ショートカットを押して自然に話してください。意図を保ちつつ必要な整理を行います。";
 "Browse themes on the right, then apply and finish." = "右側のテーマを閲覧し、適用して完了します。";
-"Hold your shortcut and start speaking anywhere you can type text." = "テキストを入力できる場所ならどこでも、ショートカットを押したまま話し始めてください。";
+"Press your shortcut and start speaking anywhere you can type text." = "テキストを入力できる場所ならどこでも、ショートカットを押して話し始めてください。";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "音声をローカルで処理するためにモデルをダウンロードします";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "전사 및 텍스트 정리를 처리할 선호하는 AI 제공자를 선택하세요.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Stet이 녹음하고 앱에 텍스트를 입력할 수 있도록 마이크 및 입력 제어 권한을 부여하세요.";
 "Choose the shortcut you want to use for dictation." = "받아쓰기에 사용할 단축키를 선택하세요.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "단축키를 누른 상태에서 자연스럽게 말하세요. 필요한 정리를 수행하면서 당신의 의도를 보존합니다.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "단축키를 누르고 자연스럽게 말하세요. 필요한 정리를 수행하면서 당신의 의도를 보존합니다.";
 "Browse themes on the right, then apply and finish." = "오른쪽의 테마를 둘러본 다음 적용하고 완료하세요.";
-"Hold your shortcut and start speaking anywhere you can type text." = "텍스트를 입력할 수 있는 곳이라면 어디서든 단축키를 누르고 말을 시작하세요.";
+"Press your shortcut and start speaking anywhere you can type text." = "텍스트를 입력할 수 있는 곳이라면 어디서든 단축키를 누르고 말을 시작하세요.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "기기에서 음성을 처리하기 위한 모델 다운로드";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "Selecione seu provedor de IA preferido para lidar com a transcrição e limpeza.";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "Conceda permissões de microfone e controle de entrada para que o Stet possa gravar e inserir texto em seus aplicativos.";
 "Choose the shortcut you want to use for dictation." = "Escolha o atalho que deseja usar para o ditado.";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Mantenha o atalho pressionado e fale naturalmente. Preservaremos sua intenção ao realizar a limpeza necessária.";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "Pressione o atalho e fale naturalmente. Preservaremos sua intenção ao realizar a limpeza necessária.";
 "Browse themes on the right, then apply and finish." = "Navegue pelos temas à direita, depois aplique e termine.";
-"Hold your shortcut and start speaking anywhere you can type text." = "Mantenha o atalho pressionado e comece a falar onde puder digitar texto.";
+"Press your shortcut and start speaking anywhere you can type text." = "Pressione o atalho e comece a falar onde puder digitar texto.";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "Baixe o modelo para processar sua voz localmente";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -175,9 +175,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "选择您偏好的 AI 服务商来处理转录和文本整理。";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "授予麦克风和输入控制权限，以便 Stet 能够录音并将文字输入您的应用。";
 "Choose the shortcut you want to use for dictation." = "选择您用于听写的快捷键。";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "按住快捷键自然说话。我们会保留您的意图并进行必要的整理。";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "按下快捷键自然说话。我们会保留您的意图并进行必要的整理。";
 "Browse themes on the right, then apply and finish." = "在右侧浏览主题，然后应用并完成。";
-"Hold your shortcut and start speaking anywhere you can type text." = "按住快捷键，在任何可以输入文字的地方开始说话。";
+"Press your shortcut and start speaking anywhere you can type text." = "按下快捷键，在任何可以输入文字的地方开始说话。";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "下载模型以在本地处理您的语音";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -160,9 +160,9 @@
 "Select your preferred AI provider to handle transcription and cleanup." = "選擇您偏好的 AI 服務商來處理轉錄和文本整理。";
 "Grant microphone and input control permissions so Stet can record and type text back into your apps." = "授予麥克風和輸入控制權限，以便 Stet 能夠錄音並將文字輸入您的應用。";
 "Choose the shortcut you want to use for dictation." = "選擇您用於聽寫的快捷鍵。";
-"Hold the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "按住快捷鍵自然說話。我們會保留您的意圖並進行必要的整理。";
+"Press the shortcut and speak naturally. We'll preserve your intent while performing necessary cleanup." = "按下快捷鍵自然說話。我們會保留您的意圖並進行必要的整理。";
 "Browse themes on the right, then apply and finish." = "在右側瀏覽主題，然後應用並完成。";
-"Hold your shortcut and start speaking anywhere you can type text." = "按住快捷鍵，在任何可以輸入文字的地方開始說話。";
+"Press your shortcut and start speaking anywhere you can type text." = "按下快捷鍵，在任何可以輸入文字的地方開始說話。";
 
 /* Onboarding steps */
 "Download the model to process your voice locally" = "下載模型以在本地處理您的語音";

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -92,7 +92,6 @@
     private final class FakeHotkeyRegistrar: MacDictationHotkeyRegistering {
         private(set) var clearDictationHandlersCallCount = 0
         private(set) var registerKeyDownCallCount = 0
-        private(set) var registerKeyUpCallCount = 0
 
         func clearDictationHandlers() {
             clearDictationHandlersCallCount += 1
@@ -100,10 +99,6 @@
 
         func registerDictationKeyDown(_ handler: @escaping () -> Void) {
             registerKeyDownCallCount += 1
-        }
-
-        func registerDictationKeyUp(_ handler: @escaping () -> Void) {
-            registerKeyUpCallCount += 1
         }
     }
 

--- a/StetMacTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerSettingsTests.swift
@@ -93,7 +93,6 @@
     private final class TestHotkeyRegistrar: MacDictationHotkeyRegistering {
         private(set) var clearHandlersCallCount = 0
         private(set) var registerKeyDownCallCount = 0
-        private(set) var registerKeyUpCallCount = 0
 
         func clearDictationHandlers() {
             clearHandlersCallCount += 1
@@ -101,10 +100,6 @@
 
         func registerDictationKeyDown(_ handler: @escaping () -> Void) {
             registerKeyDownCallCount += 1
-        }
-
-        func registerDictationKeyUp(_ handler: @escaping () -> Void) {
-            registerKeyUpCallCount += 1
         }
     }
 

--- a/StetMacTests/App/Workflows/MacDictationHotkeyInteractionTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationHotkeyInteractionTests.swift
@@ -2,69 +2,38 @@ import Testing
 
 @testable import Stet
 
-@Suite("Mac Dictation Hotkey Interaction", .serialized)
+@Suite("Mac Dictation Hotkey Interaction")
 struct MacDictationHotkeyInteractionTests {
-    @Test func shortPressLatchesListeningAndSecondPressStops() {
-        var interaction = MacDictationHotkeyInteraction()
+    @Test func tapStartsCaptureAndSecondTapStops() {
+        let interaction = MacDictationHotkeyInteraction()
 
-        #expect(interaction.handleKeyDown(for: .idle, now: 10) == .startCapture)
-        #expect(interaction.state == .pressCandidate(startedAt: 10))
-
-        #expect(interaction.handleKeyUp(for: .listening, now: 10.1) == .none)
-        #expect(interaction.state == .latchedListening)
-
-        #expect(interaction.handleKeyDown(for: .listening, now: 10.2) == .stopCapture)
-        #expect(interaction.state == .suppressNextKeyUp)
-
-        #expect(interaction.handleKeyUp(for: .processing, now: 10.21) == .none)
-        #expect(interaction.state == .idle)
+        #expect(interaction.handleKeyDown(for: .idle) == .startCapture)
+        #expect(interaction.handleKeyDown(for: .listening) == .stopCapture)
     }
 
-    @Test func heldPressStopsOnRelease() {
-        var interaction = MacDictationHotkeyInteraction()
+    @Test func tapStopsListeningStartedOutsideHotkeyFlow() {
+        let interaction = MacDictationHotkeyInteraction()
 
-        #expect(interaction.handleKeyDown(for: .idle, now: 20) == .startCapture)
-        #expect(interaction.handleKeyUp(for: .listening, now: 20.35) == .stopCapture)
-        #expect(interaction.state == .idle)
+        #expect(interaction.handleKeyDown(for: .listening) == .stopCapture)
+        #expect(interaction.handleKeyDown(for: .starting) == .stopCapture)
     }
 
-    @Test func hotkeyCanStopListeningStartedOutsideHotkeyFlow() {
-        var interaction = MacDictationHotkeyInteraction()
+    @Test func processingAndClipboardPendingIgnoreHotkeyPress() {
+        let interaction = MacDictationHotkeyInteraction()
 
-        #expect(interaction.handleKeyDown(for: .listening, now: 30) == .stopCapture)
-        #expect(interaction.state == .suppressNextKeyUp)
-
-        interaction.sync(with: .processing)
-        #expect(interaction.state == .idle)
-    }
-
-    @Test func processingStateIgnoresHotkeyEvents() {
-        var interaction = MacDictationHotkeyInteraction()
-
-        #expect(interaction.handleKeyDown(for: .processing, now: 40) == .none)
-        #expect(interaction.handleKeyUp(for: .processing, now: 40.1) == .none)
-        #expect(interaction.state == .idle)
-    }
-
-    @Test func syncResetsLatchedStateWhenDictationEnds() {
-        var interaction = MacDictationHotkeyInteraction()
-
-        _ = interaction.handleKeyDown(for: .idle, now: 50)
-        _ = interaction.handleKeyUp(for: .listening, now: 50.1)
-        #expect(interaction.state == .latchedListening)
-
-        interaction.sync(with: .result("done"))
-        #expect(interaction.state == .idle)
+        #expect(interaction.handleKeyDown(for: .processing) == .none)
+        #expect(interaction.handleKeyDown(for: .clipboardPending("copied")) == .none)
     }
 
     @Test func startActionsRemainAvailableAfterIdleResultAndError() {
+        let interaction = MacDictationHotkeyInteraction()
+
         for state in [
             DictationState.idle,
             .result("previous"),
             .error(.failedToStart),
         ] {
-            var interaction = MacDictationHotkeyInteraction()
-            #expect(interaction.handleKeyDown(for: state, now: 60) == .startCapture)
+            #expect(interaction.handleKeyDown(for: state) == .startCapture)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove push-to-talk / hold-threshold detection from the dictation hotkey so a press starts capture and a second press stops it.
- Drop key-up handling, which was the source of hold-vs-tap jitter on release.
- Update onboarding copy from “hold the shortcut” to “press the shortcut.”

## Test plan
- [ ] Press the dictation shortcut once: capture starts and continues after key-up
- [ ] Press the same shortcut again: capture stops
- [ ] Hold the shortcut for more than ~0.35s, then release: capture does **not** stop on release
- [ ] Start capture from the UI, then stop it with the hotkey
- [ ] Confirm processing / clipboard-pending states ignore the hotkey
- [ ] Skim onboarding first-success and done copy for “press” rather than “hold”


Made with [Cursor](https://cursor.com)