### PR TITLE
fix(mac): keep History transcript distinct from rewrite

### DIFF
--- a/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
+++ b/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
@@ -1,6 +1,14 @@
 import Foundation
 import SwiftData
 
+@MainActor
+public protocol DictationHistoryRecording: AnyObject {
+    func recordRaw(_ text: String)
+    func recordLLM(_ text: String)
+    @discardableResult
+    func commitPending() -> UUID?
+}
+
 // MARK: - DictationHistoryService
 
 /// Manages the persistent history of dictation sessions.
@@ -9,7 +17,7 @@ import SwiftData
 /// Persistence writes are dispatched to a background `ModelContext` so they never
 /// block the main thread or the audio/transcription pipeline.
 @MainActor
-public final class DictationHistoryService {
+public final class DictationHistoryService: DictationHistoryRecording {
     public static let shared = DictationHistoryService()
 
     // MARK: - Internal session accumulator

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -180,7 +180,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
     func stopRecording(
         onCaptureStopped: (@Sendable () async -> Void)? = nil
-    ) async throws -> String {
+    ) async throws -> SpeechTranscriptionResult {
         guard let pipeline = activePipeline,
             let captureService = activeCaptureService
         else {
@@ -283,6 +283,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
         do {
             let finalTranscript: String
+            var wasRewritten = false
             let rewriteStartedAt = ProcessInfo.processInfo.systemUptime
             do {
                 if let rewriteService = pipeline.rewriteService {
@@ -298,6 +299,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                     let rewrittenTranscript = try await rewriteService.rewrite(request)
 
                     finalTranscript = rewrittenTranscript
+                    wasRewritten = true
                     if let rewriteProvider = pipeline.rewriteProvider {
                         await DictationTranscriptTrace.shared.record(
                             provider: rewriteProvider,
@@ -351,7 +353,11 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             )
 
             await releaseContextOnExit()
-            return trimmedTranscript
+            return SpeechTranscriptionResult(
+                rawText: intermediateTranscript,
+                text: trimmedTranscript,
+                wasRewritten: wasRewritten
+            )
         } catch {
             await DictationLatencyProbe.shared.record(.transcriptionFailed, note: error.localizedDescription)
             logger.error("Post-transcription processing failed: \(error.localizedDescription)")

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -354,7 +354,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
             await releaseContextOnExit()
             return SpeechTranscriptionResult(
-                rawText: intermediateTranscript,
+                rawText: wasRewritten ? intermediateTranscript : trimmedTranscript,
                 text: trimmedTranscript,
                 wasRewritten: wasRewritten
             )

--- a/StetMac/Core/Speech/MockSpeechService.swift
+++ b/StetMac/Core/Speech/MockSpeechService.swift
@@ -14,12 +14,12 @@ struct MockSpeechService: SpeechService {
 
     func stopRecording(
         onCaptureStopped: (@Sendable () async -> Void)? = nil
-    ) async throws -> String {
+    ) async throws -> SpeechTranscriptionResult {
         if let onCaptureStopped {
             await onCaptureStopped()
         }
         try await Task.sleep(nanoseconds: 900_000_000)
-        return "This is a mock transcription from the speech service."
+        return SpeechTranscriptionResult("This is a mock transcription from the speech service.")
     }
 
     func cancelRecording() async {

--- a/StetMac/Core/Speech/SpeechService.swift
+++ b/StetMac/Core/Speech/SpeechService.swift
@@ -1,18 +1,45 @@
 import Foundation
 
+/// Outcome of a completed capture: raw ASR text plus the post-rewrite string that
+/// should be delivered. History needs both; callers that only paste text use `text`.
+struct SpeechTranscriptionResult: Equatable, Sendable, ExpressibleByStringLiteral {
+    /// Trimmed ASR output, before rewrite.
+    let rawText: String
+    /// Text after rewrite and any local punctuation cleanup. Same as `rawText` when rewrite did not run.
+    let text: String
+    /// True when a rewrite service produced `text` (even if it happens to equal `rawText`).
+    let wasRewritten: Bool
+
+    init(rawText: String, text: String, wasRewritten: Bool) {
+        self.rawText = rawText
+        self.text = text
+        self.wasRewritten = wasRewritten
+    }
+
+    init(_ text: String) {
+        self.rawText = text
+        self.text = text
+        self.wasRewritten = false
+    }
+
+    init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
 protocol SpeechService: Sendable {
     func startRecording() async throws
     func startRecordingAndActivate() async throws
     func activateRecordingWindow() async throws
     func stopRecording(
         onCaptureStopped: (@Sendable () async -> Void)?
-    ) async throws -> String
+    ) async throws -> SpeechTranscriptionResult
     func cancelRecording() async
     func prewarm() async
 }
 
 extension SpeechService {
-    func stopRecording() async throws -> String {
+    func stopRecording() async throws -> SpeechTranscriptionResult {
         try await stopRecording(onCaptureStopped: nil)
     }
 }

--- a/StetMac/Core/Speech/SpeechService.swift
+++ b/StetMac/Core/Speech/SpeechService.swift
@@ -3,7 +3,8 @@ import Foundation
 /// Outcome of a completed capture: raw ASR text plus the post-rewrite string that
 /// should be delivered. History needs both; callers that only paste text use `text`.
 struct SpeechTranscriptionResult: Equatable, Sendable, ExpressibleByStringLiteral {
-    /// Trimmed ASR output, before rewrite.
+    /// ASR output before rewrite. When rewrite did not run (or failed), this is the
+    /// delivered text after local punctuation cleanup, so it matches `text`.
     let rawText: String
     /// Text after rewrite and any local punctuation cleanup. Same as `rawText` when rewrite did not run.
     let text: String

--- a/StetMac/Features/Dictation/DictationViewModel.swift
+++ b/StetMac/Features/Dictation/DictationViewModel.swift
@@ -11,6 +11,7 @@ final class DictationViewModel: ObservableObject {
     typealias ExternalOperation = @MainActor @Sendable () async throws -> String
 
     private let speechService: any SpeechService
+    private let historyService: any DictationHistoryRecording
     private let manualActivationFallbackDelay: Duration
     private var activeTask: Task<Void, Never>?
     private var captureStartupTask: Task<Void, Error>?
@@ -36,10 +37,12 @@ final class DictationViewModel: ObservableObject {
 
     init(
         speechService: any SpeechService,
-        manualActivationFallbackDelay: Duration = .seconds(1)
+        manualActivationFallbackDelay: Duration = .seconds(1),
+        historyService: any DictationHistoryRecording = DictationHistoryService.shared
     ) {
         self.speechService = speechService
         self.manualActivationFallbackDelay = manualActivationFallbackDelay
+        self.historyService = historyService
     }
 
     func send(_ action: DictationAction) {
@@ -316,7 +319,7 @@ final class DictationViewModel: ObservableObject {
 
         activeTask = Task {
             do {
-                let text = try await speechService.stopRecording(
+                let transcription = try await speechService.stopRecording(
                     onCaptureStopped: {
                         guard let captureStoppedHandler else { return }
                         await MainActor.run {
@@ -325,19 +328,22 @@ final class DictationViewModel: ObservableObject {
                     }
                 )
                 if Task.isCancelled { return }
-                // [History point A] Record raw ASR output.
-                DictationHistoryService.shared.recordRaw(text)
+                // [History point A] Record raw ASR output, not the post-rewrite string.
+                historyService.recordRaw(transcription.rawText)
                 let finalText: String
                 if let resultTransformer {
-                    finalText = try await resultTransformer(text)
+                    finalText = try await resultTransformer(transcription.text)
                     // [History point B] Record LLM-refined output.
-                    DictationHistoryService.shared.recordLLM(finalText)
+                    historyService.recordLLM(finalText)
+                } else if transcription.wasRewritten {
+                    finalText = transcription.text
+                    historyService.recordLLM(transcription.text)
                 } else {
-                    finalText = text
+                    finalText = transcription.text
                 }
                 // Persist immediately — every transcription is recorded whether or
                 // not the text is ultimately delivered to a target app.
-                DictationHistoryService.shared.commitPending()
+                historyService.commitPending()
                 self.resultTransformer = nil
                 send(.transcriptionSucceeded(finalText))
             } catch is CancellationError {

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -821,6 +821,55 @@ struct ConfigurableSpeechServiceTests {
         #expect(await rewrite.recordedRequests().isEmpty)
     }
 
+    @Test func stopRecordingUsesCleanedTextAsRawWhenRewriteIsDisabled() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+
+        let direct = TestTranscriptionService(result: "hello.")
+        let rewrite = RecordingRewriteService()
+        await rewrite.setResult("should not be used")
+        let (store, _, _) = try makeSettingsStore(rewriteEnabled: false)
+        let service = makeDictationService(
+            settingsStore: store,
+            directTranscriptionService: direct,
+            rewriteService: rewrite
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.rawText == "hello")
+        #expect(result.text == "hello")
+        #expect(!result.wasRewritten)
+    }
+
+    @Test func stopRecordingUsesCleanedTextAsRawAfterRewriteFailure() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+
+        let direct = TestTranscriptionService(result: "hello.")
+        let rewrite = RecordingRewriteService()
+        await rewrite.setError(TestError.expected)
+        let (store, _, _) = try makeSettingsStore(
+            rewriteProvider: .appleIntelligence,
+            rewriteEnabled: true,
+            apiKey: nil
+        )
+        let service = makeDictationService(
+            settingsStore: store,
+            directTranscriptionService: direct,
+            rewriteService: rewrite
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.rawText == "hello")
+        #expect(result.text == "hello")
+        #expect(!result.wasRewritten)
+        #expect(await rewrite.recordedRequests().count == 1)
+    }
+
     @Test func stopRecordingUsesProcessedAudioURLForTranscription() async throws {
         let sourceAudioURL = makeAudioFileURL()
         let processedAudioURL = makeAudioFileURL()

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -490,7 +490,9 @@ struct ConfigurableSpeechServiceTests {
         try await service.startRecording()
         let result = try await service.stopRecording()
 
-        #expect(result == "full interval")
+        #expect(result.text == "full interval")
+        #expect(result.rawText == "full interval")
+        #expect(!result.wasRewritten)
         #expect(await postProcessor.lastInvocation() == nil)
         #expect(await direct.lastInvocation()?.fileURL == sourceAudioURL)
         #expect(await direct.lastInvocation()?.duration == 1.2)
@@ -523,7 +525,9 @@ struct ConfigurableSpeechServiceTests {
         let rewriteRequests = await rewrite.recordedRequests()
         let directInvocation = await direct.lastInvocation()
 
-        #expect(transcript == "rewritten transcript")
+        #expect(transcript.rawText == "source transcript")
+        #expect(transcript.text == "rewritten transcript")
+        #expect(transcript.wasRewritten)
         #expect(directInvocation?.prompt?.contains("OpenAI, Groq") == true)
         #expect(directInvocation?.languageCode == "en")
         #expect(await direct.callCount() == 1)
@@ -645,7 +649,9 @@ struct ConfigurableSpeechServiceTests {
         try await service.startRecording()
         let result = try await service.stopRecording()
 
-        #expect(result == "rewritten transcript")
+        #expect(result.rawText == "raw transcript")
+        #expect(result.text == "rewritten transcript")
+        #expect(result.wasRewritten)
         #expect(await direct.callCount() == 1)
         #expect(await rewrite.recordedRequests().count == 1)
     }
@@ -673,7 +679,9 @@ struct ConfigurableSpeechServiceTests {
         try await service.startRecording()
         let result = try await service.stopRecording()
 
-        #expect(result == "云端模型已经处理好这个句号。")
+        #expect(result.rawText == "raw transcript")
+        #expect(result.text == "云端模型已经处理好这个句号。")
+        #expect(result.wasRewritten)
     }
 
     @Test func appleIntelligenceRewriteKeepsManualPunctuationCleanup() async throws {
@@ -699,7 +707,9 @@ struct ConfigurableSpeechServiceTests {
         try await service.startRecording()
         let result = try await service.stopRecording()
 
-        #expect(result == "Apple Intelligence 仍然需要这层清理")
+        #expect(result.rawText == "raw transcript")
+        #expect(result.text == "Apple Intelligence 仍然需要这层清理")
+        #expect(result.wasRewritten)
     }
 
     @Test func byokGroqToGroqUsesSingleProviderForBothRemoteSteps() async throws {
@@ -726,7 +736,9 @@ struct ConfigurableSpeechServiceTests {
         let result = try await service.stopRecording()
         let request = try #require(await rewrite.recordedRequests().first)
 
-        #expect(result == "groq rewrite")
+        #expect(result.rawText == "groq transcript")
+        #expect(result.text == "groq rewrite")
+        #expect(result.wasRewritten)
         #expect(request.text == "groq transcript")
         #expect(await direct.callCount() == 1)
     }
@@ -756,10 +768,57 @@ struct ConfigurableSpeechServiceTests {
         let result = try await service.stopRecording()
         let request = try #require(await rewrite.recordedRequests().first)
 
-        #expect(result == "mixed provider rewrite")
+        #expect(result.rawText == "mixed provider transcript")
+        #expect(result.text == "mixed provider rewrite")
+        #expect(result.wasRewritten)
         #expect(request.text == "mixed provider transcript")
         #expect(request.audience == .ai)
         #expect(await direct.callCount() == 1)
+    }
+
+    @Test func stopRecordingKeepsRawASRSeparateFromRewrittenText() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+
+        let direct = TestTranscriptionService(result: " um hello world ")
+        let rewrite = RecordingRewriteService()
+        await rewrite.setResult("Hello world.")
+        let (store, _, _) = try makeSettingsStore(rewriteEnabled: true)
+        let service = makeDictationService(
+            settingsStore: store,
+            directTranscriptionService: direct,
+            rewriteService: rewrite
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.rawText == "um hello world")
+        #expect(result.text == "Hello world.")
+        #expect(result.wasRewritten)
+    }
+
+    @Test func stopRecordingDoesNotMarkRewriteWhenRewriteIsDisabled() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+
+        let direct = TestTranscriptionService(result: "raw asr text")
+        let rewrite = RecordingRewriteService()
+        await rewrite.setResult("should not be used")
+        let (store, _, _) = try makeSettingsStore(rewriteEnabled: false)
+        let service = makeDictationService(
+            settingsStore: store,
+            directTranscriptionService: direct,
+            rewriteService: rewrite
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.rawText == "raw asr text")
+        #expect(result.text == "raw asr text")
+        #expect(!result.wasRewritten)
+        #expect(await rewrite.recordedRequests().isEmpty)
     }
 
     @Test func stopRecordingUsesProcessedAudioURLForTranscription() async throws {
@@ -797,7 +856,7 @@ struct ConfigurableSpeechServiceTests {
         let postProcessorInvocation = await postProcessor.lastInvocation()
         let directInvocation = await direct.lastInvocation()
 
-        #expect(transcript == "processed transcript")
+        #expect(transcript.text == "processed transcript")
         #expect(postProcessorInvocation?.sourceURL == sourceAudioURL)
         #expect(postProcessorInvocation?.duration == 1.2)
         #expect(directInvocation?.fileURL == processedAudioURL)
@@ -905,7 +964,9 @@ struct ConfigurableSpeechServiceTests {
 
         let result = try await service.stopRecording()
 
-        #expect(result == "processed transcript")
+        #expect(result.rawText == "processed transcript")
+        #expect(result.text == "processed transcript")
+        #expect(!result.wasRewritten)
         #expect(!FileManager.default.fileExists(atPath: processedAudioURL.path))
         #expect(await direct.callCount() == 1)
         #expect(await rewrite.recordedRequests().count == 1)
@@ -1014,7 +1075,7 @@ struct ConfigurableSpeechServiceTests {
 
         let result = try await service.stopRecording()
 
-        #expect(result == "source")
+        #expect(result.text == "source")
         #expect(await direct.callCount() == 1)
         #expect(await rewrite.recordedRequests().count == 1)
     }

--- a/StetMacTests/Features/Dictation/DictationViewModelTests.swift
+++ b/StetMacTests/Features/Dictation/DictationViewModelTests.swift
@@ -73,6 +73,75 @@ struct DictationViewModelTests {
         #expect(viewModel.state == .result("DRAFT"))
     }
 
+    @Test func recordsRawASRAndRewrittenTextSeparatelyInHistory() async throws {
+        let speechService = ControllableSpeechService()
+        await speechService.setStopBehavior(
+            .immediate(
+                SpeechTranscriptionResult(
+                    rawText: "um hello world",
+                    text: "Hello world.",
+                    wasRewritten: true
+                )
+            )
+        )
+        let history = HistoryRecordingSpy()
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay,
+            historyService: history
+        )
+
+        viewModel.startCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .listening })
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("Hello world.") })
+
+        #expect(history.rawTexts == ["um hello world"])
+        #expect(history.llmTexts == ["Hello world."])
+        #expect(history.commitCount == 1)
+    }
+
+    @Test func doesNotRecordLLMHistoryWhenRewriteDidNotRun() async throws {
+        let speechService = ControllableSpeechService()
+        await speechService.setStopBehavior(.immediate("plain transcript"))
+        let history = HistoryRecordingSpy()
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay,
+            historyService: history
+        )
+
+        viewModel.startCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .listening })
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("plain transcript") })
+
+        #expect(history.rawTexts == ["plain transcript"])
+        #expect(history.llmTexts.isEmpty)
+        #expect(history.commitCount == 1)
+    }
+
+    @Test func transformIsRecordedAsLLMHistoryEvenWithoutSpeechRewrite() async throws {
+        let speechService = ControllableSpeechService()
+        await speechService.setStopBehavior(.immediate("draft"))
+        let history = HistoryRecordingSpy()
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay,
+            historyService: history
+        )
+
+        viewModel.startCapture { text in
+            text.uppercased()
+        }
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("DRAFT") })
+
+        #expect(history.rawTexts == ["draft"])
+        #expect(history.llmTexts == ["DRAFT"])
+        #expect(history.commitCount == 1)
+    }
+
     @Test func resetCancelsActiveRecordingAndReturnsToIdle() async {
         let speechService = ControllableSpeechService()
         await speechService.setStartBehavior(.suspended)
@@ -307,4 +376,24 @@ struct DictationViewModelTests {
         #expect(await TestSupport.eventually { viewModel.state == .idle })
     }
 
+}
+
+@MainActor
+private final class HistoryRecordingSpy: DictationHistoryRecording {
+    var rawTexts: [String] = []
+    var llmTexts: [String] = []
+    var commitCount = 0
+
+    func recordRaw(_ text: String) {
+        rawTexts.append(text)
+    }
+
+    func recordLLM(_ text: String) {
+        llmTexts.append(text)
+    }
+
+    func commitPending() -> UUID? {
+        commitCount += 1
+        return UUID()
+    }
 }

--- a/StetMacTests/Support/TestSupport.swift
+++ b/StetMacTests/Support/TestSupport.swift
@@ -213,7 +213,7 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
     }
 
     enum StopBehavior: Sendable {
-        case immediate(String)
+        case immediate(SpeechTranscriptionResult)
         case suspended
         case fail(any Error & Sendable)
     }
@@ -221,7 +221,7 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
     private let audioLevelBridge = AudioLevelBridge()
     private var startContinuation: CheckedContinuation<Void, Error>?
     private var activationContinuation: CheckedContinuation<Void, Error>?
-    private var stopContinuation: CheckedContinuation<String, Error>?
+    private var stopContinuation: CheckedContinuation<SpeechTranscriptionResult, Error>?
 
     private var startBehavior: StartBehavior = .immediate
     private var activationBehavior: ActivationBehavior = .immediate
@@ -284,15 +284,15 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
 
     func stopRecording(
         onCaptureStopped: (@Sendable () async -> Void)? = nil
-    ) async throws -> String {
+    ) async throws -> SpeechTranscriptionResult {
         stopCallCount += 1
 
         switch stopBehavior {
-        case .immediate(let text):
+        case .immediate(let result):
             if let onCaptureStopped {
                 await onCaptureStopped()
             }
-            return text
+            return result
         case .suspended:
             if let onCaptureStopped {
                 await onCaptureStopped()
@@ -328,7 +328,11 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
     }
 
     func finishStop(with text: String) {
-        stopContinuation?.resume(returning: text)
+        finishStop(with: SpeechTranscriptionResult(text))
+    }
+
+    func finishStop(with result: SpeechTranscriptionResult) {
+        stopContinuation?.resume(returning: result)
         stopContinuation = nil
     }
 


### PR DESCRIPTION
## Summary
- History was recording `stopRecording`'s already-rewritten string as Transcript, so Transcript / LLM Refined / Delivered all showed the same copy.
- `stopRecording` now returns raw ASR and rewritten text separately; History stores ASR as Transcript and rewrite as LLM Refined. Delivered is still the text that was actually sent.

## Test plan
- [x] `StetTests/DictationViewModelTests` and `StetTests/ConfigurableSpeechServiceTests` (56 tests), including the new raw-vs-rewrite cases
- [ ] Dictate once with rewrite on, expand the new History row: Transcript should be ASR, LLM Refined / Delivered the rewritten text
- [ ] Dictate with rewrite off: no LLM Refined row; Transcript and Delivered match
- Existing History rows stay as they were; only new dictations pick up the split


Made with [Cursor](https://cursor.com)