### PR TITLE
fix(mac): release meeting microphone on stop

### DIFF
--- a/StetMac/App/Lifecycle/MacAppModel.swift
+++ b/StetMac/App/Lifecycle/MacAppModel.swift
@@ -134,7 +134,15 @@
                 self.meetingRecordingRuntime = meetingRecordingRuntime
                 Task { [weak self] in
                     await meetingRecordingRuntime.setPhaseHandler { [weak self] phase in
-                        self?.meetingRecordingPhase = phase
+                        guard let self else { return }
+                        let previous = self.meetingRecordingPhase
+                        self.meetingRecordingPhase = phase
+                        Task {
+                            await MacDictationCompletionNotificationService.shared.notifyMeetingPhase(
+                                from: previous,
+                                to: phase
+                            )
+                        }
                     }
                 }
             }
@@ -401,6 +409,26 @@
                 return "exclamationmark.triangle"
             case .idle:
                 return "record.circle"
+            }
+        }
+
+        var meetingToggleTitle: String {
+            switch meetingRecordingPhase {
+            case .idle, .failed:
+                return "Start Meeting Recording"
+            case .recording:
+                return "Stop Meeting Recording"
+            case .processing:
+                return "Processing meeting"
+            }
+        }
+
+        var canToggleMeetingRecording: Bool {
+            switch meetingRecordingPhase {
+            case .processing:
+                return false
+            case .idle, .recording, .failed:
+                return true
             }
         }
 

--- a/StetMac/Core/Speech/MacMeetingRecordingRuntime.swift
+++ b/StetMac/Core/Speech/MacMeetingRecordingRuntime.swift
@@ -122,6 +122,7 @@
             frameTask?.cancel()
             frameTask = nil
             logger.info("Meeting stop requested")
+            await dependencies.endExclusiveCapture()
             await setPhase(.processing)
             let samples = active.samples
             let directory = active.directory
@@ -159,7 +160,6 @@
                     speakerCount: Set(turns.map(\.speakerLabel)).count
                 )
                 try writeRecord(record, to: directory.sessionURL)
-                await dependencies.endExclusiveCapture()
                 await setPhase(.idle)
             } catch {
                 logger.error("Meeting processing failed: \(error.localizedDescription, privacy: .public)")
@@ -179,7 +179,6 @@
                     speakerCount: 0
                 )
                 try? writeRecord(record, to: directory.sessionURL)
-                await dependencies.endExclusiveCapture()
                 await setPhase(.failed(error.localizedDescription))
             }
 

--- a/StetMac/Features/MacShell/MacMenuBarView.swift
+++ b/StetMac/Features/MacShell/MacMenuBarView.swift
@@ -10,26 +10,22 @@
 
         var body: some View {
             Group {
-                if appModel.isMeetingBusy {
-                    if appModel.isMeetingRecording {
-                        Button {
-                            appModel.toggleMeetingRecording()
-                        } label: {
-                            Label(
-                                appModel.meetingStatusText,
-                                systemImage: appModel.meetingMenuSymbolName
-                            )
-                        }
-                    } else {
-                        Label(
-                            appModel.meetingStatusText,
-                            systemImage: appModel.meetingMenuSymbolName
-                        )
-                        .disabled(true)
-                    }
-
-                    Divider()
+                Button {
+                    appModel.toggleMeetingRecording()
+                } label: {
+                    Label(
+                        appModel.meetingToggleTitle,
+                        systemImage: appModel.meetingMenuSymbolName
+                    )
                 }
+                .disabled(!appModel.canToggleMeetingRecording)
+
+                if appModel.isMeetingBusy {
+                    Text(appModel.meetingStatusText)
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
 
                 if MacFeatureAvailability.isPassiveListeningVisible {
                     Label(

--- a/StetMac/Features/MacShell/MeetingSetting/MacMeetingSettingsView.swift
+++ b/StetMac/Features/MacShell/MeetingSetting/MacMeetingSettingsView.swift
@@ -3,6 +3,7 @@
     import SwiftUI
 
     struct MacMeetingSettingsView: View {
+        @EnvironmentObject private var appModel: MacAppModel
         @State private var recentFolders: [URL] = []
         @State private var revealMessage: String?
 
@@ -10,6 +11,23 @@
 
         var body: some View {
             Form {
+                Section {
+                    Button {
+                        appModel.toggleMeetingRecording()
+                    } label: {
+                        Label(
+                            LocalizedStringKey(appModel.meetingToggleTitle),
+                            systemImage: appModel.meetingMenuSymbolName
+                        )
+                    }
+                    .disabled(!appModel.canToggleMeetingRecording)
+
+                    Text(appModel.meetingStatusText)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Recording")
+                }
+
                 Section {
                     MacHotKeySettingsSectionView(hotkey: .meeting)
                 } header: {
@@ -46,6 +64,9 @@
             .padding(.leading, MacUI.SettingsViewMetrics.formHorizontalPadding)
             .padding(.bottom, MacUI.SettingsViewMetrics.formBottomPadding)
             .task {
+                reloadRecentFolders()
+            }
+            .onChange(of: appModel.meetingRecordingPhase) { _, _ in
                 reloadRecentFolders()
             }
         }

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "KI-optimiert";
 "Final Sent" = "Zugestellt";
 "Target App" = "Ziel-App";
+
+/* Meetings */
+"Record Meeting" = "Meeting aufnehmen";
+"Start Meeting Recording" = "Meeting-Aufnahme starten";
+"Stop Meeting Recording" = "Meeting-Aufnahme stoppen";
+"Recording" = "Aufnahme";
+"Recording meeting" = "Meeting wird aufgenommen";
+"Press the shortcut again to stop." = "Drücken Sie das Tastenkürzel erneut, um zu stoppen.";
+"Meeting recording stopped" = "Meeting-Aufnahme gestoppt";
+"The microphone is off. The transcript will be saved when it is ready." = "Das Mikrofon ist aus. Das Transkript wird gespeichert, sobald es fertig ist.";
+"Meeting saved" = "Meeting gespeichert";
+"Meeting failed" = "Meeting fehlgeschlagen";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -239,6 +239,15 @@
 
 /* Meetings settings */
 "Record Meeting" = "Record Meeting";
+"Start Meeting Recording" = "Start Meeting Recording";
+"Stop Meeting Recording" = "Stop Meeting Recording";
+"Recording" = "Recording";
+"Recording meeting" = "Recording meeting";
+"Press the shortcut again to stop." = "Press the shortcut again to stop.";
+"Meeting recording stopped" = "Meeting recording stopped";
+"The microphone is off. The transcript will be saved when it is ready." = "The microphone is off. The transcript will be saved when it is ready.";
+"Meeting saved" = "Meeting saved";
+"Meeting failed" = "Meeting failed";
 "Shortcut" = "Shortcut";
 "Control-Option-Command-M is the default. The shortcut toggles recording on key down; it is not hold-to-talk." = "Control-Option-Command-M is the default. The shortcut toggles recording on key down; it is not hold-to-talk.";
 "Meetings Folder" = "Meetings Folder";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "Refinado por IA";
 "Final Sent" = "Entregado";
 "Target App" = "App de destino";
+
+/* Meetings */
+"Record Meeting" = "Grabar reunión";
+"Start Meeting Recording" = "Iniciar grabación de reunión";
+"Stop Meeting Recording" = "Detener grabación de reunión";
+"Recording" = "Grabación";
+"Recording meeting" = "Grabando reunión";
+"Press the shortcut again to stop." = "Vuelve a pulsar el atajo para detener.";
+"Meeting recording stopped" = "Grabación de reunión detenida";
+"The microphone is off. The transcript will be saved when it is ready." = "El micrófono está apagado. La transcripción se guardará cuando esté lista.";
+"Meeting saved" = "Reunión guardada";
+"Meeting failed" = "Error en la reunión";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "Affiné par IA";
 "Final Sent" = "Livré";
 "Target App" = "Application cible";
+
+/* Meetings */
+"Record Meeting" = "Enregistrer une réunion";
+"Start Meeting Recording" = "Démarrer l’enregistrement de la réunion";
+"Stop Meeting Recording" = "Arrêter l’enregistrement de la réunion";
+"Recording" = "Enregistrement";
+"Recording meeting" = "Réunion en cours d’enregistrement";
+"Press the shortcut again to stop." = "Appuyez à nouveau sur le raccourci pour arrêter.";
+"Meeting recording stopped" = "Enregistrement de la réunion arrêté";
+"The microphone is off. The transcript will be saved when it is ready." = "Le microphone est coupé. La transcription sera enregistrée dès qu’elle sera prête.";
+"Meeting saved" = "Réunion enregistrée";
+"Meeting failed" = "Échec de la réunion";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "Ottimizzato dall'IA";
 "Final Sent" = "Consegnato";
 "Target App" = "App di destinazione";
+
+/* Meetings */
+"Record Meeting" = "Registra riunione";
+"Start Meeting Recording" = "Avvia registrazione riunione";
+"Stop Meeting Recording" = "Interrompi registrazione riunione";
+"Recording" = "Registrazione";
+"Recording meeting" = "Registrazione riunione in corso";
+"Press the shortcut again to stop." = "Premi di nuovo la scorciatoia per interrompere.";
+"Meeting recording stopped" = "Registrazione riunione interrotta";
+"The microphone is off. The transcript will be saved when it is ready." = "Il microfono è spento. La trascrizione verrà salvata quando sarà pronta.";
+"Meeting saved" = "Riunione salvata";
+"Meeting failed" = "Riunione non riuscita";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "AI最適化";
 "Final Sent" = "配信済み";
 "Target App" = "ターゲットアプリ";
+
+/* Meetings */
+"Record Meeting" = "会議を録音";
+"Start Meeting Recording" = "会議の録音を開始";
+"Stop Meeting Recording" = "会議の録音を停止";
+"Recording" = "録音";
+"Recording meeting" = "会議を録音中";
+"Press the shortcut again to stop." = "もう一度ショートカットを押すと停止します。";
+"Meeting recording stopped" = "会議の録音を停止しました";
+"The microphone is off. The transcript will be saved when it is ready." = "マイクはオフです。書き起こしの準備ができ次第保存されます。";
+"Meeting saved" = "会議を保存しました";
+"Meeting failed" = "会議に失敗しました";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "AI 정제";
 "Final Sent" = "전달됨";
 "Target App" = "대상 앱";
+
+/* Meetings */
+"Record Meeting" = "회의 녹음";
+"Start Meeting Recording" = "회의 녹음 시작";
+"Stop Meeting Recording" = "회의 녹음 중지";
+"Recording" = "녹음";
+"Recording meeting" = "회의 녹음 중";
+"Press the shortcut again to stop." = "바로 가기를 다시 누르면 중지됩니다.";
+"Meeting recording stopped" = "회의 녹음이 중지됨";
+"The microphone is off. The transcript will be saved when it is ready." = "마이크가 꺼졌습니다. 기록이 준비되면 저장됩니다.";
+"Meeting saved" = "회의가 저장됨";
+"Meeting failed" = "회의에 실패함";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "Refinado por IA";
 "Final Sent" = "Entregue";
 "Target App" = "App de destino";
+
+/* Meetings */
+"Record Meeting" = "Gravar reunião";
+"Start Meeting Recording" = "Iniciar gravação da reunião";
+"Stop Meeting Recording" = "Parar gravação da reunião";
+"Recording" = "Gravação";
+"Recording meeting" = "Gravando reunião";
+"Press the shortcut again to stop." = "Pressione o atalho novamente para parar.";
+"Meeting recording stopped" = "Gravação da reunião interrompida";
+"The microphone is off. The transcript will be saved when it is ready." = "O microfone está desligado. A transcrição será salva quando estiver pronta.";
+"Meeting saved" = "Reunião salva";
+"Meeting failed" = "Falha na reunião";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -241,6 +241,15 @@
 
 /* Meetings settings */
 "Record Meeting" = "录制会议";
+"Start Meeting Recording" = "开始录制会议";
+"Stop Meeting Recording" = "停止录制会议";
+"Recording" = "录音";
+"Recording meeting" = "正在录制会议";
+"Press the shortcut again to stop." = "再按一次快捷键即可停止。";
+"Meeting recording stopped" = "会议录音已停止";
+"The microphone is off. The transcript will be saved when it is ready." = "麦克风已关闭。转录完成后会保存文稿。";
+"Meeting saved" = "会议已保存";
+"Meeting failed" = "会议失败";
 "Shortcut" = "快捷键";
 "Control-Option-Command-M is the default. The shortcut toggles recording on key down; it is not hold-to-talk." = "默认快捷键是 Control-Option-Command-M。按下即开始或停止录音，不是按住说话。";
 "Meetings Folder" = "会议文件夹";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -211,3 +211,15 @@
 "LLM Refined" = "AI 優化";
 "Final Sent" = "已投遞";
 "Target App" = "目標應用程式";
+
+/* Meetings */
+"Record Meeting" = "錄製會議";
+"Start Meeting Recording" = "開始錄製會議";
+"Stop Meeting Recording" = "停止錄製會議";
+"Recording" = "錄音";
+"Recording meeting" = "正在錄製會議";
+"Press the shortcut again to stop." = "再按一次快捷鍵即可停止。";
+"Meeting recording stopped" = "會議錄音已停止";
+"The microphone is off. The transcript will be saved when it is ready." = "麥克風已關閉。轉錄完成後會儲存文稿。";
+"Meeting saved" = "會議已儲存";
+"Meeting failed" = "會議失敗";

--- a/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
+++ b/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
@@ -35,6 +35,28 @@
         }
 
         func notifyDictationCompleted() async {
+            let content = UNMutableNotificationContent()
+            content.title = String(localized: "Dictation complete")
+            await post(content, identifier: Self.requestIdentifier)
+        }
+
+        func notifyMeetingPhase(
+            from previous: MacMeetingRecordingPhase,
+            to phase: MacMeetingRecordingPhase
+        ) async {
+            guard
+                let payload = MacMeetingRecordingNotification.payload(from: previous, to: phase)
+            else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = payload.title
+            if let body = payload.body {
+                content.body = body
+            }
+            await post(content, identifier: MacMeetingRecordingNotification.requestIdentifier)
+        }
+
+        private func post(_ content: UNMutableNotificationContent, identifier: String) async {
             await requestAuthorizationIfNeeded()
             let settings = await center.notificationSettings()
             switch settings.authorizationStatus {
@@ -44,10 +66,8 @@
                 return
             }
 
-            let content = UNMutableNotificationContent()
-            content.title = String(localized: "Dictation complete")
             let request = UNNotificationRequest(
-                identifier: Self.requestIdentifier,
+                identifier: identifier,
                 content: content,
                 trigger: nil
             )
@@ -60,6 +80,41 @@
             withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
         ) {
             completionHandler([.banner, .list])
+        }
+    }
+
+    enum MacMeetingRecordingNotification {
+        static let requestIdentifier = "stet.meeting.recording"
+
+        struct Payload: Equatable, Sendable {
+            var title: String
+            var body: String?
+        }
+
+        static func payload(
+            from previous: MacMeetingRecordingPhase,
+            to phase: MacMeetingRecordingPhase
+        ) -> Payload? {
+            switch (previous, phase) {
+            case (.recording, .processing):
+                return Payload(
+                    title: String(localized: "Meeting recording stopped"),
+                    body: String(
+                        localized: "The microphone is off. The transcript will be saved when it is ready."
+                    )
+                )
+            case (_, .recording):
+                return Payload(
+                    title: String(localized: "Recording meeting"),
+                    body: String(localized: "Press the shortcut again to stop.")
+                )
+            case (.processing, .idle):
+                return Payload(title: String(localized: "Meeting saved"), body: nil)
+            case (_, .failed(let message)):
+                return Payload(title: String(localized: "Meeting failed"), body: message)
+            default:
+                return nil
+            }
         }
     }
 #endif

--- a/StetMac/StetApp.swift
+++ b/StetMac/StetApp.swift
@@ -28,11 +28,26 @@ struct StetApp: App {
                 wrappedValue: MacSettingsShellViewModel(coordinator: appModel)
             )
         }
+
+        @ViewBuilder
+        private var menuBarExtraLabel: some View {
+            if appModel.isMeetingRecording {
+                Image(systemName: "record.circle.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(Color.red, Color.primary)
+                    .accessibilityLabel("Recording meeting")
+            } else if appModel.isMeetingBusy {
+                Image(systemName: "hourglass")
+                    .accessibilityLabel("Processing meeting")
+            } else {
+                Image("menuBarIcon")
+            }
+        }
     #endif
 
     var body: some Scene {
         #if os(macOS)
-            MenuBarExtra("", image: "menuBarIcon") {
+            MenuBarExtra {
                 MacMenuBarView()
                     .environmentObject(appModel)
                     .environmentObject(settingsShellViewModel)
@@ -40,11 +55,14 @@ struct StetApp: App {
                     .onOpenURL { url in
                         appModel.handleDeepLink(url)
                     }
+            } label: {
+                menuBarExtraLabel
             }
             .menuBarExtraStyle(.menu)
 
             Window("Settings", id: MacWindowSceneID.preferences) {
                 MacSettingsView()
+                    .environmentObject(appModel)
                     .environmentObject(settingsShellViewModel)
                     .environmentObject(appUpdateManager)
             }

--- a/StetMacTests/Core/Speech/MacMeetingRecordingRuntimeTests.swift
+++ b/StetMacTests/Core/Speech/MacMeetingRecordingRuntimeTests.swift
@@ -190,6 +190,61 @@
             #expect(folders.count == 1)
             continuation.finish()
         }
+
+        @Test func stopReleasesExclusiveCaptureBeforeProcessingFinishes() async throws {
+            let root = TestSupport.temporaryDirectoryURL()
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let (stream, continuation) = AsyncStream<AudioCaptureFrame>.makeStream()
+            let exclusive = CallCounter()
+            let hold = AsyncHold()
+            let runtime = MacMeetingRecordingRuntime(
+                dependencies: MacMeetingRecordingRuntime.Dependencies(
+                    store: MeetingRecordingStore(rootDirectory: root),
+                    ensureCaptureRunning: {},
+                    beginExclusiveCapture: { exclusive.increment() },
+                    endExclusiveCapture: { exclusive.increment() },
+                    makeFrameStream: { stream },
+                    processor: MeetingSessionProcessor(
+                        sampleRate: 16_000,
+                        diarize: { _ in
+                            await hold.wait()
+                            return []
+                        },
+                        transcribe: { _ in "held" },
+                        identify: { _ in PassiveSpeakerMatch(identity: .other, similarity: nil) }
+                    ),
+                    now: { Date(timeIntervalSince1970: 1_704_067_200) }
+                )
+            )
+
+            await runtime.start()
+            continuation.yield(
+                AudioCaptureFrame(epoch: 1, startSample: 0, samples: [0.2, -0.2])
+            )
+            #expect(
+                await TestSupport.eventuallyAsync {
+                    await runtime.recordedSampleCount() == 2
+                }
+            )
+
+            let stopTask = Task { await runtime.toggle() }
+            #expect(
+                await TestSupport.eventuallyAsync {
+                    await runtime.currentPhase() == .processing
+                }
+            )
+            #expect(exclusive.value == 2)
+
+            await hold.waitUntilWaiting()
+            await hold.resume()
+            await stopTask.value
+            #expect(
+                await TestSupport.eventuallyAsync {
+                    await runtime.currentPhase() == .idle
+                }
+            )
+            continuation.finish()
+        }
     }
 
     private actor AsyncHold {

--- a/StetMacTests/Shared/Utilities/MacMeetingRecordingNotificationTests.swift
+++ b/StetMacTests/Shared/Utilities/MacMeetingRecordingNotificationTests.swift
@@ -1,0 +1,48 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+
+    @testable import Stet
+
+    @Suite("Mac Meeting Recording Notification")
+    struct MacMeetingRecordingNotificationTests {
+        @Test func startPostsRecordingBanner() {
+            let payload = MacMeetingRecordingNotification.payload(
+                from: .idle,
+                to: .recording(startedAt: Date(), folderName: "2024-01-01")
+            )
+
+            #expect(payload?.title == String(localized: "Recording meeting"))
+            #expect(payload?.body == String(localized: "Press the shortcut again to stop."))
+        }
+
+        @Test func stopPostsMicrophoneOffBannerBeforeTranscriptIsReady() {
+            let payload = MacMeetingRecordingNotification.payload(
+                from: .recording(startedAt: Date(), folderName: "2024-01-01"),
+                to: .processing
+            )
+
+            #expect(payload?.title == String(localized: "Meeting recording stopped"))
+            #expect(
+                payload?.body
+                    == String(
+                        localized: "The microphone is off. The transcript will be saved when it is ready."
+                    )
+            )
+        }
+
+        @Test func completedProcessingPostsSavedBanner() {
+            let payload = MacMeetingRecordingNotification.payload(
+                from: .processing,
+                to: .idle
+            )
+
+            #expect(payload?.title == String(localized: "Meeting saved"))
+            #expect(payload?.body == nil)
+        }
+
+        @Test func idleDoesNotPostABanner() {
+            #expect(MacMeetingRecordingNotification.payload(from: .idle, to: .idle) == nil)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- Stop meeting recording releases the microphone immediately, instead of holding capture until diarization and per-turn ASR finish.
- Post notifications when a meeting starts, stops (mic off), and saves, and add explicit start/stop controls in the menu bar and Meetings settings.

## Test plan
- [ ] Press the meeting shortcut to start recording; a "Recording meeting" notification appears and the menu bar icon shows recording.
- [ ] Press the same shortcut again; the system microphone indicator turns off immediately, even if transcript processing is still running.
- [ ] Confirm a "Meeting recording stopped" notification, then "Meeting saved" when the transcript is written.
- [ ] Stop from the menu bar item and from Settings → Meetings.
- [ ] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Stet.xcodeproj -scheme Stet -destination 'platform=macOS,arch=arm64' -only-testing:StetTests/MacMeetingRecordingRuntimeTests -only-testing:StetTests/MacMeetingRecordingNotificationTests test`


Made with [Cursor](https://cursor.com)