### PR TITLE
fix(mac): discard cancelled dictation instead of pasting it

### DIFF
--- a/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
@@ -61,9 +61,13 @@
         func bindState() {
             workflowController.dictationViewModel.$state
                 .dropFirst()
+                .map { [weak self] state in
+                    (state, self?.workflowController.dictationViewModel.captureSessionID)
+                }
                 .receive(on: DispatchQueue.main)
-                .sink { [weak self] state in
-                    self?.handleDictationStateChange(state)
+                .sink { [weak self] state, sessionID in
+                    guard let self, sessionID == workflowController.dictationViewModel.captureSessionID else { return }
+                    handleDictationStateChange(state)
                 }
                 .store(in: &cancellables)
         }
@@ -258,6 +262,7 @@
         }
 
         func startDictationCapture(from source: PrimaryActionSource) {
+            cancelPendingStateTasks()
             workflowController.startDictationCapture(
                 source: source,
                 allowCurrentAppTarget: requiresOnboarding && onboardingStepState == .firstSuccess,

--- a/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
@@ -107,6 +107,12 @@
 
             completionHandlingTask = Task { @MainActor [weak self] in
                 guard let self else { return }
+                guard !Task.isCancelled, case .result = dictationState else {
+                    Self.logger.info(
+                        "OutputTrace stage=session_result_mapping_skipped reason=cancelled_or_state_changed currentState=\(self.stateLabel(self.dictationState))"
+                    )
+                    return
+                }
                 let outcome = await workflowController.handleCompletedResult(
                     text: text,
                     showTransientPanel: showTransientPanel
@@ -150,6 +156,11 @@
                         showTransientPanel()
                     }
                     workflowController.dictationViewModel.send(.clipboardPending(text))
+                case .cancelled:
+                    hidePanel()
+                    if case .result = dictationState {
+                        workflowController.dictationViewModel.send(.resetTapped)
+                    }
                 case .failed(let failure):
                     if failure.preservesRecoveredTextInClipboard {
                         if !isPanelVisible {
@@ -307,6 +318,8 @@
                 return "completed"
             case .clipboardPending:
                 return "clipboardPending"
+            case .cancelled:
+                return "cancelled"
             case .failed(let failure):
                 return "failed:\(failureLabel(failure))"
             }

--- a/StetMac/App/Workflows/MacAppSessionController+Interface.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Interface.swift
@@ -17,6 +17,7 @@
         }
 
         func cancelActiveCapture() {
+            cancelPendingStateTasks()
             workflowController.cancelActiveCapture()
             hidePanel()
         }

--- a/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -29,6 +29,7 @@
             let shouldRevealPanelOnCapture: Bool
         }
 
+        private var completionID: UInt64 = 0
         private let clipboardService: any ClipboardService
         private let textInjectionService: any TextInjectionService
         private let pasteboard: NSPasteboard
@@ -77,6 +78,8 @@
                 return .completed
             }
 
+            completionID += 1
+            let outputID = completionID
             let shouldRestoreClipboardAfterSuccessfulPaste =
                 settings.shouldAutoPaste && !settings.shouldCopyToClipboard
 
@@ -183,6 +186,13 @@
                 }
 
                 let pasteOutcome = await textInjectionService.pasteClipboard(into: targetApplication)
+                guard outputID == completionID else { return .cancelled }
+                guard !Task.isCancelled else {
+                    if shouldRestoreClipboardAfterSuccessfulPaste {
+                        pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                    }
+                    return .cancelled
+                }
                 let targetAppProfile = resolveTargetAppOutputProfile(targetApplication: targetApplication)
                 emitOutputTrace(
                     traceID,
@@ -217,6 +227,7 @@
                     )
                     AnalyticsService.track("output_success", parameters: ["method": "auto_paste"])
                     // [History point C] Optimistic delivery confirmed.
+                    guard !Task.isCancelled, outputID == completionID else { return .cancelled }
                     DictationHistoryService.shared.updateFinal(
                         text,
                         targetBundleID: targetApplication?.bundleIdentifier,
@@ -234,6 +245,7 @@
                     emitOutputTrace(traceID, stage: "completion", details: "outcome=completed")
                     AnalyticsService.track("output_success", parameters: ["method": "auto_paste"])
                     // [History point C] Verified delivery.
+                    guard !Task.isCancelled, outputID == completionID else { return .cancelled }
                     DictationHistoryService.shared.updateFinal(
                         text,
                         targetBundleID: targetApplication?.bundleIdentifier,
@@ -327,6 +339,7 @@
             if outcome == .completed {
                 AnalyticsService.track("output_success", parameters: ["method": "clipboard"])
                 // [History point C] Copied directly to clipboard, no paste step.
+                guard !Task.isCancelled, outputID == completionID else { return .cancelled }
                 DictationHistoryService.shared.updateFinal(
                     text,
                     targetBundleID: targetApplication?.bundleIdentifier,

--- a/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -19,6 +19,7 @@
         enum CompletionOutcome: Equatable {
             case completed
             case clipboardPending
+            case cancelled
             case failed(DictationFailure)
         }
 
@@ -64,6 +65,11 @@
                 details:
                     "textLength=\(text.count) target=\(applicationSummary(targetApplication)) shouldCopyToClipboard=\(settings.shouldCopyToClipboard) shouldAutoPaste=\(settings.shouldAutoPaste) shouldRevealPanel=\(settings.shouldRevealPanelOnCapture)"
             )
+
+            guard !Task.isCancelled else {
+                emitOutputTrace(traceID, stage: "completion", details: "outcome=cancelled reason=task_cancelled")
+                return .cancelled
+            }
 
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 emitOutputTrace(traceID, stage: "completion", details: "outcome=completed reason=empty_text")
@@ -115,6 +121,14 @@
             }
 
             if settings.shouldAutoPaste {
+                guard !Task.isCancelled else {
+                    if shouldRestoreClipboardAfterSuccessfulPaste {
+                        pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                    }
+                    emitOutputTrace(
+                        traceID, stage: "completion", details: "outcome=cancelled reason=task_cancelled_before_paste")
+                    return .cancelled
+                }
                 if !textInjectionService.isAvailable {
                     let accessState = textInjectionService.accessState
                     emitOutputTrace(
@@ -370,6 +384,8 @@
                 return "completed"
             case .clipboardPending:
                 return "clipboardPending"
+            case .cancelled:
+                return "cancelled"
             case .failed(let failure):
                 return "failed:\(failureLabel(failure))"
             }

--- a/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
+++ b/StetMac/App/Workflows/MacDictationCaptureCoordinator.swift
@@ -185,11 +185,17 @@
                     return .failed(.autoPastePermissionMissing)
                 }
 
+                let temporaryChangeCount = pasteboard.changeCount
                 let pasteOutcome = await textInjectionService.pasteClipboard(into: targetApplication)
                 guard outputID == completionID else { return .cancelled }
                 guard !Task.isCancelled else {
                     if shouldRestoreClipboardAfterSuccessfulPaste {
-                        pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                        if pasteboard.changeCount == temporaryChangeCount {
+                            pasteboardRestoreCoordinator.restoreImmediatelyIfNeeded(on: pasteboard)
+                        } else {
+                            // Preserve anything the user copied during the cancelled paste.
+                            pasteboardRestoreCoordinator.discardPendingRestore()
+                        }
                     }
                     return .cancelled
                 }

--- a/StetMac/App/Workflows/MacDictationWorkflowController.swift
+++ b/StetMac/App/Workflows/MacDictationWorkflowController.swift
@@ -125,7 +125,9 @@
 
             startActivationTask = Task { @MainActor [weak self] in
                 guard let self else { return }
-                defer { startActivationTask = nil }
+                defer {
+                    if !Task.isCancelled { startActivationTask = nil }
+                }
 
                 await awaitStartPromptBeforeActivation(preset: settings.interactionSoundPreset)
 
@@ -225,6 +227,7 @@
                 settings: captureSettings,
                 showPanel: showTransientPanel
             )
+            guard !Task.isCancelled else { return .cancelled }
             let settings = settingsSnapshot
             if outcome == .completed, settings.interactionSoundsEnabled {
                 interactionSoundPlayer.playFinish(preset: settings.interactionSoundPreset)

--- a/StetMac/App/Workflows/MacDictationWorkflowController.swift
+++ b/StetMac/App/Workflows/MacDictationWorkflowController.swift
@@ -197,6 +197,11 @@
                 return .failed(.emptyTranscription)
             }
 
+            guard !Task.isCancelled else {
+                pendingSessionDuration = nil
+                return .cancelled
+            }
+
             if let duration = pendingSessionDuration {
                 let wordCount = Self.countWords(in: text)
                 statsModel?.record(

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -32,6 +32,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     #endif
     private var reusableCaptureService: (any AudioCaptureService)?
     private var ownsActiveCapture = false
+    private var nextCaptureSessionID: UInt64 = 0
+    private var invalidatedThroughCaptureSessionID: UInt64 = 0
 
     init(
         settingsStore: DictationSettingsStore = DictationSettingsStore(),
@@ -94,15 +96,23 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             throw SpeechServiceError.alreadyRecording
         }
 
+        let sessionID = try beginCaptureSession()
         if let beginActiveCapture {
             await beginActiveCapture()
             ownsActiveCapture = true
+            do {
+                try ensureCaptureSessionIsActive(sessionID)
+            } catch {
+                await resumePassiveCaptureIfNeeded()
+                throw error
+            }
         }
         let snapshot = settingsStore.loadSnapshot()
         let pipelineStartedAt = ProcessInfo.processInfo.systemUptime
         let pipeline: DictationPipeline
         do {
             pipeline = try await pipelineFactory.makePipeline(from: snapshot)
+            try ensureCaptureSessionIsActive(sessionID)
         } catch {
             await resumePassiveCaptureIfNeeded()
             throw error
@@ -125,14 +135,17 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         activeCaptureService = captureService
 
         do {
+            try ensureCaptureSessionIsActive(sessionID)
             let captureServiceStartedAt = ProcessInfo.processInfo.systemUptime
             try await captureService.startRecording()
+            try ensureCaptureSessionIsActive(sessionID)
             let captureServiceStartMs = Self.elapsedMilliseconds(since: captureServiceStartedAt)
             Self.logStartupTiming("captureServiceStartMs=\(Self.formatMilliseconds(captureServiceStartMs))")
 
             if activateRecordingWindow {
                 let captureWindowStartedAt = ProcessInfo.processInfo.systemUptime
                 try await captureService.activateRecordingWindow()
+                try ensureCaptureSessionIsActive(sessionID)
                 let captureWindowActivationMs = Self.elapsedMilliseconds(since: captureWindowStartedAt)
                 Self.logStartupTiming("captureWindowActivationMs=\(Self.formatMilliseconds(captureWindowActivationMs))")
             }
@@ -186,6 +199,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         else {
             throw SpeechServiceError.notRecording
         }
+        let sessionID = nextCaptureSessionID
+        try ensureCaptureSessionIsActive(sessionID)
 
         defer {
             self.activePipeline = nil
@@ -209,6 +224,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         let captureResult: (url: URL, duration: TimeInterval?)
         do {
             captureResult = try await captureService.stopRecording()
+            try ensureCaptureSessionIsActive(sessionID)
         } catch {
             await resumePassiveCaptureIfNeeded()
             throw error
@@ -216,6 +232,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         await resumePassiveCaptureIfNeeded()
         if let onCaptureStopped {
             await onCaptureStopped()
+            try ensureCaptureSessionIsActive(sessionID)
         }
         let processedCaptureResult =
             if settingsStore.loadSnapshot().transcriptionEngine == .funASRNano {
@@ -229,6 +246,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                     duration: captureResult.duration
                 )
             }
+        try ensureCaptureSessionIsActive(sessionID)
 
         defer {
             let cleanupURLs = Set(processedCaptureResult.cleanupURLs)
@@ -249,6 +267,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         var transcriptionPrompt: String? = nil
         if let provider = pipeline.promptProvider {
             transcriptionPrompt = await provider()
+            try ensureCaptureSessionIsActive(sessionID)
         }
 
         logger.info("Submitting transcription request.")
@@ -258,6 +277,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         let transcriptionResult: TranscriptionResult
         do {
             await waitForTranscriptionPrewarm()
+            try ensureCaptureSessionIsActive(sessionID)
             await DictationLatencyProbe.shared.record(.transcriptionStarted)
             transcriptionResult = try await pipeline.transcriptionService.transcribe(
                 audioFileAt: processedCaptureResult.url,
@@ -265,6 +285,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                 prompt: transcriptionPrompt,
                 audioDurationSeconds: processedCaptureResult.duration
             )
+            try ensureCaptureSessionIsActive(sessionID)
             let trimmedTranscript = transcriptionResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmedTranscript.isEmpty else {
                 throw SpeechServiceError.emptyTranscription
@@ -274,6 +295,9 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             logger.info(
                 "DictationStage transcriptionMs=\(Self.formatMilliseconds(transcriptionStageMs)) audioDurationSeconds=\(Self.formatDurationSeconds(processedCaptureResult.duration)) transcriptChars=\(trimmedTranscript.count) rewriteEnabled=\(pipeline.rewriteService != nil) detectedLanguage=\(transcriptionResult.languageCode ?? "unknown")"
             )
+        } catch is CancellationError {
+            await releaseContextOnExit()
+            throw CancellationError()
         } catch {
             await DictationLatencyProbe.shared.record(.transcriptionFailed, note: error.localizedDescription)
             logger.error("Transcription failed: \(error.localizedDescription)")
@@ -297,6 +321,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                         appName: appName
                     )
                     let rewrittenTranscript = try await rewriteService.rewrite(request)
+                    try ensureCaptureSessionIsActive(sessionID)
 
                     finalTranscript = rewrittenTranscript
                     wasRewritten = true
@@ -316,6 +341,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                         "DictationStage rewriteSkipped inputChars=\(intermediateTranscript.count)"
                     )
                 }
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 logger.error("Rewrite failed: \(error.localizedDescription). Falling back to raw transcript.")
                 if let rewriteProvider = pipeline.rewriteProvider {
@@ -342,6 +369,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             } else {
                 trimmedTranscript = trimmedFinalTranscript
             }
+            try ensureCaptureSessionIsActive(sessionID)
             guard !trimmedTranscript.isEmpty else {
                 await releaseContextOnExit()
                 throw SpeechServiceError.emptyTranscription
@@ -358,6 +386,9 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                 text: trimmedTranscript,
                 wasRewritten: wasRewritten
             )
+        } catch is CancellationError {
+            await releaseContextOnExit()
+            throw CancellationError()
         } catch {
             await DictationLatencyProbe.shared.record(.transcriptionFailed, note: error.localizedDescription)
             logger.error("Post-transcription processing failed: \(error.localizedDescription)")
@@ -367,7 +398,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     }
 
     func cancelRecording() async {
-        guard activePipeline != nil else { return }
+        invalidateActiveCaptureSession()
+        guard activePipeline != nil || activeCaptureService != nil else { return }
         self.activePipeline = nil
         stopTranscriptionPrewarm()
         stopRewritePrewarm()
@@ -394,6 +426,28 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         guard ownsActiveCapture else { return }
         ownsActiveCapture = false
         await resumePassiveCapture?()
+    }
+
+    private func beginCaptureSession() throws -> UInt64 {
+        try Task.checkCancellation()
+        nextCaptureSessionID += 1
+        let sessionID = nextCaptureSessionID
+        try ensureCaptureSessionIsActive(sessionID)
+        return sessionID
+    }
+
+    private func invalidateActiveCaptureSession() {
+        invalidatedThroughCaptureSessionID = max(
+            invalidatedThroughCaptureSessionID,
+            nextCaptureSessionID
+        )
+    }
+
+    private func ensureCaptureSessionIsActive(_ sessionID: UInt64) throws {
+        try Task.checkCancellation()
+        guard sessionID > invalidatedThroughCaptureSessionID else {
+            throw CancellationError()
+        }
     }
 
     func prewarm() async {

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -32,6 +32,15 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     #endif
     private var reusableCaptureService: (any AudioCaptureService)?
     private var ownsActiveCapture = false
+    // The session is reserved before the first suspension. Hardware operations are
+    // drained before reuse; cancelled ASR work may finish independently.
+    private var activeCaptureSessionID: UInt64?
+    private var captureTransitionTask: Task<Void, Error>?
+    private var captureStopTask: Task<(url: URL, duration: TimeInterval?), Error>?
+    private var cancellationTask: Task<Void, Never>?
+    private var contextCleanupTask: Task<Void, Never>?
+    private var processingSessions: Set<UInt64> = []
+    private var retiringPrewarmTasks: [Task<Void, Never>] = []
     private var nextCaptureSessionID: UInt64 = 0
     private var invalidatedThroughCaptureSessionID: UInt64 = 0
 
@@ -92,11 +101,38 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     }
 
     private func startRecording(activateRecordingWindow: Bool) async throws {
-        guard activePipeline == nil else {
+        let sessionID = try beginCaptureSession()
+        // Recheck after every wait: another cancellation may have been queued.
+        while let cancellationTask { await cancellationTask.value }
+        while let contextCleanupTask { await contextCleanupTask.value }
+        try Task.checkCancellation()
+        guard activeCaptureSessionID == nil else {
             throw SpeechServiceError.alreadyRecording
         }
+        guard sessionID > invalidatedThroughCaptureSessionID else { throw CancellationError() }
+        activeCaptureSessionID = sessionID
+        let operation = Task {
+            try await prepareCapture(sessionID: sessionID, activateRecordingWindow: activateRecordingWindow)
+        }
+        captureTransitionTask = operation
+        do {
+            try await withTaskCancellationHandler {
+                try await operation.value
+            } onCancel: {
+                operation.cancel()
+            }
+            try ensureCaptureSessionIsActive(sessionID)
+            captureTransitionTask = nil
+        } catch {
+            if activeCaptureSessionID == sessionID, cancellationTask == nil {
+                await cancelRecording()
+            }
+            throw error
+        }
+    }
 
-        let sessionID = try beginCaptureSession()
+    private func prepareCapture(sessionID: UInt64, activateRecordingWindow: Bool) async throws {
+        try ensureCaptureSessionIsActive(sessionID)
         if let beginActiveCapture {
             await beginActiveCapture()
             ownsActiveCapture = true
@@ -134,102 +170,102 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         }
         activeCaptureService = captureService
 
-        do {
-            try ensureCaptureSessionIsActive(sessionID)
-            let captureServiceStartedAt = ProcessInfo.processInfo.systemUptime
-            try await captureService.startRecording()
-            try ensureCaptureSessionIsActive(sessionID)
-            let captureServiceStartMs = Self.elapsedMilliseconds(since: captureServiceStartedAt)
-            Self.logStartupTiming("captureServiceStartMs=\(Self.formatMilliseconds(captureServiceStartMs))")
+        try ensureCaptureSessionIsActive(sessionID)
+        let captureServiceStartedAt = ProcessInfo.processInfo.systemUptime
+        try await captureService.startRecording()
+        try ensureCaptureSessionIsActive(sessionID)
+        let captureServiceStartMs = Self.elapsedMilliseconds(since: captureServiceStartedAt)
+        Self.logStartupTiming("captureServiceStartMs=\(Self.formatMilliseconds(captureServiceStartMs))")
 
-            if activateRecordingWindow {
-                let captureWindowStartedAt = ProcessInfo.processInfo.systemUptime
-                try await captureService.activateRecordingWindow()
-                try ensureCaptureSessionIsActive(sessionID)
-                let captureWindowActivationMs = Self.elapsedMilliseconds(since: captureWindowStartedAt)
-                Self.logStartupTiming("captureWindowActivationMs=\(Self.formatMilliseconds(captureWindowActivationMs))")
-            }
-
-            await startAudioLevelForwarding(using: captureService)
-            #if os(macOS)
-                await startAudioFeatureForwarding(using: captureService)
-            #endif
-            startTranscriptionPrewarm(using: pipeline)
-            startRewritePrewarm(using: pipeline)
-        } catch is CancellationError {
-            activePipeline = nil
-            activeCaptureService = nil
-            stopTranscriptionPrewarm()
-            stopRewritePrewarm()
-            stopAudioLevelForwarding()
-            #if os(macOS)
-                stopAudioFeatureForwarding()
-            #endif
-            await DictationStartupProbe.shared.record(.cancelled)
-            await resumePassiveCaptureIfNeeded()
-            throw CancellationError()
-        } catch {
-            activePipeline = nil
-            activeCaptureService = nil
-            stopTranscriptionPrewarm()
-            stopRewritePrewarm()
-            stopAudioLevelForwarding()
-            #if os(macOS)
-                stopAudioFeatureForwarding()
-            #endif
-            await DictationStartupProbe.shared.record(.failed, note: error.localizedDescription)
-            await resumePassiveCaptureIfNeeded()
-            throw error
+        if activateRecordingWindow {
+            let captureWindowStartedAt = ProcessInfo.processInfo.systemUptime
+            try await captureService.activateRecordingWindow()
+            try ensureCaptureSessionIsActive(sessionID)
+            let captureWindowActivationMs = Self.elapsedMilliseconds(since: captureWindowStartedAt)
+            Self.logStartupTiming("captureWindowActivationMs=\(Self.formatMilliseconds(captureWindowActivationMs))")
         }
+
+        await startAudioLevelForwarding(using: captureService)
+        try ensureCaptureSessionIsActive(sessionID)
+        #if os(macOS)
+            await startAudioFeatureForwarding(using: captureService)
+            try ensureCaptureSessionIsActive(sessionID)
+        #endif
+        startTranscriptionPrewarm(using: pipeline)
+        startRewritePrewarm(using: pipeline)
     }
 
     func activateRecordingWindow() async throws {
-        guard let captureService = activeCaptureService else {
-            throw SpeechServiceError.notRecording
+        guard let sessionID = activeCaptureSessionID,
+            let captureService = activeCaptureService,
+            captureTransitionTask == nil
+        else { throw SpeechServiceError.notRecording }
+        try ensureCaptureSessionIsActive(sessionID)
+        let operation = Task { try await captureService.activateRecordingWindow() }
+        captureTransitionTask = operation
+        defer {
+            if activeCaptureSessionID == sessionID { captureTransitionTask = nil }
         }
-
-        try await captureService.activateRecordingWindow()
+        do {
+            try await withTaskCancellationHandler {
+                try await operation.value
+            } onCancel: {
+                operation.cancel()
+            }
+            try ensureCaptureSessionIsActive(sessionID)
+        } catch {
+            if activeCaptureSessionID == sessionID, cancellationTask == nil {
+                await cancelRecording()
+            }
+            throw error
+        }
     }
 
     func stopRecording(
         onCaptureStopped: (@Sendable () async -> Void)? = nil
     ) async throws -> SpeechTranscriptionResult {
-        guard let pipeline = activePipeline,
-            let captureService = activeCaptureService
+        guard let sessionID = activeCaptureSessionID,
+            let pipeline = activePipeline,
+            let captureService = activeCaptureService,
+            !processingSessions.contains(sessionID),
+            captureTransitionTask == nil
         else {
             throw SpeechServiceError.notRecording
         }
-        let sessionID = nextCaptureSessionID
         try ensureCaptureSessionIsActive(sessionID)
+        processingSessions.insert(sessionID)
 
+        var cleanupURLs: Set<URL> = []
         defer {
-            self.activePipeline = nil
-            self.activeCaptureService = nil
-            stopTranscriptionPrewarm()
-            stopRewritePrewarm()
-            stopAudioLevelForwarding()
-            #if os(macOS)
-                stopAudioFeatureForwarding()
-            #endif
+            for url in cleanupURLs { try? FileManager.default.removeItem(at: url) }
+            processingSessions.remove(sessionID)
+            finishCaptureSession(sessionID)
+            scheduleContextCleanupIfIdle()
         }
 
-        let releaseContextOnExit: @Sendable () async -> Void = {
-            #if os(macOS)
-                await LocalWhisperContextManager.shared.cleanupResources()
-                await LocalParakeetContextManager.shared.cleanupResources()
-                await FunASRNanoContextManager.shared.cleanupResources()
-            #endif
+        let stopTask = Task {
+            let result = try await captureService.stopRecording()
+            await resumePassiveCaptureIfNeeded()
+            return result
         }
-
+        captureStopTask = stopTask
         let captureResult: (url: URL, duration: TimeInterval?)
         do {
-            captureResult = try await captureService.stopRecording()
+            captureResult = try await withTaskCancellationHandler {
+                try await stopTask.value
+            } onCancel: {
+                stopTask.cancel()
+            }
+            // Register ownership before any cancellation check or callback.
+            cleanupURLs.insert(captureResult.url)
             try ensureCaptureSessionIsActive(sessionID)
+            captureStopTask = nil
         } catch {
-            await resumePassiveCaptureIfNeeded()
+            if activeCaptureSessionID == sessionID {
+                await resumePassiveCaptureIfNeeded()
+            }
             throw error
         }
-        await resumePassiveCaptureIfNeeded()
         if let onCaptureStopped {
             await onCaptureStopped()
             try ensureCaptureSessionIsActive(sessionID)
@@ -246,18 +282,11 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                     duration: captureResult.duration
                 )
             }
+        cleanupURLs.formUnion(processedCaptureResult.cleanupURLs)
         try ensureCaptureSessionIsActive(sessionID)
-
-        defer {
-            let cleanupURLs = Set(processedCaptureResult.cleanupURLs)
-            for url in cleanupURLs {
-                try? FileManager.default.removeItem(at: url)
-            }
-        }
 
         guard !processedCaptureResult.shouldDiscardAsNoSpeech else {
             logger.info("Discarding dictation capture because no speech was detected locally.")
-            await releaseContextOnExit()
             throw SpeechServiceError.emptyTranscription
         }
 
@@ -276,9 +305,11 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         let transcriptionStartedAt = ProcessInfo.processInfo.systemUptime
         let transcriptionResult: TranscriptionResult
         do {
+            try ensureCaptureSessionIsActive(sessionID)
             await waitForTranscriptionPrewarm()
             try ensureCaptureSessionIsActive(sessionID)
             await DictationLatencyProbe.shared.record(.transcriptionStarted)
+            try ensureCaptureSessionIsActive(sessionID)
             transcriptionResult = try await pipeline.transcriptionService.transcribe(
                 audioFileAt: processedCaptureResult.url,
                 languageCode: pipeline.transcriptionLanguageCode,
@@ -296,12 +327,10 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                 "DictationStage transcriptionMs=\(Self.formatMilliseconds(transcriptionStageMs)) audioDurationSeconds=\(Self.formatDurationSeconds(processedCaptureResult.duration)) transcriptChars=\(trimmedTranscript.count) rewriteEnabled=\(pipeline.rewriteService != nil) detectedLanguage=\(transcriptionResult.languageCode ?? "unknown")"
             )
         } catch is CancellationError {
-            await releaseContextOnExit()
             throw CancellationError()
         } catch {
             await DictationLatencyProbe.shared.record(.transcriptionFailed, note: error.localizedDescription)
             logger.error("Transcription failed: \(error.localizedDescription)")
-            await releaseContextOnExit()
             throw error
         }
 
@@ -344,6 +373,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
+                try ensureCaptureSessionIsActive(sessionID)
                 logger.error("Rewrite failed: \(error.localizedDescription). Falling back to raw transcript.")
                 if let rewriteProvider = pipeline.rewriteProvider {
                     await DictationTranscriptTrace.shared.record(
@@ -371,7 +401,6 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             }
             try ensureCaptureSessionIsActive(sessionID)
             guard !trimmedTranscript.isEmpty else {
-                await releaseContextOnExit()
                 throw SpeechServiceError.emptyTranscription
             }
 
@@ -380,46 +409,79 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                 "DictationSummary totalProcessingMs=\(Self.formatMilliseconds(totalProcessingMs)) audioDurationSeconds=\(Self.formatDurationSeconds(processedCaptureResult.duration)) finalTextChars=\(trimmedTranscript.count) rewriteEnabled=\(pipeline.rewriteService != nil)"
             )
 
-            await releaseContextOnExit()
             return SpeechTranscriptionResult(
                 rawText: wasRewritten ? intermediateTranscript : trimmedTranscript,
                 text: trimmedTranscript,
                 wasRewritten: wasRewritten
             )
         } catch is CancellationError {
-            await releaseContextOnExit()
             throw CancellationError()
         } catch {
             await DictationLatencyProbe.shared.record(.transcriptionFailed, note: error.localizedDescription)
             logger.error("Post-transcription processing failed: \(error.localizedDescription)")
-            await releaseContextOnExit()
             throw error
         }
     }
 
     func cancelRecording() async {
         invalidateActiveCaptureSession()
-        guard activePipeline != nil || activeCaptureService != nil else { return }
-        self.activePipeline = nil
+        if let cancellationTask {
+            await cancellationTask.value
+            return
+        }
+        guard let sessionID = activeCaptureSessionID else { return }
+        let transition = captureTransitionTask
+        let stop = captureStopTask
+        transition?.cancel()
+        stop?.cancel()
+        let cleanup = Task {
+            // A delayed start must finish before cancel touches the reusable recorder.
+            _ = await transition?.result
+            _ = await stop?.result
+            if let captureService = activeCaptureService {
+                await captureService.cancelRecording()
+            }
+            await resumePassiveCaptureIfNeeded()
+            finishCaptureSession(sessionID)
+            cancellationTask = nil
+            scheduleContextCleanupIfIdle()
+        }
+        cancellationTask = cleanup
+        await cleanup.value
+    }
+
+    private func finishCaptureSession(_ sessionID: UInt64) {
+        guard activeCaptureSessionID == sessionID else { return }
+        activeCaptureSessionID = nil
+        activePipeline = nil
+        activeCaptureService = nil
+        captureTransitionTask = nil
+        captureStopTask = nil
         stopTranscriptionPrewarm()
         stopRewritePrewarm()
-        let captureService = activeCaptureService
-        activeCaptureService = nil
         stopAudioLevelForwarding()
         #if os(macOS)
             stopAudioFeatureForwarding()
         #endif
-        if let captureService {
-            await captureService.cancelRecording()
+    }
+
+    private func scheduleContextCleanupIfIdle() {
+        guard activeCaptureSessionID == nil, processingSessions.isEmpty,
+            cancellationTask == nil, contextCleanupTask == nil
+        else { return }
+        let prewarms = retiringPrewarmTasks
+        retiringPrewarmTasks.removeAll()
+        // New sessions wait for this task, so global model cleanup cannot unload
+        // a new session's context. Late cancelled processing defers it until idle.
+        contextCleanupTask = Task {
+            for task in prewarms { await task.value }
+            #if os(macOS)
+                await LocalWhisperContextManager.shared.cleanupResources()
+                await LocalParakeetContextManager.shared.cleanupResources()
+                await FunASRNanoContextManager.shared.cleanupResources()
+            #endif
+            contextCleanupTask = nil
         }
-        await resumePassiveCaptureIfNeeded()
-        // Match VoiceInk's cleanupResources() in the cancel branch of toggleRecord:
-        // a prewarm task may have loaded the model already, so release it here too.
-        #if os(macOS)
-            await LocalWhisperContextManager.shared.cleanupResources()
-            await LocalParakeetContextManager.shared.cleanupResources()
-            await FunASRNanoContextManager.shared.cleanupResources()
-        #endif
     }
 
     private func resumePassiveCaptureIfNeeded() async {
@@ -431,9 +493,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     private func beginCaptureSession() throws -> UInt64 {
         try Task.checkCancellation()
         nextCaptureSessionID += 1
-        let sessionID = nextCaptureSessionID
-        try ensureCaptureSessionIsActive(sessionID)
-        return sessionID
+        return nextCaptureSessionID
     }
 
     private func invalidateActiveCaptureSession() {
@@ -445,7 +505,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
     private func ensureCaptureSessionIsActive(_ sessionID: UInt64) throws {
         try Task.checkCancellation()
-        guard sessionID > invalidatedThroughCaptureSessionID else {
+        guard sessionID == activeCaptureSessionID, sessionID > invalidatedThroughCaptureSessionID else {
             throw CancellationError()
         }
     }
@@ -522,11 +582,13 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     }
 
     private func stopTranscriptionPrewarm() {
+        if let transcriptionPrewarmTask { retiringPrewarmTasks.append(transcriptionPrewarmTask) }
         transcriptionPrewarmTask?.cancel()
         transcriptionPrewarmTask = nil
     }
 
     private func stopRewritePrewarm() {
+        if let rewritePrewarmTask { retiringPrewarmTasks.append(rewritePrewarmTask) }
         rewritePrewarmTask?.cancel()
         rewritePrewarmTask = nil
     }

--- a/StetMac/Core/TextInput/TextInjectionService.swift
+++ b/StetMac/Core/TextInput/TextInjectionService.swift
@@ -325,6 +325,7 @@
         }
 
         private func selectedTextBySimulatedCopy() -> String? {
+            guard !Task.isCancelled else { return .eventPostFailed }
             guard accessState.canSimulateInput else { return nil }
 
             let snapshot = PasteboardSnapshot.capture(from: pasteboard)
@@ -390,6 +391,7 @@
                     "target=\(applicationSummary(application)) frontmost=\(frontmostApplicationSummary()) accessibility=\(accessState.hasAccessibilityAccess) postEvent=\(accessState.hasPostEventAccess)"
             )
 
+            guard !Task.isCancelled else { return .eventPostFailed }
             guard accessState.canSimulateInput else {
                 emitTextInjectionTrace(
                     traceID,
@@ -433,6 +435,8 @@
                 traceID: traceID
             )
 
+            // Cancellation during focus activation or baseline polling must not post Cmd-V.
+            guard !Task.isCancelled else { return .eventPostFailed }
             let pasteCommandPosted = simulatePasteCommand()
             emitTextInjectionTrace(
                 traceID,

--- a/StetMac/Core/TextInput/TextInjectionService.swift
+++ b/StetMac/Core/TextInput/TextInjectionService.swift
@@ -325,7 +325,6 @@
         }
 
         private func selectedTextBySimulatedCopy() -> String? {
-            guard !Task.isCancelled else { return .eventPostFailed }
             guard accessState.canSimulateInput else { return nil }
 
             let snapshot = PasteboardSnapshot.capture(from: pasteboard)

--- a/StetMac/Features/Dictation/DictationViewModel.swift
+++ b/StetMac/Features/Dictation/DictationViewModel.swift
@@ -28,6 +28,7 @@ final class DictationViewModel: ObservableObject {
     private var pendingActivationAfterStart = false
     private var pendingCaptureStoppedHandler: (@MainActor @Sendable () -> Void)?
     private var resultTransformer: ResultTransformer?
+    private var captureSessionID: UInt64 = 0
 
     @Published private(set) var state: DictationState = .idle
     @Published private(set) var recordingLevel = 0.0
@@ -97,6 +98,7 @@ final class DictationViewModel: ObservableObject {
         #if os(macOS)
             audioFeatureTask?.cancel()
         #endif
+        let sessionID = beginCaptureSession()
         isStartingRecording = true
         isActivatingRecordingWindow = false
         hasPreparedCapture = false
@@ -122,7 +124,7 @@ final class DictationViewModel: ObservableObject {
             do {
                 try await captureStartupTask.value
                 self.captureStartupTask = nil
-                if Task.isCancelled { return }
+                guard isCurrentCaptureSession(sessionID) else { return }
 
                 isStartingRecording = false
                 hasPreparedCapture = true
@@ -313,6 +315,7 @@ final class DictationViewModel: ObservableObject {
         state = .processing
         let captureStoppedHandler = pendingCaptureStoppedHandler
         pendingCaptureStoppedHandler = nil
+        let sessionID = captureSessionID
         Task {
             await DictationRuntimeProbe.shared.markAction("processingFromStopCapture")
         }
@@ -327,12 +330,13 @@ final class DictationViewModel: ObservableObject {
                         }
                     }
                 )
-                if Task.isCancelled { return }
+                guard isCurrentCaptureSession(sessionID) else { return }
                 // [History point A] Record raw ASR output, not the post-rewrite string.
                 historyService.recordRaw(transcription.rawText)
                 let finalText: String
                 if let resultTransformer {
                     finalText = try await resultTransformer(transcription.text)
+                    guard isCurrentCaptureSession(sessionID) else { return }
                     // [History point B] Record LLM-refined output.
                     historyService.recordLLM(finalText)
                 } else if transcription.wasRewritten {
@@ -341,6 +345,7 @@ final class DictationViewModel: ObservableObject {
                 } else {
                     finalText = transcription.text
                 }
+                guard isCurrentCaptureSession(sessionID) else { return }
                 // Persist immediately — every transcription is recorded whether or
                 // not the text is ultimately delivered to a target app.
                 historyService.commitPending()
@@ -413,12 +418,13 @@ final class DictationViewModel: ObservableObject {
         pendingActivationAfterStart = false
         pendingCaptureStoppedHandler = nil
         resultTransformer = nil
+        let sessionID = beginCaptureSession()
         state = .processing
 
         activeTask = Task {
             do {
                 let text = try await operation()
-                if Task.isCancelled { return }
+                guard isCurrentCaptureSession(sessionID) else { return }
                 send(.transcriptionSucceeded(text))
             } catch is CancellationError {
                 finishLevelMonitoring()
@@ -443,6 +449,7 @@ final class DictationViewModel: ObservableObject {
         Task {
             await DictationRuntimeProbe.shared.markAction("reset")
         }
+        invalidateCaptureSession()
         activeTask?.cancel()
         captureStartupTask?.cancel()
         captureStartupTask = nil
@@ -463,6 +470,19 @@ final class DictationViewModel: ObservableObject {
             await speechService.cancelRecording()
         }
         state = .idle
+    }
+
+    private func beginCaptureSession() -> UInt64 {
+        captureSessionID += 1
+        return captureSessionID
+    }
+
+    private func invalidateCaptureSession() {
+        captureSessionID += 1
+    }
+
+    private func isCurrentCaptureSession(_ sessionID: UInt64) -> Bool {
+        !Task.isCancelled && sessionID == captureSessionID
     }
 
     private func scheduleActivationFallbackIfNeeded() {

--- a/StetMac/Features/Dictation/DictationViewModel.swift
+++ b/StetMac/Features/Dictation/DictationViewModel.swift
@@ -14,6 +14,7 @@ final class DictationViewModel: ObservableObject {
     private let historyService: any DictationHistoryRecording
     private let manualActivationFallbackDelay: Duration
     private var activeTask: Task<Void, Never>?
+    private var cancellationTask: Task<Void, Never>?
     private var captureStartupTask: Task<Void, Error>?
     private var activationFallbackTask: Task<Void, Never>?
     private var levelTask: Task<Void, Never>?
@@ -28,7 +29,7 @@ final class DictationViewModel: ObservableObject {
     private var pendingActivationAfterStart = false
     private var pendingCaptureStoppedHandler: (@MainActor @Sendable () -> Void)?
     private var resultTransformer: ResultTransformer?
-    private var captureSessionID: UInt64 = 0
+    private(set) var captureSessionID: UInt64 = 0
 
     @Published private(set) var state: DictationState = .idle
     @Published private(set) var recordingLevel = 0.0
@@ -111,7 +112,10 @@ final class DictationViewModel: ObservableObject {
 
         let shouldActivateAfterStart = activateWhenReady
         let speechService = self.speechService
+        let pendingCancellation = cancellationTask
         let captureStartupTask = Task.detached(priority: .userInitiated) {
+            await pendingCancellation?.value
+            try Task.checkCancellation()
             if shouldActivateAfterStart {
                 try await speechService.startRecordingAndActivate()
             } else {
@@ -123,8 +127,8 @@ final class DictationViewModel: ObservableObject {
         activeTask = Task {
             do {
                 try await captureStartupTask.value
-                self.captureStartupTask = nil
                 guard isCurrentCaptureSession(sessionID) else { return }
+                self.captureStartupTask = nil
 
                 isStartingRecording = false
                 hasPreparedCapture = true
@@ -151,11 +155,13 @@ final class DictationViewModel: ObservableObject {
                     scheduleActivationFallbackIfNeeded()
                 }
 
+                guard isCurrentCaptureSession(sessionID) else { return }
                 if pendingActivationAfterStart {
                     pendingActivationAfterStart = false
                     try await activateCaptureWindowInline()
                 }
             } catch is CancellationError {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 captureStartupTask.cancel()
                 self.captureStartupTask = nil
                 activationFallbackTask?.cancel()
@@ -180,6 +186,7 @@ final class DictationViewModel: ObservableObject {
                     await DictationStartupProbe.shared.record(.cancelled)
                 }
             } catch {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 captureStartupTask.cancel()
                 self.captureStartupTask = nil
                 activationFallbackTask?.cancel()
@@ -222,10 +229,12 @@ final class DictationViewModel: ObservableObject {
 
         activationFallbackTask?.cancel()
         activationFallbackTask = nil
+        let sessionID = captureSessionID
         activeTask = Task {
             do {
                 try await activateCaptureWindowInline()
             } catch is CancellationError {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 activationFallbackTask?.cancel()
                 activationFallbackTask = nil
                 isActivatingRecordingWindow = false
@@ -239,6 +248,7 @@ final class DictationViewModel: ObservableObject {
 
                 state = .idle
             } catch {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 activationFallbackTask?.cancel()
                 activationFallbackTask = nil
                 isActivatingRecordingWindow = false
@@ -266,10 +276,11 @@ final class DictationViewModel: ObservableObject {
         activationFallbackTask?.cancel()
         activationFallbackTask = nil
         isActivatingRecordingWindow = true
+        let sessionID = captureSessionID
 
         do {
             try await speechService.activateRecordingWindow()
-            if Task.isCancelled { return }
+            guard isCurrentCaptureSession(sessionID) else { return }
 
             isActivatingRecordingWindow = false
             state = .listening
@@ -277,12 +288,14 @@ final class DictationViewModel: ObservableObject {
                 await DictationRuntimeProbe.shared.markAction("enteredListening")
             }
             await DictationStartupProbe.shared.record(.listeningStateEntered)
+            guard isCurrentCaptureSession(sessionID) else { return }
 
             if pendingStopAfterStart {
                 pendingStopAfterStart = false
                 stopCapture()
             }
         } catch {
+            guard isCurrentCaptureSession(sessionID) else { return }
             isActivatingRecordingWindow = false
             throw error
         }
@@ -326,32 +339,32 @@ final class DictationViewModel: ObservableObject {
                     onCaptureStopped: {
                         guard let captureStoppedHandler else { return }
                         await MainActor.run {
+                            guard self.isCurrentCaptureSession(sessionID) else { return }
                             captureStoppedHandler()
                         }
                     }
                 )
                 guard isCurrentCaptureSession(sessionID) else { return }
-                // [History point A] Record raw ASR output, not the post-rewrite string.
-                historyService.recordRaw(transcription.rawText)
                 let finalText: String
                 if let resultTransformer {
                     finalText = try await resultTransformer(transcription.text)
                     guard isCurrentCaptureSession(sessionID) else { return }
-                    // [History point B] Record LLM-refined output.
-                    historyService.recordLLM(finalText)
-                } else if transcription.wasRewritten {
-                    finalText = transcription.text
-                    historyService.recordLLM(transcription.text)
                 } else {
                     finalText = transcription.text
                 }
                 guard isCurrentCaptureSession(sessionID) else { return }
+                // Commit both History stages together after the last suspension.
+                historyService.recordRaw(transcription.rawText)
+                if resultTransformer != nil || transcription.wasRewritten {
+                    historyService.recordLLM(finalText)
+                }
                 // Persist immediately — every transcription is recorded whether or
                 // not the text is ultimately delivered to a target app.
                 historyService.commitPending()
                 self.resultTransformer = nil
                 send(.transcriptionSucceeded(finalText))
             } catch is CancellationError {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 activationFallbackTask?.cancel()
                 activationFallbackTask = nil
                 resultTransformer = nil
@@ -365,6 +378,7 @@ final class DictationViewModel: ObservableObject {
 
                 state = .idle
             } catch let error as SpeechServiceError where error == .emptyTranscription {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 activationFallbackTask?.cancel()
                 activationFallbackTask = nil
                 resultTransformer = nil
@@ -381,6 +395,7 @@ final class DictationViewModel: ObservableObject {
                     await DictationRuntimeProbe.shared.markAction("stopCaptureEmptyTranscription")
                 }
             } catch {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 activationFallbackTask?.cancel()
                 activationFallbackTask = nil
                 resultTransformer = nil
@@ -427,6 +442,7 @@ final class DictationViewModel: ObservableObject {
                 guard isCurrentCaptureSession(sessionID) else { return }
                 send(.transcriptionSucceeded(text))
             } catch is CancellationError {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 finishLevelMonitoring()
                 #if os(macOS)
                     finishAudioFeatureMonitoring()
@@ -434,6 +450,7 @@ final class DictationViewModel: ObservableObject {
 
                 state = .idle
             } catch {
+                guard isCurrentCaptureSession(sessionID) else { return }
                 finishLevelMonitoring()
                 #if os(macOS)
                     finishAudioFeatureMonitoring()
@@ -466,9 +483,12 @@ final class DictationViewModel: ObservableObject {
         pendingActivationAfterStart = false
         pendingCaptureStoppedHandler = nil
         resultTransformer = nil
-        activeTask = Task {
+        let pendingCancellation = cancellationTask
+        cancellationTask = Task {
+            await pendingCancellation?.value
             await speechService.cancelRecording()
         }
+        activeTask = nil
         state = .idle
     }
 

--- a/StetMac/Features/MacShell/DictationPanel/MacDictationCapsuleSurface.swift
+++ b/StetMac/Features/MacShell/DictationPanel/MacDictationCapsuleSurface.swift
@@ -23,18 +23,35 @@
         }
 
         private func dismissAction() {
-            switch viewModel.state {
-            case .listening, .starting:
+            switch MacDictationCapsuleDismissBehavior.forState(viewModel.state) {
+            case .cancelActiveCapture:
                 viewModel.cancelActiveCapture()
-            case .idle, .error(_):
+            case .hidePanel:
                 viewModel.hidePanel()
-            default:
+            case .ignore:
                 break
             }
         }
 
         private var shaderTheme: MacDictationVisualTheme {
             MacDictationVisualTheme.fromStoredValue(shaderThemeRawValue)
+        }
+    }
+
+    enum MacDictationCapsuleDismissBehavior: Equatable {
+        case cancelActiveCapture
+        case hidePanel
+        case ignore
+
+        static func forState(_ state: DictationState) -> Self {
+            switch state {
+            case .starting, .listening, .processing:
+                return .cancelActiveCapture
+            case .idle, .error:
+                return .hidePanel
+            case .result, .clipboardPending:
+                return .ignore
+            }
         }
     }
 #endif

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -258,6 +258,53 @@
             #expect(subject.shell.isPanelVisible == false)
         }
 
+        @Test func cancelDuringProcessingDoesNotPasteLateTranscript() async {
+            let subject = makeSubject()
+            let presentationModel = FakePresentationModel()
+            subject.session.activate(presentationModel: presentationModel, showInDock: false)
+            await subject.speechService.setStopBehavior(.suspended)
+            await subject.speechService.setCancelFailsPendingStop(false)
+
+            subject.session.startDictationCapture(from: .interface)
+            #expect(
+                await TestSupport.eventually {
+                    subject.workflow.dictationViewModel.state == .listening
+                }
+            )
+
+            subject.session.requestDictationCaptureStopIfNeeded()
+            #expect(
+                await TestSupport.eventually {
+                    subject.workflow.dictationViewModel.state == .processing
+                }
+            )
+            #expect(
+                await TestSupport.eventuallyAsync {
+                    await subject.speechService.counts().stop == 1
+                }
+            )
+
+            subject.session.cancelActiveCapture()
+            #expect(subject.workflow.dictationViewModel.state == .idle)
+            #expect(
+                await TestSupport.eventuallyAsync {
+                    await subject.speechService.counts().cancel == 1
+                }
+            )
+
+            await subject.speechService.finishStop(with: "late transcript")
+            #expect(
+                await TestSupport.eventually {
+                    subject.workflow.dictationViewModel.state == .idle
+                }
+            )
+            try? await Task.sleep(for: .milliseconds(80))
+
+            #expect(subject.workflow.dictationViewModel.state == .idle)
+            #expect(subject.textInjectionService.pasteTargets.isEmpty)
+            #expect(subject.clipboardService.copiedTexts.isEmpty)
+        }
+
         @Test func dismissPendingCopyHidesPanelAndResetsClipboardPendingState() async {
             let subject = makeSubject()
 

--- a/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -584,6 +584,31 @@
             #expect(textInjection.pasteTargets.isEmpty)
         }
 
+        @Test func cancellationDuringInjectionDoesNotFallbackToClipboard() async throws {
+            let clipboard = TestClipboardService()
+            let injection = TestTextInjectionService()
+            let gate = TestSuspensionGate()
+            injection.pasteGate = gate
+            injection.pasteOutcome = .eventPostFailed
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: injection)
+            let task = Task { @MainActor in
+                await coordinator.handleCompletedCapture(
+                    text: "cancelled",
+                    targetApplication: nil,
+                    settings: .init(
+                        shouldCopyToClipboard: false, shouldAutoPaste: true, shouldRevealPanelOnCapture: false
+                    ),
+                    showPanel: { Issue.record("Cancelled output revealed the panel") }
+                )
+            }
+            #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+            task.cancel()
+            await gate.open()
+            #expect(await task.value == .cancelled)
+            // Only the initial temporary copy is allowed; no recovery copy after cancellation.
+            #expect(clipboard.copiedTexts == ["cancelled"])
+        }
+
         @Test func cancelledTaskDoesNotAutoPaste() async {
             let clipboard = TestClipboardService()
             let textInjection = TestTextInjectionService()

--- a/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -601,7 +601,7 @@
                     showPanel: { Issue.record("Cancelled output revealed the panel") }
                 )
             }
-            #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+            try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
             task.cancel()
             await gate.open()
             #expect(await task.value == .cancelled)

--- a/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+    import AppKit
     import Foundation
     import Testing
 
@@ -582,6 +583,39 @@
             #expect(outcome == .completed)
             #expect(clipboard.copiedTexts.isEmpty)
             #expect(textInjection.pasteTargets.isEmpty)
+        }
+
+        @Test(arguments: [false, true])
+        func cancelledPasteRestoresOnlyItsOwnClipboardOverride(userCopied: Bool) async throws {
+            let pasteboard = NSPasteboard(name: .init("StetTests.\(UUID().uuidString)"))
+            defer { pasteboard.releaseGlobally() }
+            pasteboard.setString("original", forType: .string)
+            let injection = TestTextInjectionService()
+            let gate = TestSuspensionGate()
+            injection.pasteGate = gate
+            let coordinator = MacDictationCaptureCoordinator(
+                clipboardService: SystemClipboardService(pasteboard: pasteboard),
+                textInjectionService: injection,
+                pasteboard: pasteboard
+            )
+            let task = Task { @MainActor in
+                await coordinator.handleCompletedCapture(
+                    text: "cancelled", targetApplication: nil,
+                    settings: .init(
+                        shouldCopyToClipboard: false, shouldAutoPaste: true, shouldRevealPanelOnCapture: false
+                    ), showPanel: {}
+                )
+            }
+            try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+            #expect(pasteboard.string(forType: .string) == "cancelled")
+            if userCopied {
+                pasteboard.clearContents()
+                pasteboard.setString("user copy", forType: .string)
+            }
+            task.cancel()
+            await gate.open()
+            #expect(await task.value == .cancelled)
+            #expect(pasteboard.string(forType: .string) == (userCopied ? "user copy" : "original"))
         }
 
         @Test func cancellationDuringInjectionDoesNotFallbackToClipboard() async throws {

--- a/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationCaptureCoordinatorTests.swift
@@ -583,5 +583,30 @@
             #expect(clipboard.copiedTexts.isEmpty)
             #expect(textInjection.pasteTargets.isEmpty)
         }
+
+        @Test func cancelledTaskDoesNotAutoPaste() async {
+            let clipboard = TestClipboardService()
+            let textInjection = TestTextInjectionService()
+            let coordinator = makeCoordinator(clipboard: clipboard, textInjection: textInjection)
+
+            let task = Task { @MainActor in
+                withUnsafeCurrentTask { $0?.cancel() }
+                return await coordinator.handleCompletedCapture(
+                    text: "hello",
+                    targetApplication: nil,
+                    settings: .init(
+                        shouldCopyToClipboard: false,
+                        shouldAutoPaste: true,
+                        shouldRevealPanelOnCapture: false
+                    ),
+                    showPanel: {}
+                )
+            }
+
+            let outcome = await task.value
+            #expect(outcome == .cancelled)
+            #expect(clipboard.copiedTexts.isEmpty)
+            #expect(textInjection.pasteTargets.isEmpty)
+        }
     }
 #endif

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -117,7 +117,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let oldStop = Task { try await service.stopRecording() }
-        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync(timeout: .seconds(3)) { await gate.hasWaiter })
         await service.cancelRecording()
         // ASR is still blocked; starting the next microphone must not wait for it.
         try await service.startRecordingAndActivate()
@@ -187,7 +187,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let stop = Task { try await service.stopRecording() }
-        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync(timeout: .seconds(3)) { await gate.hasWaiter })
         await service.cancelRecording()
         await gate.open()
         await #expect(throws: CancellationError.self) { try await stop.value }
@@ -211,7 +211,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let stop = Task { try await service.stopRecording(onCaptureStopped: { await gate.wait() }) }
-        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync(timeout: .seconds(3)) { await gate.hasWaiter })
         await service.cancelRecording()
         await gate.open()
         await #expect(throws: CancellationError.self) { try await stop.value }

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -100,6 +100,125 @@ private func makeProcessedAudioResult(
 
 @Suite("Configurable Speech Service", .serialized)
 struct ConfigurableSpeechServiceTests {
+    @Test(arguments: [false, true])
+    func cancelledTranscriptionCannotClearRestartedCapture(fails: Bool) async throws {
+        let (store, _, _) = try makeSettingsStore()
+        let gate = TestSuspensionGate()
+        let direct = TestTranscriptionService(result: "old")
+        await direct.setGate(gate)
+        let capture = TestAudioCaptureService(audioFileURL: makeAudioFileURL())
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() }
+            ),
+            captureService: capture
+        )
+        try await service.startRecordingAndActivate()
+        let oldStop = Task { try await service.stopRecording() }
+        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        await service.cancelRecording()
+        // ASR is still blocked; starting the next microphone must not wait for it.
+        try await service.startRecordingAndActivate()
+        if fails { await direct.setOutcome(.failure(TestError.expected)) }
+        await gate.open()
+        do {
+            _ = try await oldStop.value
+            Issue.record("Cancelled processing returned a transcript")
+        } catch {}
+        await direct.setOutcome(.success("new"))
+        let result = try await service.stopRecording()
+        #expect(result.text == "new")
+        #expect(await capture.counts().start == 2)
+    }
+
+    @Test func restartWaitsForCancelledMicrophoneStartupAndTeardown() async throws {
+        let (store, _, _) = try makeSettingsStore()
+        let startGate = TestSuspensionGate()
+        let cancelGate = TestSuspensionGate()
+        let capture = TestAudioCaptureService(
+            audioFileURL: makeAudioFileURL(), startGate: startGate, cancelGate: cancelGate
+        )
+        let direct = TestTranscriptionService(result: "new")
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() }
+            ),
+            captureService: capture
+        )
+        let first = Task { try await service.startRecordingAndActivate() }
+        #require(await TestSupport.eventuallyAsync { await startGate.hasWaiter })
+        let cancel = Task { await service.cancelRecording() }
+        #require(await TestSupport.eventuallyAsync { await startGate.observedCancellation })
+        let second = Task { try await service.startRecordingAndActivate() }
+        await startGate.open()
+        #require(await TestSupport.eventuallyAsync { await cancelGate.hasWaiter })
+        #expect(await capture.counts().start == 1)
+        await cancelGate.open()
+        await cancel.value
+        await #expect(throws: CancellationError.self) { try await first.value }
+        try await second.value
+        #expect(await capture.counts().start == 2)
+        #expect(await capture.counts().activate == 1)
+        #expect(try await service.stopRecording().text == "new")
+    }
+
+    @Test func cancelDuringPostProcessingDeletesAllOwnedAudio() async throws {
+        let (store, _, _) = try makeSettingsStore()
+        store.saveTranscriptionEngine(.fluidAudio)
+        let source = makeAudioFileURL()
+        let processed = makeAudioFileURL()
+        let gate = TestSuspensionGate()
+        let direct = TestTranscriptionService(result: "unused")
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() }
+            ),
+            audioPostProcessor: TestAudioPostProcessor(
+                result: .rewritten(sourceURL: source, rewrittenURL: processed, duration: 1),
+                onProcessAudioFile: { await gate.wait() }
+            ),
+            captureService: TestAudioCaptureService(audioFileURL: source)
+        )
+        try await service.startRecordingAndActivate()
+        let stop = Task { try await service.stopRecording() }
+        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        await service.cancelRecording()
+        await gate.open()
+        await #expect(throws: CancellationError.self) { try await stop.value }
+        #expect(!FileManager.default.fileExists(atPath: source.path))
+        #expect(!FileManager.default.fileExists(atPath: processed.path))
+        #expect(await direct.callCount() == 0)
+    }
+
+    @Test func cancelDuringCaptureStoppedCallbackDeletesSourceAudio() async throws {
+        let (store, _, _) = try makeSettingsStore()
+        let source = makeAudioFileURL()
+        let gate = TestSuspensionGate()
+        let direct = TestTranscriptionService(result: "unused")
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() }
+            ),
+            captureService: TestAudioCaptureService(audioFileURL: source)
+        )
+        try await service.startRecordingAndActivate()
+        let stop = Task { try await service.stopRecording(onCaptureStopped: { await gate.wait() }) }
+        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        await service.cancelRecording()
+        await gate.open()
+        await #expect(throws: CancellationError.self) { try await stop.value }
+        #expect(!FileManager.default.fileExists(atPath: source.path))
+        #expect(await direct.callCount() == 0)
+    }
+
     private actor LevelLog {
         private var levels: [Double] = []
 
@@ -1351,14 +1470,22 @@ private actor TestAudioCaptureService: AudioCaptureService, AudioLevelSource {
     private var stopCount = 0
     private var cancelCount = 0
     private let audioDurationSeconds: TimeInterval?
+    private let startGate: TestSuspensionGate?
+    private let cancelGate: TestSuspensionGate?
 
-    init(audioFileURL: URL, audioDurationSeconds: TimeInterval? = 1.2) {
+    init(
+        audioFileURL: URL, audioDurationSeconds: TimeInterval? = 1.2,
+        startGate: TestSuspensionGate? = nil, cancelGate: TestSuspensionGate? = nil
+    ) {
+        self.startGate = startGate
+        self.cancelGate = cancelGate
         self.audioFileURL = audioFileURL
         self.audioDurationSeconds = audioDurationSeconds
     }
 
     func startRecording() async throws {
         startCount += 1
+        await startGate?.wait()
     }
 
     func activateRecordingWindow() async throws {
@@ -1372,6 +1499,7 @@ private actor TestAudioCaptureService: AudioCaptureService, AudioLevelSource {
 
     func cancelRecording() async {
         cancelCount += 1
+        await cancelGate?.wait()
     }
 
     func prewarm() async {}
@@ -1419,6 +1547,9 @@ private actor TestTranscriptionService: AudioFileTranscriptionService {
     }
 
     private(set) var outcome: Outcome
+    private var gate: TestSuspensionGate?
+
+    func setGate(_ gate: TestSuspensionGate) { self.gate = gate }
     private var callCountValue = 0
     private var lastInvocationValue: (fileURL: URL, languageCode: String?, prompt: String?, duration: TimeInterval?)?
 
@@ -1445,6 +1576,7 @@ private actor TestTranscriptionService: AudioFileTranscriptionService {
             fileURL: fileURL, languageCode: languageCode, prompt: prompt, duration: audioDurationSeconds
         )
         #expect(!fileURL.path.isEmpty)
+        await gate?.wait()
 
         switch outcome {
         case .success(let value):

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -117,7 +117,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let oldStop = Task { try await service.stopRecording() }
-        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
         await service.cancelRecording()
         // ASR is still blocked; starting the next microphone must not wait for it.
         try await service.startRecordingAndActivate()
@@ -150,12 +150,12 @@ struct ConfigurableSpeechServiceTests {
             captureService: capture
         )
         let first = Task { try await service.startRecordingAndActivate() }
-        #require(await TestSupport.eventuallyAsync { await startGate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await startGate.hasWaiter })
         let cancel = Task { await service.cancelRecording() }
-        #require(await TestSupport.eventuallyAsync { await startGate.observedCancellation })
+        try #require(await TestSupport.eventuallyAsync { await startGate.observedCancellation })
         let second = Task { try await service.startRecordingAndActivate() }
         await startGate.open()
-        #require(await TestSupport.eventuallyAsync { await cancelGate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await cancelGate.hasWaiter })
         #expect(await capture.counts().start == 1)
         await cancelGate.open()
         await cancel.value
@@ -187,7 +187,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let stop = Task { try await service.stopRecording() }
-        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
         await service.cancelRecording()
         await gate.open()
         await #expect(throws: CancellationError.self) { try await stop.value }
@@ -211,7 +211,7 @@ struct ConfigurableSpeechServiceTests {
         )
         try await service.startRecordingAndActivate()
         let stop = Task { try await service.stopRecording(onCaptureStopped: { await gate.wait() }) }
-        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
         await service.cancelRecording()
         await gate.open()
         await #expect(throws: CancellationError.self) { try await stop.value }

--- a/StetMacTests/Core/TextInput/SystemTextInjectionServiceTests.swift
+++ b/StetMacTests/Core/TextInput/SystemTextInjectionServiceTests.swift
@@ -8,6 +8,29 @@
     @MainActor
     @Suite("System Text Injection Service", .serialized)
     struct SystemTextInjectionServiceTests {
+        @Test func cancellationDuringPasteDelayNeverPostsCommand() async throws {
+            let service = SystemTextInjectionService(clipboardService: TestClipboardService())
+            let gate = TestSuspensionGate()
+            var posted = false
+            let task = Task { @MainActor in
+                await service.performPasteClipboard(
+                    into: nil,
+                    accessState: .init(hasAccessibilityAccess: true, hasPostEventAccess: true),
+                    activateApplication: { _ in },
+                    snapshotProvider: { nil },
+                    simulatePasteCommand: {
+                        posted = true; return true
+                    },
+                    sleep: { _ in await gate.wait() }
+                )
+            }
+            #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+            task.cancel()
+            await gate.open()
+            #expect(await task.value == .eventPostFailed)
+            #expect(!posted)
+        }
+
         @Test func pasteCapturesVerificationSnapshotAfterTargetActivation() async throws {
             let service = SystemTextInjectionService(clipboardService: TestClipboardService())
             let targetApplication = try #require(Self.activationCandidateApplication())

--- a/StetMacTests/Core/TextInput/SystemTextInjectionServiceTests.swift
+++ b/StetMacTests/Core/TextInput/SystemTextInjectionServiceTests.swift
@@ -24,7 +24,7 @@
                     sleep: { _ in await gate.wait() }
                 )
             }
-            #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+            try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
             task.cancel()
             await gate.open()
             #expect(await task.value == .eventPostFailed)

--- a/StetMacTests/Features/Dictation/DictationViewModelTests.swift
+++ b/StetMacTests/Features/Dictation/DictationViewModelTests.swift
@@ -18,13 +18,13 @@ struct DictationViewModelTests {
         let history = HistoryRecordingSpy()
         let viewModel = DictationViewModel(speechService: speech, historyService: history)
         viewModel.startCapture()
-        #require(await TestSupport.eventually { viewModel.state == .listening })
+        try #require(await TestSupport.eventually { viewModel.state == .listening })
         viewModel.stopCapture()
-        #require(await TestSupport.eventuallyAsync { await speech.counts().stop == 1 })
+        try #require(await TestSupport.eventuallyAsync { await speech.counts().stop == 1 })
         viewModel.send(.resetTapped)
         // Deliberately restart in the same main-actor turn as reset.
         viewModel.startCapture { $0.uppercased() }
-        #require(await TestSupport.eventually { viewModel.state == .listening })
+        try #require(await TestSupport.eventually { viewModel.state == .listening })
         switch failureKind {
         case 0: await speech.failStop(with: CancellationError())
         case 1: await speech.failStop(with: SpeechServiceError.emptyTranscription)
@@ -50,12 +50,12 @@ struct DictationViewModelTests {
             await gate.wait()
             return "OLD"
         }
-        #require(await TestSupport.eventually { viewModel.state == .listening })
+        try #require(await TestSupport.eventually { viewModel.state == .listening })
         viewModel.stopCapture()
-        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
         viewModel.send(.resetTapped)
         viewModel.startCapture()
-        #require(await TestSupport.eventually { viewModel.state == .listening })
+        try #require(await TestSupport.eventually { viewModel.state == .listening })
         await gate.open()
         try await Task.sleep(for: .milliseconds(50))
         #expect(viewModel.state == .listening)
@@ -75,10 +75,10 @@ struct DictationViewModelTests {
             await gate.wait()
             throw CancellationError()
         }
-        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        try #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
         viewModel.send(.resetTapped)
         viewModel.startCapture()
-        #require(await TestSupport.eventually { viewModel.state == .listening })
+        try #require(await TestSupport.eventually { viewModel.state == .listening })
         await gate.open()
         try await Task.sleep(for: .milliseconds(50))
         #expect(viewModel.state == .listening)

--- a/StetMacTests/Features/Dictation/DictationViewModelTests.swift
+++ b/StetMacTests/Features/Dictation/DictationViewModelTests.swift
@@ -158,6 +158,32 @@ struct DictationViewModelTests {
         #expect(await speechService.counts().cancel == 1)
     }
 
+    @Test func resetDuringProcessingDiscardsLateTranscriptionResult() async throws {
+        let speechService = ControllableSpeechService()
+        await speechService.setStopBehavior(.suspended)
+        await speechService.setCancelFailsPendingStop(false)
+        let viewModel = DictationViewModel(
+            speechService: speechService,
+            manualActivationFallbackDelay: fallbackDelay
+        )
+
+        viewModel.startCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .listening })
+
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .processing })
+        #expect(await TestSupport.eventuallyAsync { await speechService.counts().stop == 1 })
+
+        viewModel.send(.resetTapped)
+        #expect(viewModel.state == .idle)
+        #expect(await TestSupport.eventuallyAsync { await speechService.counts().cancel == 1 })
+
+        await speechService.finishStop(with: "should not be delivered")
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(viewModel.state == .idle)
+    }
+
     @Test func explicitActivationKeepsViewModelStartingUntilActivated() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setActivationBehavior(.suspended)

--- a/StetMacTests/Features/Dictation/DictationViewModelTests.swift
+++ b/StetMacTests/Features/Dictation/DictationViewModelTests.swift
@@ -10,6 +10,82 @@ import Testing
 struct DictationViewModelTests {
     private let fallbackDelay: Duration = .milliseconds(20)
 
+    @Test(arguments: [0, 1, 2])
+    func lateProcessingFailureDoesNotResetNewRecording(failureKind: Int) async throws {
+        let speech = ControllableSpeechService()
+        await speech.setStopBehavior(.suspended)
+        await speech.setCancelFailsPendingStop(false)
+        let history = HistoryRecordingSpy()
+        let viewModel = DictationViewModel(speechService: speech, historyService: history)
+        viewModel.startCapture()
+        #require(await TestSupport.eventually { viewModel.state == .listening })
+        viewModel.stopCapture()
+        #require(await TestSupport.eventuallyAsync { await speech.counts().stop == 1 })
+        viewModel.send(.resetTapped)
+        // Deliberately restart in the same main-actor turn as reset.
+        viewModel.startCapture { $0.uppercased() }
+        #require(await TestSupport.eventually { viewModel.state == .listening })
+        switch failureKind {
+        case 0: await speech.failStop(with: CancellationError())
+        case 1: await speech.failStop(with: SpeechServiceError.emptyTranscription)
+        default: await speech.failStop(with: TestError.expected)
+        }
+        // Let the old task's catch run before testing the new session's stop path.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.state == .listening)
+        await speech.setStopBehavior(.immediate("new"))
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("NEW") })
+        #expect(history.rawTexts == ["new"])
+        #expect(history.llmTexts == ["NEW"])
+    }
+
+    @Test func cancelledTransformerCannotWriteIntoNewHistory() async throws {
+        let speech = ControllableSpeechService()
+        await speech.setStopBehavior(.immediate("old"))
+        let gate = TestSuspensionGate()
+        let history = HistoryRecordingSpy()
+        let viewModel = DictationViewModel(speechService: speech, historyService: history)
+        viewModel.startCapture { _ in
+            await gate.wait()
+            return "OLD"
+        }
+        #require(await TestSupport.eventually { viewModel.state == .listening })
+        viewModel.stopCapture()
+        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        viewModel.send(.resetTapped)
+        viewModel.startCapture()
+        #require(await TestSupport.eventually { viewModel.state == .listening })
+        await gate.open()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.state == .listening)
+        #expect(history.rawTexts.isEmpty)
+        #expect(history.llmTexts.isEmpty)
+        await speech.setStopBehavior(.immediate("new"))
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("new") })
+        #expect(history.rawTexts == ["new"])
+    }
+
+    @Test func lateExternalOperationFailureDoesNotResetNewRecording() async throws {
+        let speech = ControllableSpeechService()
+        let gate = TestSuspensionGate()
+        let viewModel = DictationViewModel(speechService: speech)
+        viewModel.runProcessingOperation {
+            await gate.wait()
+            throw CancellationError()
+        }
+        #require(await TestSupport.eventuallyAsync { await gate.hasWaiter })
+        viewModel.send(.resetTapped)
+        viewModel.startCapture()
+        #require(await TestSupport.eventually { viewModel.state == .listening })
+        await gate.open()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(viewModel.state == .listening)
+        viewModel.stopCapture()
+        #expect(await TestSupport.eventually { viewModel.state == .result("transcript") })
+    }
+
     @Test func startAndStopCaptureProducesResult() async throws {
         let speechService = ControllableSpeechService()
         await speechService.setStopBehavior(.immediate("hello world"))

--- a/StetMacTests/Features/MacShell/MacDictationPanelViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/MacDictationPanelViewModelTests.swift
@@ -200,4 +200,14 @@ struct MacDictationPanelViewModelTests {
                     && viewModel.statusText == "Provider configuration required"
             })
     }
+
+    @Test func capsuleDismissCancelsCaptureWhileProcessing() {
+        #expect(MacDictationCapsuleDismissBehavior.forState(.starting) == .cancelActiveCapture)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.listening) == .cancelActiveCapture)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.processing) == .cancelActiveCapture)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.idle) == .hidePanel)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.error(.emptyTranscription)) == .hidePanel)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.result("done")) == .ignore)
+        #expect(MacDictationCapsuleDismissBehavior.forState(.clipboardPending("copy")) == .ignore)
+    }
 }

--- a/StetMacTests/Support/TestSupport.swift
+++ b/StetMacTests/Support/TestSupport.swift
@@ -154,6 +154,7 @@ final class TestTextInjectionService: TextInjectionService {
     var didOpenAccessibilitySettings = false
     var pasteResult = true
     var pasteOutcome: TextInjectionOutcome = .verifiedSuccess
+    var pasteGate: TestSuspensionGate?
     var replacementOutcome: TextReplacementOutcome = .replaced
     var selectedTextValue: String?
     var accessState = TextInjectionAccessState(
@@ -177,6 +178,7 @@ final class TestTextInjectionService: TextInjectionService {
 
     func pasteClipboard(into application: NSRunningApplication?) async -> TextInjectionOutcome {
         pasteTargets.append(application?.bundleIdentifier)
+        await pasteGate?.wait()
         return pasteResult ? pasteOutcome : .verificationFailed
     }
 
@@ -465,5 +467,32 @@ enum TestURLSessionFactory {
         }
 
         return URLSession(configuration: configuration)
+    }
+}
+
+/// Holds an async dependency at a known suspension, even if its caller is cancelled.
+actor TestSuspensionGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private(set) var hasWaiter = false
+    private(set) var observedCancellation = false
+
+    func wait() async {
+        await withTaskCancellationHandler {
+            guard !isOpen else { return }
+            hasWaiter = true
+            await withCheckedContinuation { continuations.append($0) }
+        } onCancel: {
+            Task { await self.markCancelled() }
+        }
+    }
+
+    private func markCancelled() { observedCancellation = true }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending { continuation.resume() }
     }
 }

--- a/StetMacTests/Support/TestSupport.swift
+++ b/StetMacTests/Support/TestSupport.swift
@@ -226,6 +226,7 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
     private var startBehavior: StartBehavior = .immediate
     private var activationBehavior: ActivationBehavior = .immediate
     private var stopBehavior: StopBehavior = .immediate("transcript")
+    private var cancelFailsPendingStop = true
     private(set) var startCallCount = 0
     private(set) var activationCallCount = 0
     private(set) var stopCallCount = 0
@@ -241,6 +242,10 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
 
     func setStopBehavior(_ behavior: StopBehavior) {
         stopBehavior = behavior
+    }
+
+    func setCancelFailsPendingStop(_ shouldFail: Bool) {
+        cancelFailsPendingStop = shouldFail
     }
 
     func counts() -> (start: Int, activate: Int, stop: Int, cancel: Int) {
@@ -311,6 +316,7 @@ actor ControllableSpeechService: SpeechService, AudioLevelSource {
         startContinuation = nil
         activationContinuation?.resume(throwing: CancellationError())
         activationContinuation = nil
+        guard cancelFailsPendingStop else { return }
         stopContinuation?.resume(throwing: CancellationError())
         stopContinuation = nil
     }

--- a/StetVisuals/MacDictationCapsuleVisualView.swift
+++ b/StetVisuals/MacDictationCapsuleVisualView.swift
@@ -7,8 +7,6 @@
         static let orbHiddenScale: CGFloat = 0.84
         static let panelHiddenScale: CGFloat = 0.90
         static let orbRevealDelay: Duration = .milliseconds(130)
-        static let closeAnimationDuration: UInt64 = 320_000_000
-
         static let panelSpring = Animation.spring(response: 0.34, dampingFraction: 0.90)
         static let orbSpring = Animation.spring(response: 0.62, dampingFraction: 0.90)
         static let closeSpring = Animation.spring(response: 0.30, dampingFraction: 0.92)
@@ -216,10 +214,7 @@
                 showOrbs = false
             }
 
-            Task { @MainActor in
-                try? await Task.sleep(nanoseconds: MacDictationCapsuleVisualTuning.closeAnimationDuration)
-                actions.onDismiss()
-            }
+            actions.onDismiss()
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- Cancel during Thinking/processing now aborts the session immediately instead of only hiding the capsule after a 320ms animation.
- Late ASR/rewrite results from a cancelled session are dropped, so cancelled dictation is no longer auto-pasted into the focused field.
- Auto-paste also bails out if the completion task was cancelled mid-flight.

## Test plan
- [ ] Start dictation, stop into Thinking, click X: capsule dismisses and no text is pasted.
- [ ] Cancel while listening: session returns to idle and does not transcribe/paste.
- [ ] Complete a dictation normally and confirm auto-paste still works.
- [ ] Unit tests: `resetDuringProcessingDiscardsLateTranscriptionResult`, `cancelDuringProcessingDoesNotPasteLateTranscript`, `cancelledTaskDoesNotAutoPaste`.


Made with [Cursor](https://cursor.com)