### PR TITLE
feat(mac): replace appearance theme cards with cover flow

### DIFF
--- a/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
+++ b/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
@@ -13,26 +13,12 @@
             _viewModel = StateObject(wrappedValue: viewModel)
         }
 
-        private struct ThemeCard {
-            let theme: MacDictationVisualTheme
-            let imageName: String
-        }
-
-        private let themeCards: [ThemeCard] = [
-            .init(theme: .blossom, imageName: "flower"),
-            .init(theme: .egg, imageName: "onboardingEgg"),
-            .init(theme: .harbor, imageName: "onboardingArch"),
-            .init(theme: .cat, imageName: "onboardingFloat"),
-            .init(theme: .beacon, imageName: "onboardingPanel5"),
-            .init(theme: .autumn, imageName: "autumn"),
-        ]
-
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     capsulePreview
 
-                    themeCardScroller
+                    appearanceCoverFlow
 
                     Text("Choose the color palette used by the dictation capsule.")
                         .font(.caption)
@@ -57,48 +43,18 @@
             .padding(.vertical, 20)
         }
 
-        private var themeCardScroller: some View {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(themeCards, id: \.theme) { card in
-                        themeCardButton(card)
-                    }
+        private var appearanceCoverFlow: some View {
+            OnboardingAppearanceCoverFlowPanel(
+                selectedTheme: viewModel.shaderTheme,
+                isSelectedThemeApplied: viewModel.hasAppliedSelectedTheme,
+                onFocusedThemeChange: { theme in
+                    viewModel.updateShaderTheme(theme, persist: true)
+                },
+                onApplyTheme: { theme in
+                    viewModel.updateShaderTheme(theme, persist: true)
                 }
-                .padding(.horizontal, 4)
-                .padding(.vertical, 8)
-            }
-        }
-
-        private func themeCardButton(_ card: ThemeCard) -> some View {
-            let isSelected = viewModel.shaderTheme == card.theme
-
-            return Button {
-                viewModel.updateShaderTheme(card.theme, persist: true)
-            } label: {
-                ZStack(alignment: .bottom) {
-                    Image(card.imageName)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 96, height: 134)
-                        .clipped()
-
-                    LinearGradient(
-                        colors: [.clear, Color.black.opacity(0.45)],
-                        startPoint: .center,
-                        endPoint: .bottom
-                    )
-
-                    Text(card.theme.title)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white)
-                        .padding(.bottom, 8)
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .shadow(color: Color.black.opacity(isSelected ? 0.30 : 0.15), radius: isSelected ? 10 : 6, x: 0, y: 4)
-                .scaleEffect(isSelected ? 1.04 : 1.0)
-                .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSelected)
-            }
-            .buttonStyle(.plain)
+            )
+            .frame(minHeight: 390)
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- replace the macOS Appearance settings theme strip with the onboarding cover flow
- keep the live capsule preview and persist focused theme selection through the existing view model
- remove the duplicate small-card picker

## Validation
- `git diff --check` passes
- `make test` could not run because the active developer directory is Command Line Tools rather than a full Xcode installation

Closes #53
