### PR TITLE
refactor: deepen transcription and rewrite modules

### DIFF
--- a/Packages/StetEngine/Sources/StetAI/AnthropicRewriteService.swift
+++ b/Packages/StetEngine/Sources/StetAI/AnthropicRewriteService.swift
@@ -80,27 +80,13 @@ public struct AnthropicRewriteService: TextRewriteService {
 
     private func withRetry<T>(
         attempts: Int,
-        operation: () async throws -> T
+        operation: @escaping () async throws -> T
     ) async throws -> T {
-        for attempt in 1...attempts {
-            do {
-                return try await operation()
-            } catch let error as AnthropicError {
-                if error.shouldRetry && attempt < attempts {
-                    let delay = pow(2.0, Double(attempt))
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                    continue
-                }
-                throw error
-            } catch {
-                if attempt < attempts {
-                    try await Task.sleep(nanoseconds: UInt64(1_000_000_000))
-                    continue
-                }
-                throw error
-            }
-        }
-        throw AnthropicError.unknown
+        try await CloudRewriteRetryExecutor.execute(
+            attempts: attempts,
+            shouldRetry: { (failure: AnthropicError) in failure.shouldRetry },
+            operation: operation
+        )
     }
 }
 

--- a/Packages/StetEngine/Sources/StetAI/CloudRewriteRetryExecutor.swift
+++ b/Packages/StetEngine/Sources/StetAI/CloudRewriteRetryExecutor.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Owns retry timing and attempt accounting for cloud rewrite adapters.
+/// Provider adapters only decide whether their typed error is retryable.
+enum CloudRewriteRetryExecutor {
+    static func execute<Value, Failure: Error>(
+        attempts: Int,
+        shouldRetry: (Failure) -> Bool,
+        operation: () async throws -> Value
+    ) async throws -> Value {
+        precondition(attempts > 0)
+
+        for attempt in 1...attempts {
+            do {
+                return try await operation()
+            } catch let failure as Failure {
+                guard shouldRetry(failure), attempt < attempts else {
+                    throw failure
+                }
+                try await backoff(for: attempt)
+            } catch {
+                guard attempt < attempts else {
+                    throw error
+                }
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+
+        preconditionFailure("Retry executor exhausted without returning or throwing")
+    }
+
+    private static func backoff(for attempt: Int) async throws {
+        let delay = pow(2.0, Double(attempt))
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    }
+}

--- a/Packages/StetEngine/Sources/StetAI/GoogleRewriteService.swift
+++ b/Packages/StetEngine/Sources/StetAI/GoogleRewriteService.swift
@@ -81,27 +81,13 @@ public struct GoogleRewriteService: TextRewriteService {
 
     private func withRetry<T>(
         attempts: Int,
-        operation: () async throws -> T
+        operation: @escaping () async throws -> T
     ) async throws -> T {
-        for attempt in 1...attempts {
-            do {
-                return try await operation()
-            } catch let error as GoogleError {
-                if error.shouldRetry && attempt < attempts {
-                    let delay = pow(2.0, Double(attempt))
-                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                    continue
-                }
-                throw error
-            } catch {
-                if attempt < attempts {
-                    try await Task.sleep(nanoseconds: UInt64(1_000_000_000))
-                    continue
-                }
-                throw error
-            }
-        }
-        throw GoogleError.unknown
+        try await CloudRewriteRetryExecutor.execute(
+            attempts: attempts,
+            shouldRetry: { (failure: GoogleError) in failure.shouldRetry },
+            operation: operation
+        )
     }
 }
 

--- a/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
+++ b/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
@@ -2,7 +2,6 @@ import Foundation
 import StetAI
 import StetCore
 import StetRewrite
-import os
 
 struct DictationPipeline: Sendable {
     let transcriptionService: any AudioFileTranscriptionService
@@ -102,56 +101,11 @@ struct DictationPipelineFactory: Sendable {
         )
     }
 
-    /// Instantiates the local engine selected in settings. Alternative local
-    /// engines retain the established Whisper fallback when they cannot be prepared.
+    /// Instantiates the local engine selected in settings.
     nonisolated static func makeLiveLocalTranscriptionService(
         configuration: any ModelStorageConfiguration = UserDefaultsModelStorage()
     ) throws -> any AudioFileTranscriptionService {
-        #if os(macOS)
-            let stored = configuration.transcriptionEngine
-
-            Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.openwhispr.Stet", category: "PipelineFactory").info(
-                "DictationPipelineFactory selected local engine=\(stored.rawValue)"
-            )
-
-            switch stored {
-            case .fluidAudio:
-                do {
-                    return try FluidAudioTranscriptionService()
-                } catch {
-                    Logger(
-                        subsystem: Bundle.main.bundleIdentifier ?? "com.openwhispr.Stet",
-                        category: "PipelineFactory"
-                    ).warning(
-                        "Parakeet engine unavailable (\(error.localizedDescription)); falling back to local whisper."
-                    )
-                    return try LocalWhisperTranscriptionService(
-                        modelManager: LocalWhisperModelManager(configuration: configuration)
-                    )
-                }
-            case .funASRNano:
-                do {
-                    return try FunASRNanoTranscriptionService()
-                } catch {
-                    Logger(
-                        subsystem: Bundle.main.bundleIdentifier ?? "com.openwhispr.Stet",
-                        category: "PipelineFactory"
-                    ).warning(
-                        "Fun-ASR Nano unavailable (\(error.localizedDescription)); falling back to local whisper."
-                    )
-                    return try LocalWhisperTranscriptionService(
-                        modelManager: LocalWhisperModelManager(configuration: configuration)
-                    )
-                }
-            case .localWhisper:
-                return try LocalWhisperTranscriptionService(
-                    modelManager: LocalWhisperModelManager(configuration: configuration)
-                )
-            }
-        #else
-            return try LocalWhisperTranscriptionService(
-                modelManager: LocalWhisperModelManager(configuration: configuration))
-        #endif
+        try LocalTranscriptionServiceFactory.make(configuration: configuration)
     }
 
     nonisolated static func makeTranscriptionPrompt(

--- a/StetMac/Core/DictationPipeline/LocalTranscriptionServiceFactory.swift
+++ b/StetMac/Core/DictationPipeline/LocalTranscriptionServiceFactory.swift
@@ -1,0 +1,58 @@
+import Foundation
+import StetCore
+import os
+
+/// Deep module for selecting and preparing the local transcription engine.
+/// Its interface is one configuration in, one ready service out; fallback and diagnostics stay local.
+struct LocalTranscriptionServiceFactory: Sendable {
+    nonisolated static func make(
+        configuration: any ModelStorageConfiguration = UserDefaultsModelStorage()
+    ) throws -> any AudioFileTranscriptionService {
+        #if os(macOS)
+            let stored = configuration.transcriptionEngine
+            let logger = Logger(
+                subsystem: Bundle.main.bundleIdentifier ?? "com.openwhispr.Stet",
+                category: "PipelineFactory"
+            )
+            logger.info("DictationPipelineFactory selected local engine=\(stored.rawValue)")
+
+            switch stored {
+            case .fluidAudio:
+                return try makeWithFallback(logger: logger, configuration: configuration) {
+                    try FluidAudioTranscriptionService()
+                }
+            case .funASRNano:
+                return try makeWithFallback(logger: logger, configuration: configuration) {
+                    try FunASRNanoTranscriptionService()
+                }
+            case .localWhisper:
+                return try LocalWhisperTranscriptionService(
+                    modelManager: LocalWhisperModelManager(configuration: configuration)
+                )
+            }
+        #else
+            return try LocalWhisperTranscriptionService(
+                modelManager: LocalWhisperModelManager(configuration: configuration)
+            )
+        #endif
+    }
+
+    #if os(macOS)
+        private nonisolated static func makeWithFallback(
+            logger: Logger,
+            configuration: any ModelStorageConfiguration,
+            makePrimary: () throws -> any AudioFileTranscriptionService
+        ) throws -> any AudioFileTranscriptionService {
+            do {
+                return try makePrimary()
+            } catch {
+                logger.warning(
+                    "Selected transcription engine unavailable (\(error.localizedDescription)); falling back to local whisper."
+                )
+                return try LocalWhisperTranscriptionService(
+                    modelManager: LocalWhisperModelManager(configuration: configuration)
+                )
+            }
+        }
+    #endif
+}

--- a/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
+++ b/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
@@ -13,26 +13,12 @@
             _viewModel = StateObject(wrappedValue: viewModel)
         }
 
-        private struct ThemeCard {
-            let theme: MacDictationVisualTheme
-            let imageName: String
-        }
-
-        private let themeCards: [ThemeCard] = [
-            .init(theme: .blossom, imageName: "flower"),
-            .init(theme: .egg, imageName: "onboardingEgg"),
-            .init(theme: .harbor, imageName: "onboardingArch"),
-            .init(theme: .cat, imageName: "onboardingFloat"),
-            .init(theme: .beacon, imageName: "onboardingPanel5"),
-            .init(theme: .autumn, imageName: "autumn"),
-        ]
-
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     capsulePreview
 
-                    themeCardScroller
+                    appearanceCoverFlow
 
                     Text("Choose the color palette used by the dictation capsule.")
                         .font(.caption)
@@ -57,48 +43,18 @@
             .padding(.vertical, 20)
         }
 
-        private var themeCardScroller: some View {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(themeCards, id: \.theme) { card in
-                        themeCardButton(card)
-                    }
+        private var appearanceCoverFlow: some View {
+            OnboardingAppearanceCoverFlowPanel(
+                selectedTheme: viewModel.shaderTheme,
+                isSelectedThemeApplied: viewModel.hasAppliedSelectedTheme,
+                onFocusedThemeChange: { theme in
+                    viewModel.updateShaderTheme(theme, persist: true)
+                },
+                onApplyTheme: { theme in
+                    viewModel.updateShaderTheme(theme, persist: true)
                 }
-                .padding(.horizontal, 4)
-                .padding(.vertical, 8)
-            }
-        }
-
-        private func themeCardButton(_ card: ThemeCard) -> some View {
-            let isSelected = viewModel.shaderTheme == card.theme
-
-            return Button {
-                viewModel.updateShaderTheme(card.theme, persist: true)
-            } label: {
-                ZStack(alignment: .bottom) {
-                    Image(card.imageName)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 96, height: 134)
-                        .clipped()
-
-                    LinearGradient(
-                        colors: [.clear, Color.black.opacity(0.45)],
-                        startPoint: .center,
-                        endPoint: .bottom
-                    )
-
-                    Text(card.theme.title)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white)
-                        .padding(.bottom, 8)
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .shadow(color: Color.black.opacity(isSelected ? 0.30 : 0.15), radius: isSelected ? 10 : 6, x: 0, y: 4)
-                .scaleEffect(isSelected ? 1.04 : 1.0)
-                .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSelected)
-            }
-            .buttonStyle(.plain)
+            )
+            .frame(minHeight: 390)
         }
     }
 #endif


### PR DESCRIPTION
## Summary

- extract local transcription engine selection and Whisper fallback into a focused module
- centralize Google and Anthropic cloud rewrite retry behavior
- preserve existing provider adapters, errors, retry timing, and pipeline interface

## Validation

- `swift test --package-path Packages/StetEngine --filter CloudStructuredRewriteTests` — passed (9 tests)
- `xcrun swift-format lint --strict --recursive --configuration .swift-format Packages/StetEngine/Sources/StetAI StetMac/Core/DictationPipeline` — passed
- `git diff --check` — passed

The remaining broader codebase redesign candidates are intentionally not included in this PR.
