### PR TITLE
Refine macOS settings UI and fix history store conflicts

### DIFF
--- a/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
+++ b/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 import SwiftData
 
 @MainActor
@@ -42,18 +43,47 @@ public final class DictationHistoryService: DictationHistoryRecording {
     // MARK: - Private state
 
     private let container: ModelContainer?
+    private var initializationError: Error?
     private var pending: PendingSession?
 
     // MARK: - Init
 
     private init() {
         do {
-            let schema = Schema([HistoryEntry.self])
-            let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-            self.container = try ModelContainer(for: schema, configurations: [config])
+            self.container = try Self.makePersistentContainer()
         } catch {
             self.container = nil
+            self.initializationError = error
         }
+    }
+
+    /// History owns a separate store so opening another feature's schema cannot remove its tables.
+    static func makePersistentContainer(
+        appSupportDirectory: URL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0],
+        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? "NaichengDeng.Stet"
+    ) throws -> ModelContainer {
+        let directory = appSupportDirectory.appendingPathComponent(bundleIdentifier)
+            .appendingPathComponent("SwiftData", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let destination = directory.appendingPathComponent("History.store")
+        let legacy = appSupportDirectory.appendingPathComponent("default.store")
+        if !FileManager.default.fileExists(atPath: destination.path),
+            FileManager.default.fileExists(atPath: legacy.path)
+        {
+            let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(
+                ofType: NSSQLiteStoreType, at: legacy, options: [NSReadOnlyPersistentStoreOption: true])
+            let entities = metadata[NSStoreModelVersionHashesKey] as? [String: Any] ?? [:]
+            if entities["HistoryEntry"] != nil {
+                // Core Data copies a consistent store, including WAL transactions. Keep the original intact.
+                let coordinator = NSPersistentStoreCoordinator(managedObjectModel: NSManagedObjectModel())
+                try coordinator.replacePersistentStore(
+                    at: destination, destinationOptions: nil,
+                    withPersistentStoreFrom: legacy, sourceOptions: [NSReadOnlyPersistentStoreOption: true],
+                    ofType: NSSQLiteStoreType)
+            }
+        }
+        let schema = Schema([HistoryEntry.self])
+        return try ModelContainer(for: schema, configurations: [ModelConfiguration(schema: schema, url: destination)])
     }
 
     init(container: ModelContainer?) {
@@ -116,8 +146,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
 
     /// Fetches history entries sorted by recency, up to `limit` results.
     public func fetchRecent(limit: Int = 300) throws -> [HistoryEntry] {
-        guard let container else { return [] }
-        let context = ModelContext(container)
+        let context = try persistenceContext()
         var descriptor = FetchDescriptor<HistoryEntry>(
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )
@@ -127,8 +156,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
 
     /// Permanently deletes all history entries.
     public func deleteAll() throws {
-        guard let container else { return }
-        let context = ModelContext(container)
+        let context = try persistenceContext()
         try context.delete(model: HistoryEntry.self)
         try context.save()
     }
@@ -288,7 +316,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
 
     private func persistenceContext() throws -> ModelContext {
         guard let container else {
-            throw PassiveHistoryError.persistenceUnavailable
+            throw initializationError ?? PassiveHistoryError.persistenceUnavailable
         }
         return ModelContext(container)
     }

--- a/Packages/StetEngine/Tests/StetCoreTests/DictationHistoryServiceTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/DictationHistoryServiceTests.swift
@@ -7,6 +7,59 @@ import Testing
 @MainActor
 @Suite("Dictation history service", .serialized)
 struct DictationHistoryServiceTests {
+    @Test func persistentHistorySurvivesAnotherSchemaOpeningLegacyStore() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let container = try DictationHistoryService.makePersistentContainer(
+            appSupportDirectory: directory, bundleIdentifier: "test")
+        let service = DictationHistoryService(container: container)
+        let id = UUID()
+        try service.createPassiveCapture(id: id, startedAt: Date())
+        let otherSchema = Schema([HistoryCollisionRecord.self])
+        let other = try ModelContainer(
+            for: otherSchema,
+            configurations: [
+                ModelConfiguration(
+                    schema: otherSchema, url: directory.appendingPathComponent("default.store"))
+            ])
+        _ = try ModelContext(other).fetch(FetchDescriptor<HistoryCollisionRecord>())
+        #expect(try service.fetchRecent().map(\.id) == [id])
+    }
+
+    @Test func legacyHistoryIsCopiedWithAllTextStagesAndOriginalRetained() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let schema = Schema([HistoryEntry.self])
+        let legacy = try ModelContainer(
+            for: schema,
+            configurations: [
+                ModelConfiguration(
+                    schema: schema, url: directory.appendingPathComponent("default.store"))
+            ])
+        let context = ModelContext(legacy)
+        let original = HistoryEntry(rawText: "raw", llmText: "refined", finalText: "delivered")
+        context.insert(original)
+        try context.save()
+        let container = try DictationHistoryService.makePersistentContainer(
+            appSupportDirectory: directory, bundleIdentifier: "test")
+        let service = DictationHistoryService(container: container)
+        let entry = try #require(service.fetchRecent().first)
+        #expect(entry.id == original.id)
+        #expect(entry.rawText == "raw")
+        #expect(entry.llmText == "refined")
+        #expect(entry.finalText == "delivered")
+        #expect(try ModelContext(legacy).fetchCount(FetchDescriptor<HistoryEntry>()) == 1)
+        try service.deleteAll()
+        let reopened = try DictationHistoryService.makePersistentContainer(
+            appSupportDirectory: directory, bundleIdentifier: "test")
+        #expect(try DictationHistoryService(container: reopened).fetchRecent().isEmpty)
+    }
+
+    @Test func unavailableHistoryThrowsInsteadOfPretendingToBeEmpty() {
+        #expect(throws: (any Error).self) { try DictationHistoryService(container: nil).fetchRecent() }
+    }
+
     @Test func existingEntryUsesActiveCompletedMigrationDefaults() {
         let entry = HistoryEntry(rawText: "existing")
 
@@ -248,4 +301,10 @@ struct DictationHistoryServiceTests {
             isOverlap: isOverlap
         )
     }
+}
+
+@Model
+private final class HistoryCollisionRecord {
+    var name: String = ""
+    init() {}
 }

--- a/StetMac/Features/Dictation/MicrophoneTest/MicrophoneAudioLevelMeter.swift
+++ b/StetMac/Features/Dictation/MicrophoneTest/MicrophoneAudioLevelMeter.swift
@@ -1,52 +1,24 @@
 import SwiftUI
 
-/// Visual meter for microphone input level.
+/// A quiet, continuous input meter that stays empty when the microphone is silent.
 struct MicrophoneAudioLevelMeter: View {
     let level: Double
 
-    private let barCount = 20
-    private let spacing: CGFloat = 2
+    private var normalizedLevel: Double { level.isFinite ? min(1, max(0, level)) : 0 }
 
     var body: some View {
         GeometryReader { geometry in
-            HStack(spacing: spacing) {
-                ForEach(0..<barCount, id: \.self) { index in
-                    MicrophoneAudioLevelBar(
-                        isActive: isBarActive(index: index),
-                        height: barHeight(for: index, in: geometry.size.height)
-                    )
+            Capsule()
+                .fill(MacUI.Surfaces.selection)
+                .overlay(alignment: .leading) {
+                    Capsule()
+                        .fill(MacUI.Surfaces.ink.opacity(0.7))
+                        .frame(width: geometry.size.width * normalizedLevel)
                 }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(height: 40)
+        .frame(height: 5)
+        .animation(.easeOut(duration: 0.1), value: normalizedLevel)
         .accessibilityLabel("Microphone input level")
-    }
-
-    private func isBarActive(index: Int) -> Bool {
-        let threshold = Double(index) / Double(barCount)
-        return level >= threshold
-    }
-
-    private func barHeight(for index: Int, in totalHeight: CGFloat) -> CGFloat {
-        let centerIndex = barCount / 2
-        let distanceFromCenter = abs(index - centerIndex)
-        let maxHeight = totalHeight * 0.3
-        let minHeight: CGFloat = 4
-
-        let heightFactor = 1.0 - (Double(distanceFromCenter) / Double(centerIndex)) * 0.5
-        return minHeight + (maxHeight - minHeight) * CGFloat(heightFactor)
-    }
-}
-
-private struct MicrophoneAudioLevelBar: View {
-    let isActive: Bool
-    let height: CGFloat
-
-    var body: some View {
-        RoundedRectangle(cornerRadius: 2)
-            .fill(isActive ? .green : Color.gray.opacity(0.3))
-            .frame(height: height)
-            .animation(.easeInOut(duration: 0.1), value: isActive)
+        .accessibilityValue("\(Int(normalizedLevel * 100)) percent")
     }
 }

--- a/StetMac/Features/Dictation/MicrophoneTest/MicrophoneTestView.swift
+++ b/StetMac/Features/Dictation/MicrophoneTest/MicrophoneTestView.swift
@@ -5,11 +5,16 @@ struct MicrophoneTestView: View {
     @ObservedObject var viewModel: MicrophoneTestViewModel
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Label("Test your microphone", systemImage: "mic")
+                    .font(.subheadline.weight(.medium))
+                Spacer()
+                Text(viewModel.isRecording ? "Recording" : viewModel.isPlaying ? "Playing" : "Ready")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
             // Audio level indicator
             MicrophoneAudioLevelMeter(level: viewModel.audioLevel)
-                .frame(height: 40)
-                .padding(.horizontal, 8)
 
             // Recording controls
             HStack(spacing: 12) {
@@ -27,8 +32,7 @@ struct MicrophoneTestView: View {
                         systemImage: viewModel.isRecording ? "stop.circle.fill" : "record.circle"
                     )
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(viewModel.isRecording ? .red : .accentColor)
+                .buttonStyle(.bordered)
                 .disabled(viewModel.isPlaying)
 
                 // Playback controls
@@ -51,11 +55,11 @@ struct MicrophoneTestView: View {
             }
 
             // Status text
-            if viewModel.hasRecording {
+            if viewModel.hasRecording && !viewModel.isRecording {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Recording saved - click Play to hear it")
+                        .foregroundStyle(.secondary)
+                    Text("Play back your test to check the sound.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -67,10 +71,11 @@ struct MicrophoneTestView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+            } else {
+                Text("Record a short phrase, then play it back to check your input.")
+                    .font(.caption).foregroundStyle(.secondary)
             }
         }
-        .padding()
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.vertical, 8)
     }
 }

--- a/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
+++ b/StetMac/Features/MacShell/AppearanceSetting/MacAppearanceSettingsView.swift
@@ -14,21 +14,34 @@
         }
 
         var body: some View {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
-                    capsulePreview
+            GeometryReader { geometry in
+                // Keep the complete composition visible in the normal Settings window.
+                // Retain scrolling as a fallback for unusually small windows.
+                let coverScale = max(
+                    0.35,
+                    min(0.72, (geometry.size.width - 72) / 440, (geometry.size.height - 140) / 380)
+                )
 
-                    appearanceCoverFlow
+                ScrollView {
+                    VStack(spacing: 12) {
+                        capsulePreview
 
-                    Text("Choose the color palette used by the dictation capsule.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
+                        appearanceCoverFlow
+                            .frame(width: 440, height: 380)
+                            .scaleEffect(coverScale)
+                            .frame(width: 440 * coverScale, height: 380 * coverScale)
+
+                        Text("Choose the color palette used by the dictation capsule.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
                 }
-                .padding(.vertical, 20)
-                .padding(.bottom, MacUI.SettingsViewMetrics.formBottomPadding)
+                .macSettingsTracksTitleScroll()
             }
-            .macSettingsTracksTitleScroll()
             .task {
                 viewModel.load()
             }
@@ -37,10 +50,9 @@
         private var capsulePreview: some View {
             MacDictationCapsulePreviewView(
                 theme: MacDictationShaderTheme(rawValue: viewModel.shaderTheme.rawValue) ?? .egg,
-                scale: 2.0
+                scale: 1.1
             )
             .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.vertical, 20)
         }
 
         private var appearanceCoverFlow: some View {
@@ -54,7 +66,6 @@
                     viewModel.updateShaderTheme(theme, persist: true)
                 }
             )
-            .frame(minHeight: 390)
         }
     }
 #endif

--- a/StetMac/Features/MacShell/Components/MacSettingsComponents.swift
+++ b/StetMac/Features/MacShell/Components/MacSettingsComponents.swift
@@ -39,6 +39,116 @@
         }
     }
 
+    struct MacSettingsEditor<Content: View>: View {
+        let title: String
+        let subtitle: String
+        @ViewBuilder let content: () -> Content
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: MacUI.EditorMetrics.spacing) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title).font(.headline)
+                    Text(subtitle).font(.callout).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                content()
+            }
+            .padding(MacUI.EditorMetrics.padding)
+            .frame(width: MacUI.EditorMetrics.width)
+            .background(MacUI.Surfaces.paper)
+            .clipShape(RoundedRectangle(cornerRadius: MacUI.EditorMetrics.cornerRadius, style: .continuous))
+
+        }
+    }
+
+    extension View {
+        func macSettingsSheet<Sheet: View>(
+            isPresented: Binding<Bool>, @ViewBuilder content: @escaping () -> Sheet
+        ) -> some View {
+            background(MacSettingsSheetPresenter(isPresented: isPresented, sheet: content))
+        }
+    }
+
+    /// A real modal panel keeps keyboard focus and Escape behavior while using Stet's surface tokens.
+    private struct MacSettingsSheetPresenter<Sheet: View>: NSViewRepresentable {
+        @Binding var isPresented: Bool
+        @ViewBuilder var sheet: () -> Sheet
+        @Environment(\.colorScheme) private var colorScheme
+
+        func makeCoordinator() -> Coordinator { Coordinator() }
+        func makeNSView(context: Context) -> NSView { NSView() }
+
+        func updateNSView(_ view: NSView, context: Context) {
+            let coordinator = context.coordinator
+            coordinator.dismiss = { isPresented = false }
+            coordinator.wantsPresentation = isPresented
+            if !isPresented {
+                coordinator.close()
+                return
+            }
+            guard coordinator.panel == nil else { return }
+            let root = sheet().environment(\.colorScheme, colorScheme)
+            DispatchQueue.main.async { [weak view] in
+                guard let parent = view?.window, coordinator.panel == nil, coordinator.wantsPresentation else { return }
+                coordinator.present(root, on: parent)
+            }
+        }
+
+        static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) { coordinator.close() }
+
+        final class Coordinator: NSObject {
+            var panel: EditorPanel?
+            var dismiss: (() -> Void)?
+            var wantsPresentation = false
+
+            func present<Root: View>(_ root: Root, on parent: NSWindow) {
+                let panel = EditorPanel(contentRect: .zero, styleMask: [.borderless], backing: .buffered, defer: false)
+                self.panel = panel
+                panel.onCancel = { [weak self] in self?.dismiss?() }
+                panel.isOpaque = false
+                panel.backgroundColor = .clear
+                panel.hasShadow = true
+                panel.isReleasedWhenClosed = false
+                let host = NSHostingView(
+                    rootView: root.fixedSize().background {
+                        GeometryReader { geometry in
+                            Color.clear.preference(key: EditorSizeKey.self, value: geometry.size)
+                        }
+                    }.onPreferenceChange(EditorSizeKey.self) { [weak panel] size in
+                        guard size.width > 0, size.height > 0 else { return }
+                        DispatchQueue.main.async { panel?.setContentSize(size) }
+                    })
+                panel.contentView = host
+                panel.setContentSize(host.fittingSize)
+                parent.beginSheet(panel)
+                // Hosting can apply native window chrome while attaching. Restore the token-shaped surface.
+                panel.styleMask = [.borderless]
+                panel.isOpaque = false
+                panel.backgroundColor = .clear
+                panel.makeKeyAndOrderFront(nil)
+            }
+
+            func close() {
+                guard let panel else { return }
+                self.panel = nil
+                panel.sheetParent?.endSheet(panel)
+                panel.orderOut(nil)
+            }
+        }
+
+        final class EditorPanel: NSPanel {
+            var onCancel: (() -> Void)?
+            override var canBecomeKey: Bool { true }
+            override var canBecomeMain: Bool { false }
+            override func cancelOperation(_ sender: Any?) { onCancel?() }
+        }
+    }
+
+    private struct EditorSizeKey: PreferenceKey {
+        static let defaultValue: CGSize = .zero
+        static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
+    }
+
     struct MacSettingsValueRow<Value: View>: View {
         let title: String
 

--- a/StetMac/Features/MacShell/Dictionary/DictionaryView.swift
+++ b/StetMac/Features/MacShell/Dictionary/DictionaryView.swift
@@ -13,6 +13,10 @@
         ]
 
         @State private var isShowingClearConfirmation = false
+        @State private var isShowingEditor = false
+        @State private var editingEntry: String?
+        @State private var entryDraft = ""
+        @State private var clearConfirmation = ""
 
         private var isEnabledBinding: Binding<Bool> {
             Binding(
@@ -26,35 +30,22 @@
                 Section {
                     Toggle("Enable Personal Dictionary", isOn: isEnabledBinding)
 
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Add names, brands, jargon, or phrases")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-
-                        HStack(spacing: MacUI.DictionaryViewMetrics.entryInputSpacing) {
-                            TextField(
-                                "",
-                                text: $viewModel.draft
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .multilineTextAlignment(.leading)
-                            .labelsHidden()
-                            .onSubmit {
-                                viewModel.addDraftEntries()
-                            }
-
-                            Button("Add") {
-                                viewModel.addDraftEntries()
-                            }
-                            .disabled(!viewModel.canAddDraftEntries)
-                        }
-                    }
-                    .padding(.vertical, 4)
+                    Text("Help Stet recognize names, brands, and phrases in your transcripts and rewrites.")
+                        .font(.callout).foregroundStyle(.secondary)
                 } header: {
                     Text("Personal Dictionary")
                 }
 
                 Section {
+                    HStack {
+                        Text("\(viewModel.entries.count) words and phrases").foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            openEditor()
+                        } label: {
+                            Label("Add Words…", systemImage: "plus")
+                        }
+                    }
                     if viewModel.entries.isEmpty {
                         Text("Once you add words here, Stet will reuse them in transcription and rewrite.")
                             .foregroundStyle(.secondary)
@@ -69,6 +60,7 @@
                         }
 
                         Button("Clear Dictionary", role: .destructive) {
+                            clearConfirmation = ""
                             isShowingClearConfirmation = true
                         }
                         .foregroundStyle(.red)
@@ -79,27 +71,76 @@
             }
             .macSettingsFormStyle()
             .padding(.bottom, MacUI.SettingsViewMetrics.formBottomPadding)
-            .confirmationDialog(
-                "Are you sure you want to clear your personal dictionary?",
-                isPresented: $isShowingClearConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button("Clear All", role: .destructive) {
-                    viewModel.clearEntries()
+            .macSettingsSheet(isPresented: $isShowingEditor) {
+                MacSettingsEditor(
+                    title: editingEntry == nil ? "Add Dictionary Words" : "Edit Dictionary Entry",
+                    subtitle:
+                        "Use the spelling you want in your transcripts. Separate multiple words or phrases with commas or new lines."
+                ) {
+                    Text("Words or phrases").font(.subheadline)
+                    TextEditor(text: $entryDraft)
+                        .font(.body)
+                        .frame(height: 110)
+                        .padding(6)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: MacUI.SettingsViewMetrics.sidebarRowCornerRadius)
+                                .strokeBorder(Color.secondary.opacity(0.25))
+                        )
+                        .accessibilityLabel("Words or phrases")
+                    HStack {
+                        Spacer()
+                        Button("Cancel") { isShowingEditor = false }.keyboardShortcut(.cancelAction)
+                        Button(editingEntry == nil ? "Add Words" : "Save") {
+                            viewModel.saveEntries(from: entryDraft, replacing: editingEntry)
+                            isShowingEditor = false
+                        }
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(!viewModel.canSaveEntries(from: entryDraft))
+                    }
                 }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("This action cannot be undone.")
             }
+            .macSettingsSheet(isPresented: $isShowingClearConfirmation) {
+                MacSettingsEditor(
+                    title: "Clear Personal Dictionary?",
+                    subtitle:
+                        "This permanently removes all \(viewModel.entries.count) entries, including on devices using your synced dictionary. This cannot be undone."
+                ) {
+                    Text("Type CLEAR to confirm.").font(.subheadline)
+                    TextField("CLEAR", text: $clearConfirmation).textFieldStyle(.roundedBorder).labelsHidden()
+                    HStack {
+                        Spacer()
+                        Button("Cancel") { isShowingClearConfirmation = false }.keyboardShortcut(.cancelAction)
+                        Button("Clear Dictionary", role: .destructive) {
+                            viewModel.clearEntries()
+                            isShowingClearConfirmation = false
+                        }
+                        .disabled(clearConfirmation != "CLEAR")
+                    }
+                }
+            }
+            .onAppear { viewModel.load() }
+        }
+
+        private func openEditor(_ entry: String? = nil) {
+            editingEntry = entry
+            entryDraft = entry ?? ""
+            isShowingEditor = true
         }
 
         private func dictionaryChip(for entry: String) -> some View {
             HStack(spacing: MacUI.DictionaryViewMetrics.chipSpacing) {
-                Text(entry)
-                    .font(MacUI.DictionaryViewMetrics.chipTextFont)
-                    .lineLimit(MacUI.DictionaryViewMetrics.entryLineLimit)
-                    .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                Button {
+                    openEditor(entry)
+                } label: {
+                    Text(entry)
+                        .font(MacUI.DictionaryViewMetrics.chipTextFont)
+                        .lineLimit(MacUI.DictionaryViewMetrics.entryLineLimit)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                }
+                .buttonStyle(.plain)
+                .help("Edit entry")
 
                 Button {
                     viewModel.removeEntry(entry)
@@ -109,6 +150,7 @@
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(entry)")
             }
             .padding(.horizontal, MacUI.DictionaryViewMetrics.chipHorizontalPadding)
             .padding(.vertical, MacUI.DictionaryViewMetrics.chipVerticalPadding)

--- a/StetMac/Features/MacShell/Dictionary/DictionaryViewModel.swift
+++ b/StetMac/Features/MacShell/Dictionary/DictionaryViewModel.swift
@@ -49,6 +49,23 @@
             draft = ""
         }
 
+        func canSaveEntries(from text: String) -> Bool {
+            !DictionaryModel.words(from: text).isEmpty
+        }
+
+        func saveEntries(from text: String, replacing original: String?) {
+            let additions = DictionaryModel.words(from: text)
+            guard !additions.isEmpty else { return }
+            var updated = dictionaryModel.loadEntries()
+            if let original, let index = updated.firstIndex(of: original) {
+                updated.replaceSubrange(index...index, with: additions)
+            } else {
+                updated.append(contentsOf: additions)
+            }
+            dictionaryModel.saveEntries(updated)
+            entries = dictionaryModel.loadEntries()
+        }
+
         func removeEntry(_ entry: String) {
             entries = dictionaryModel.removeEntry(entry)
         }

--- a/StetMac/Features/MacShell/MacUIMetrics.swift
+++ b/StetMac/Features/MacShell/MacUIMetrics.swift
@@ -75,6 +75,13 @@
             static let detailTitleCollapseDistance: CGFloat = 32
         }
 
+        enum EditorMetrics {
+            static let width: CGFloat = 440
+            static let padding: CGFloat = 24
+            static let spacing: CGFloat = 16
+            static let cornerRadius: CGFloat = 12
+        }
+
         enum DictionaryViewMetrics {
             // Form paddings
             static let formHorizontalPadding: CGFloat = 20

--- a/StetMac/Features/MacShell/Openai/MacOpenAISettingsView.swift
+++ b/StetMac/Features/MacShell/Openai/MacOpenAISettingsView.swift
@@ -7,6 +7,8 @@
         var onManageAccount: (() -> Void)? = nil
         private let controlWidth: CGFloat = 240
         @State private var apiKeySheet: APIKeySheetItem?
+        @State private var isEditingEndpoint = false
+        @State private var credentialError: String?
 
         var body: some View {
             AppForm {
@@ -76,83 +78,22 @@
 
                 if viewModel.isRewriteEnabled, viewModel.unifiedProvider == .custom {
                     Section {
-                        VStack(alignment: .leading, spacing: MacUI.SettingsViewMetrics.cardContentSpacing) {
-                            Text(
-                                NSLocalizedString(
-                                    "Use any OpenAI-compatible API. Stet lists models from GET /models, or you can type a model ID.",
-                                    comment: "")
-                            )
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-
-                            MacSettingsValueRow(title: NSLocalizedString("Base URL", comment: "")) {
-                                TextField(
-                                    "https://api.example.com/v1",
-                                    text: $viewModel.customBaseURL
-                                )
-                                .textFieldStyle(.roundedBorder)
-                                .font(.system(.body, design: .monospaced))
-                                .frame(width: controlWidth, alignment: .trailing)
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Connect a service that supports the OpenAI API format.")
+                                .font(.callout).foregroundStyle(.secondary)
+                            MacSettingsValueRow(title: "Server") {
+                                Text(viewModel.customBaseURL.isEmpty ? "Not configured" : viewModel.customBaseURL)
+                                    .lineLimit(1).truncationMode(.middle)
                             }
-
+                            MacSettingsValueRow(title: "Model") {
+                                Text(viewModel.customModelID.isEmpty ? "Not selected" : viewModel.customModelID)
+                                    .lineLimit(1).truncationMode(.middle)
+                            }
                             apiKeyStatusRow(for: .custom)
-
-                            if !viewModel.discoveredCustomModels.isEmpty {
-                                MacSettingsValueRow(title: NSLocalizedString("Preferred Model", comment: "")) {
-                                    Picker("", selection: $viewModel.customModelID) {
-                                        ForEach(viewModel.discoveredCustomModels, id: \.self) { modelID in
-                                            Text(modelID).tag(modelID)
-                                        }
-                                        if !viewModel.discoveredCustomModels.contains(viewModel.customModelID),
-                                            !viewModel.customModelID.isEmpty
-                                        {
-                                            Text(viewModel.customModelID).tag(viewModel.customModelID)
-                                        }
-                                    }
-                                    .labelsHidden()
-                                    .pickerStyle(.menu)
-                                    .frame(width: controlWidth, alignment: .trailing)
-                                }
-                            }
-
-                            MacSettingsValueRow(title: NSLocalizedString("Model ID", comment: "")) {
-                                TextField("llama3.1", text: $viewModel.customModelID)
-                                    .textFieldStyle(.roundedBorder)
-                                    .font(.system(.body, design: .monospaced))
-                                    .frame(width: controlWidth, alignment: .trailing)
-                            }
-
-                            HStack(spacing: 12) {
-                                Button(NSLocalizedString("Load Models", comment: "")) {
-                                    Task { await viewModel.loadCustomModels() }
-                                }
-                                .disabled(viewModel.customModelProbeState == .loading)
-
-                                apiKeyActions(for: .custom)
-                            }
-
-                            switch viewModel.customModelProbeState {
-                            case .idle, .loading:
-                                EmptyView()
-                            case .loaded(let count):
-                                Text(
-                                    count == 0
-                                        ? NSLocalizedString(
-                                            "No models were returned. Enter a model ID below.", comment: "")
-                                        : String(
-                                            format: NSLocalizedString("%d models found.", comment: ""),
-                                            count)
-                                )
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                            case .failed(let message):
-                                Text(message)
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(.red)
-                            }
+                            Button("Edit Connection…") { isEditingEndpoint = true }
                         }
                     } header: {
-                        Text(NSLocalizedString("Custom Endpoint", comment: ""))
+                        Text("Custom Endpoint")
                     }
                 }
 
@@ -170,20 +111,27 @@
                     }
                 }
             }
-            .sheet(item: $apiKeySheet) { item in
-                MacAPIKeySheet(
-                    placeholder: viewModel.credentialPlaceholder(for: item.provider),
-                    onCancel: { apiKeySheet = nil },
-                    onSave: { key in
-                        viewModel.setAPIKey(key, for: item.provider)
-                        if item.provider == .custom {
-                            viewModel.saveCustomEndpoint()
-                        } else {
-                            viewModel.saveCredential(for: item.provider)
-                        }
-                        apiKeySheet = nil
-                    }
+            .macSettingsSheet(
+                isPresented: Binding(
+                    get: { apiKeySheet != nil }, set: { if !$0 { apiKeySheet = nil } }
                 )
+            ) {
+                if let item = apiKeySheet {
+                    MacAPIKeySheet(provider: item.provider, viewModel: viewModel) { apiKeySheet = nil }
+                }
+            }
+            .macSettingsSheet(isPresented: $isEditingEndpoint) {
+                MacCustomEndpointSheet(viewModel: viewModel) { isEditingEndpoint = false }
+            }
+            .alert(
+                "Could not update API key",
+                isPresented: Binding(
+                    get: { credentialError != nil }, set: { if !$0 { credentialError = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) { credentialError = nil }
+            } message: {
+                Text(credentialError ?? "")
             }
             .onAppear {
                 viewModel.load()
@@ -192,13 +140,18 @@
 
         private func apiKeyStatusRow(for provider: DictationProvider) -> some View {
             MacSettingsValueRow(title: NSLocalizedString("API key", comment: "")) {
-                Text(
-                    viewModel.hasAPIKey(for: provider)
-                        ? NSLocalizedString("Set", comment: "")
-                        : NSLocalizedString("Not set", comment: "")
-                )
-                .foregroundStyle(.secondary)
-                .frame(width: controlWidth, alignment: .trailing)
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(viewModel.credentialPreview(for: provider))
+                        .font(.system(.body, design: .monospaced))
+                    Text(
+                        viewModel.hasAPIKey(for: provider)
+                            ? "Saved securely in Keychain"
+                            : provider == .custom
+                                ? "Optional for servers without authentication" : "Add a key to connect this provider"
+                    )
+                    .font(.caption).foregroundStyle(.secondary)
+                }
+
             }
         }
 
@@ -214,7 +167,9 @@
 
             if viewModel.hasAPIKey(for: provider) {
                 Button(NSLocalizedString("Remove", comment: ""), role: .destructive) {
-                    viewModel.clearCredential(for: provider)
+                    do { try viewModel.storeCredential("", for: provider) } catch {
+                        credentialError = "The key could not be removed from Keychain. Please try again."
+                    }
                 }
                 .foregroundStyle(.red)
             }
@@ -227,44 +182,173 @@
     }
 
     private struct MacAPIKeySheet: View {
-        let placeholder: String
-        let onCancel: () -> Void
-        let onSave: (String) -> Void
-
+        let provider: DictationProvider
+        @ObservedObject var viewModel: MacOpenAISettingsViewModel
+        let onClose: () -> Void
         @State private var draft = ""
-        @FocusState private var isFieldFocused: Bool
+        @State private var isVerifying = false
+        @State private var verified = false
+        @State private var message: String?
+        @FocusState private var focused: Bool
 
-        private var canSave: Bool {
-            !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        var body: some View {
+            MacSettingsEditor(
+                title: "\(provider.displayName) API Key",
+                subtitle: "Your key is stored securely in Keychain. Verify it to check whether the provider accepts it."
+            ) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("API key").font(.subheadline)
+                    SecureField("Paste your API key", text: $draft)
+                        .textFieldStyle(.roundedBorder)
+                        .labelsHidden()
+                        .focused($focused)
+                        .disabled(isVerifying)
+                    if viewModel.hasAPIKey(for: provider) {
+                        Text("Current key: \(viewModel.credentialPreview(for: provider))")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                if let message {
+                    Label(message, systemImage: verified ? "checkmark.circle" : "info.circle")
+                        .font(.callout).foregroundStyle(verified ? Color.primary : Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                HStack {
+                    Button(isVerifying ? "Verifying…" : "Verify Key") {
+                        isVerifying = true
+                        Task {
+                            do {
+                                try await viewModel.verifyCredential(draft, for: provider)
+                                verified = true
+                                message = "Key accepted. Model access may depend on your account."
+                            } catch {
+                                verified = false
+                                message =
+                                    "Could not verify this key. Check the key, your connection, and provider access."
+                            }
+                            isVerifying = false
+                        }
+                    }
+                    .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                    Spacer()
+                    Button("Cancel", action: onClose).keyboardShortcut(.cancelAction)
+                    Button("Save") {
+                        do {
+                            try viewModel.storeCredential(draft, for: provider)
+                            onClose()
+                        } catch {
+                            message = "Could not save to Keychain. Please try again."
+                            verified = false
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                }
+            }
+            .interactiveDismissDisabled(isVerifying)
+            .onChange(of: draft) { _, _ in
+                verified = false; message = nil
+            }
+            .onAppear { focused = true }
+        }
+    }
+
+    private struct MacCustomEndpointSheet: View {
+        @ObservedObject var viewModel: MacOpenAISettingsViewModel
+        let onClose: () -> Void
+        @State private var baseURL = ""
+        @State private var key = ""
+        @State private var modelID = ""
+        @State private var models: [String] = []
+        @State private var isLoading = false
+        @State private var message: String?
+
+        init(viewModel: MacOpenAISettingsViewModel, onClose: @escaping () -> Void) {
+            self.viewModel = viewModel
+            self.onClose = onClose
+            _baseURL = State(initialValue: viewModel.customBaseURL)
+            _key = State(initialValue: viewModel.customAPIKey)
+            _modelID = State(initialValue: viewModel.customModelID)
+            _models = State(initialValue: viewModel.discoveredCustomModels)
         }
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 16) {
-                Text(NSLocalizedString("API key", comment: ""))
-                    .font(.headline)
-
-                SecureField(placeholder, text: $draft)
-                    .textFieldStyle(.roundedBorder)
-                    .font(.system(.body, design: .monospaced))
-                    .focused($isFieldFocused)
-
+            MacSettingsEditor(
+                title: "Custom Connection", subtitle: "Connect your server, then choose a model for Stet to use."
+            ) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Base URL").font(.subheadline)
+                    TextField("https://api.example.com/v1", text: $baseURL).labelsHidden()
+                    Text("Include the API version path if your provider requires one.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("API key (optional)").font(.subheadline)
+                    SecureField("Leave empty for a server without authentication", text: $key).labelsHidden()
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Model").font(.subheadline)
+                    Picker("Model", selection: $modelID) {
+                        Text(models.isEmpty ? "Verify connection to load models" : "Choose a model").tag("")
+                        ForEach(models, id: \.self) { Text($0).tag($0) }
+                        if !modelID.isEmpty && !models.contains(modelID) {
+                            Text("\(modelID) (saved)").tag(modelID)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .disabled(models.isEmpty)
+                }
+                if let message {
+                    Text(message).font(.callout).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 HStack {
+                    Button(isLoading ? "Checking…" : "Verify & Load Models") {
+                        isLoading = true
+                        Task {
+                            do {
+                                models = try await viewModel.discoverModels(baseURL: baseURL, key: key)
+                                if !models.contains(modelID) { modelID = "" }
+                                message =
+                                    models.isEmpty
+                                    ? "Connected, but this server returned no models. Check model availability on your server and try again."
+                                    : "Connected. Choose a model above, then save."
+                            } catch {
+                                models = []
+                                modelID = ""
+                                message =
+                                    "Could not load models. Check your server address, API key, and connection, then try again."
+                            }
+                            isLoading = false
+                        }
+                    }.disabled(baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isLoading)
                     Spacer()
-                    Button(NSLocalizedString("Cancel", comment: ""), action: onCancel)
-                        .keyboardShortcut(.cancelAction)
-                    Button(NSLocalizedString("Save", comment: "")) {
-                        onSave(draft)
+                    Button("Cancel", action: onClose).keyboardShortcut(.cancelAction)
+                    Button("Save") {
+                        do {
+                            try viewModel.storeCustomEndpoint(
+                                baseURL: baseURL, modelID: modelID, key: key, models: models)
+                            onClose()
+                        } catch { message = "Could not save. Check the server URL and Keychain access." }
                     }
                     .keyboardShortcut(.defaultAction)
-                    .disabled(!canSave)
+                    .disabled(
+                        isLoading || baseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
-            .padding(20)
-            .frame(width: 380)
-            .onAppear {
-                draft = ""
-                isFieldFocused = true
+            .textFieldStyle(.roundedBorder)
+            .disabled(isLoading)
+            .interactiveDismissDisabled(isLoading)
+            .onChange(of: baseURL) { _, _ in
+                models = []; modelID = ""; message = nil
             }
+            .onChange(of: key) { _, _ in
+                models = []; modelID = ""; message = nil
+            }
+
         }
     }
 #endif

--- a/StetMac/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
+++ b/StetMac/Features/MacShell/Openai/MacOpenAISettingsViewModel.swift
@@ -60,14 +60,17 @@
 
         private let settingsStore: DictationSettingsStore
         private let modelProbe: any OpenAICompatibleModelProbing
+        private let credentialValidator: any ProviderCredentialValidating
         private var hasLoadedState = false
 
         init(
             settingsStore: DictationSettingsStore = DictationSettingsStore(),
-            modelProbe: any OpenAICompatibleModelProbing = OpenAICompatibleModelProbe()
+            modelProbe: any OpenAICompatibleModelProbing = OpenAICompatibleModelProbe(),
+            credentialValidator: any ProviderCredentialValidating = ProviderCredentialValidationService()
         ) {
             self.settingsStore = settingsStore
             self.modelProbe = modelProbe
+            self.credentialValidator = credentialValidator
         }
 
         var connectionNeedsAttention: Bool {
@@ -107,6 +110,39 @@
             }
 
             hasLoadedState = true
+        }
+
+        func credentialPreview(for provider: DictationProvider) -> String {
+            let key = apiKey(for: provider).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { return "Not configured" }
+            // Never reveal an entire short key.
+            return String(key.prefix(min(6, max(0, key.count - 4)))) + "••••••••"
+        }
+
+        func verifyCredential(_ key: String, for provider: DictationProvider) async throws {
+            try await credentialValidator.validateCredential(
+                apiKey: key.trimmingCharacters(in: .whitespacesAndNewlines), provider: provider)
+        }
+
+        func discoverModels(baseURL: String, key: String) async throws -> [String] {
+            try await modelProbe.listModels(
+                baseURL: OpenAICompatibleBaseURL.normalize(baseURL),
+                apiKey: key.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        func storeCredential(_ key: String, for provider: DictationProvider) throws {
+            let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+            try settingsStore.saveAPIKey(trimmed, for: provider)
+            setAPIKey(trimmed, for: provider)
+        }
+
+        func storeCustomEndpoint(baseURL: String, modelID: String, key: String, models: [String]) throws {
+            let normalized = try OpenAICompatibleBaseURL.normalize(baseURL)
+            try storeCredential(key, for: .custom)
+            customBaseURL = normalized.absoluteString
+            customModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+            discoveredCustomModels = models
+            settingsStore.saveCustomRewriteDiscoveredModels(models)
         }
 
         func saveCustomEndpoint() {
@@ -284,7 +320,7 @@
 
         var visibleCredentialProviders: [DictationProvider] {
             guard isRewriteEnabled else { return [] }
-            guard rewriteProvider.requiresAPIKey else { return [] }
+            guard rewriteProvider.requiresAPIKey, rewriteProvider != .custom else { return [] }
             return [rewriteProvider]
         }
 

--- a/StetMac/Features/MacShell/Setting/MacHistorySettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacHistorySettingsView.swift
@@ -5,6 +5,7 @@
     import UniformTypeIdentifiers
 
     struct MacHistorySettingsView: View {
+        @Environment(\.scenePhase) private var scenePhase
         @State private var entries: [HistoryEntry] = []
         @State private var searchText = ""
         @State private var isExporting = false
@@ -30,6 +31,7 @@
                 content
             }
             .task { reload() }
+            .onChange(of: scenePhase) { _, phase in if phase == .active { reload() } }
         }
 
         // MARK: - Toolbar
@@ -53,6 +55,12 @@
                     .buttonStyle(.plain)
                 }
                 Spacer()
+                Button {
+                    reload()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help("Refresh history").accessibilityLabel("Refresh history")
                 Button(LocalizedStringKey("Export JSON")) {
                     exportJSON()
                 }
@@ -187,7 +195,7 @@
         }
 
         private var displayText: String {
-            entry.llmText ?? entry.rawText
+            entry.finalText ?? entry.llmText ?? entry.rawText
         }
 
         @ViewBuilder

--- a/StetMac/Shared/Models/LegacyDictionaryMigration.swift
+++ b/StetMac/Shared/Models/LegacyDictionaryMigration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 import os
 import StetCore
 import SwiftData
@@ -130,6 +131,11 @@ enum LegacyDictionaryMigration {
         }
 
         do {
+            // Inspect metadata before opening: a different schema can migrate away history tables.
+            let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(
+                ofType: NSSQLiteStoreType, at: storeURL, options: [NSReadOnlyPersistentStoreOption: true])
+            let entities = metadata[NSStoreModelVersionHashesKey] as? [String: Any] ?? [:]
+            guard entities["LegacyDictionaryEntryRecord"] != nil else { return nil }
             let schema = Schema([LegacyDictionaryEntryRecord.self])
             let configuration = ModelConfiguration(schema: schema, url: storeURL)
             let container = try ModelContainer(for: schema, configurations: [configuration])

--- a/StetMacTests/Features/MacShell/Dictionary/DictionaryViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/Dictionary/DictionaryViewModelTests.swift
@@ -25,6 +25,16 @@
             )
         }
 
+        @Test func editingPreservesOtherEntriesAndNormalizesReplacement() {
+            let subject = makeViewModel(defaults: TestSupport.makeUserDefaults())
+            subject.model.saveEntries(["OpenAI", "Groq", "Stet"])
+            subject.viewModel.load()
+            subject.viewModel.saveEntries(from: "  Google  , Stet", replacing: "Groq")
+            #expect(subject.viewModel.entries == ["OpenAI", "Google", "Stet"])
+            subject.viewModel.saveEntries(from: "  ", replacing: "Google")
+            #expect(subject.model.loadEntries() == ["OpenAI", "Google", "Stet"])
+        }
+
         @Test func loadReflectsStoredEntriesAndEnabledState() {
             let defaults = TestSupport.makeUserDefaults()
             let subject = makeViewModel(defaults: defaults)

--- a/StetMacTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/Openai/MacOpenAISettingsViewModelTests.swift
@@ -10,6 +10,44 @@
     @Suite("Mac OpenAI Settings View Model", .serialized)
     struct MacOpenAISettingsViewModelTests {
 
+        @Test func verificationDoesNotSaveDraftOrOverwriteExistingKey() async throws {
+            let secretStore = TestSecretStore()
+            let validator = RecordingCredentialValidator()
+            let viewModel = MacOpenAISettingsViewModel(
+                settingsStore: DictationSettingsStore(
+                    defaults: TestSupport.makeUserDefaults(), secretStore: secretStore), credentialValidator: validator)
+            viewModel.load()
+            try viewModel.storeCredential("existing-key", for: .google)
+            try await viewModel.verifyCredential("  draft-key  ", for: .google)
+            #expect(await validator.lastKey == "draft-key")
+            #expect(viewModel.apiKey(for: .google) == "existing-key")
+            #expect(try secretStore.loadString(forAccount: "google.api_key") == "existing-key")
+        }
+
+        @Test func modelDiscoveryDoesNotSaveEndpointDraft() async throws {
+            let viewModel = MacOpenAISettingsViewModel(
+                settingsStore: DictationSettingsStore(
+                    defaults: TestSupport.makeUserDefaults(), secretStore: TestSecretStore()),
+                modelProbe: StubModelProbe(models: ["test-model"]))
+            viewModel.load()
+            let originalURL = viewModel.customBaseURL
+            let models = try await viewModel.discoverModels(baseURL: "http://localhost:11434/v1", key: "")
+            #expect(models == ["test-model"])
+            #expect(viewModel.customBaseURL == originalURL)
+        }
+
+        @Test func credentialPreviewNeverRevealsWholeKey() throws {
+            let viewModel = MacOpenAISettingsViewModel(
+                settingsStore: DictationSettingsStore(
+                    defaults: TestSupport.makeUserDefaults(), secretStore: TestSecretStore()))
+            viewModel.load()
+            #expect(viewModel.credentialPreview(for: .google) == "Not configured")
+            try viewModel.storeCredential("abcdef123456789", for: .google)
+            #expect(viewModel.credentialPreview(for: .google) == "abcdef••••••••")
+            try viewModel.storeCredential("abc", for: .google)
+            #expect(viewModel.credentialPreview(for: .google) == "••••••••")
+        }
+
         @Test func loadReadsStoredValues() throws {
             let defaults = TestSupport.makeUserDefaults()
             let secretStore = TestSecretStore()
@@ -261,6 +299,13 @@
                 defaults.stringArray(forKey: MacPreferences.customRewriteDiscoveredModels) == [
                     "gpt-4o-mini", "llama3.1",
                 ])
+        }
+    }
+
+    private actor RecordingCredentialValidator: ProviderCredentialValidating {
+        private(set) var lastKey: String?
+        func validateCredential(apiKey: String, provider: DictationProvider) async throws {
+            lastKey = apiKey
         }
     }
 

--- a/StetMacTests/Shared/Models/LegacyDictionaryMigrationTests.swift
+++ b/StetMacTests/Shared/Models/LegacyDictionaryMigrationTests.swift
@@ -18,6 +18,28 @@ struct LegacyDictionaryMigrationTests {
         return directoryURL
     }
 
+    @MainActor
+    @Test func dictionaryMigrationDoesNotReplaceHistorySchema() throws {
+        let directory = try makeAppSupportDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let schema = Schema([HistoryEntry.self])
+        let container = try ModelContainer(
+            for: schema,
+            configurations: [
+                ModelConfiguration(
+                    schema: schema, url: directory.appendingPathComponent("default.store"))
+            ])
+        let context = ModelContext(container)
+        context.insert(HistoryEntry(rawText: "Preserve this transcript"))
+        try context.save()
+        let defaults = TestSupport.makeUserDefaults()
+        LegacyDictionaryMigration.migrateIfNeededForTests(
+            defaults: defaults,
+            dictionaryModel: DictionaryModel(defaults: defaults, entriesKey: UUID().uuidString),
+            appSupportDirectory: directory, bundleIdentifier: "test")
+        #expect(try ModelContext(container).fetchCount(FetchDescriptor<HistoryEntry>()) == 1)
+    }
+
     @Test func migrationMovesLegacyDefaultStoreEntriesIntoSharedDictionary() throws {
         let appSupportDirectory = try makeAppSupportDirectory()
         defer { try? FileManager.default.removeItem(at: appSupportDirectory) }


### PR DESCRIPTION
Settings now use compact, consistent editors for API keys, custom connections, and dictionary entries. The microphone test uses the settings palette, and Theme scales its preview and cards to fit the window.

- Show a masked key prefix and explicit configuration status; verify draft credentials without saving them, and surface Keychain save errors.
- Discover custom endpoint models and select from the returned list before saving. Cancel discards connection edits.
- Add and edit dictionary entries in a floating form, with a typed CLEAR confirmation for clearing the dictionary.
- Give history a dedicated store and copy existing legacy history without changing the source. Prevent legacy dictionary migration from replacing the history schema; report storage failures instead of pretending history is empty.

Validation before rebasing onto current main: macOS CI build, all 512 macOS tests, 11 focused history tests, and repository lint passed. Model discovery and selection were exercised against a local test endpoint. The user manually verified the UI, including the compact Theme page. GitHub CI will validate the rebased PR head.

Existing history is preserved when its table is still present; this change cannot recover rows already removed by earlier conflicting schema migrations.
