### PR TITLE
Cache macOS CI builds and stabilize asynchronous timeout tests

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,3 +9,5 @@
 | `macos-release-candidate.yml` | Manual | Release candidate build (runs at repository root) |
 
 Release jobs run at the repository root, where the scripts and Xcode project now live.
+
+macOS CI cache design, measured baseline, and cold/warm validation results: [CI performance](ci-performance.md).

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -38,7 +38,7 @@ References: [Apple Xcode 26 release notes](https://developer.apple.com/documenta
 | Skip redundant resolution, changed test source, [34460313988 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34460313988/attempts/1) | 154 s | 265 s | 521 tests passed; tests: 996 cache-hit and 15 cache-miss diagnostics |
 | Native + manifests fully warm, same commit, attempt 2 | 137 s | 246 s | 521 tests passed |
 
-The clipboard test raced a 100 ms timeout against polling on a loaded runner. It now checks cancellation on the captured task and awaits completion, without changing production behavior. The revised source passed both full-suite runs.
+The first clipboard-test adjustment captured and awaited the cancelled task and passed two runs, but failed again in the final cold run. Increasing the timeout did not establish reliable readiness; those two passes were insufficient evidence of stability.
 
 Native caching leaves substantial build preparation and Swift test macro work even with zero compiler misses. The next experiment caches incremental products with content-checked source timestamps. Changed files retain fresh mtimes; removed/untracked paths and symlinks cannot be restored by cached metadata. The helper is covered by fixture tests, including same-length edits and nanosecond precision. Each CI job still invokes its original build/test command; test results are never used to skip execution.
 
@@ -51,4 +51,12 @@ Incremental archives are approximately 476 MiB (build) / 501 MiB (tests), taking
 
 The changed-source run [34462415559](https://github.com/DengNaichen/Stet/actions/runs/34462415559) passed all checks: build 126 s, tests 298 s, including cache uploads. The test-source edit was recompiled and all 521 tests ran. This is slower than a no-change rerun; do not advertise warm rerun timing as the cost of every code change.
 
-The final v2 namespace intentionally starts empty for a clean-cache benchmark, then an unchanged warm rerun. These final measurements are pending.
+The v2 namespace intentionally started empty in [34463067580](https://github.com/DengNaichen/Stet/actions/runs/34463067580): build passed in 254 s; tests took 504 s and failed on clipboard restoration and pending-result readiness. Package resolution alone took 78 s in the test job. This failed run is not a successful performance result. It retained package/native caches but deliberately did not save incremental test products.
+
+## Flaky-test investigation
+
+Historical runs failed intermittently on `restoreHandlesEmptyClipboardGracefully`, `hotkeyPreservesNewerClipboardAndCancelsOldTimeout`, and `listeningToProcessingTransitionDefersResumeUntilConfiguredDelayElapses`. Tests assumed that a short real sleep or a brief polling window established asynchronous completion. A busy runner can start or resume the production task later than the test expects.
+
+The fix injects controllable sleep functions into clipboard restore, pending-result dismissal and media resume, keeping their existing real-time defaults in the app. Tests await sleep registration, advance a virtual clock and await the actual task. Cancellation assertions also await completion. All related pending-result timeout tests use the same approach. The hotkey action test starts from an already-copied pending result; separate tests retain coverage of the failed-paste fallback pipeline. Its fixture uses a private pasteboard.
+
+The clock has regression tests for deadline ordering and cancellation before/after registration. A standalone harness passed 1,000 repetitions of each of these three cases. Final repeated app-suite and hosted CI results are pending.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -41,3 +41,10 @@ References: [Apple Xcode 26 release notes](https://developer.apple.com/documenta
 The clipboard test raced a 100 ms timeout against polling on a loaded runner. It now checks cancellation on the captured task and awaits completion, without changing production behavior. The revised source passed both full-suite runs.
 
 Native caching leaves substantial build preparation and Swift test macro work even with zero compiler misses. The next experiment caches incremental products with content-checked source timestamps. Changed files retain fresh mtimes; removed/untracked paths and symlinks cannot be restored by cached metadata. The helper is covered by fixture tests, including same-length edits and nanosecond precision. Each CI job still invokes its original build/test command; test results are never used to skip execution.
+
+| Incremental experiment | Build job | Test job | Result |
+| --- | ---: | ---: | --- |
+| Seed products from native caches, [34461659602 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34461659602/attempts/1) | 163 s | 184 s | 521 tests passed |
+| Same revision with incremental cache, attempt 2 | 109 s | 168 s | 521 tests passed; build has no SwiftCompile/SwiftDriver tasks |
+
+Incremental archives are approximately 476 MiB (build) / 501 MiB (tests), taking 12–14 seconds to restore in this sample. Total job times include that cost. Directory fingerprints are being strengthened to cover nested resource contents, with a real Swift test-source edit used for the final invalidation run.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -59,4 +59,27 @@ Historical runs failed intermittently on `restoreHandlesEmptyClipboardGracefully
 
 The fix injects controllable sleep functions into clipboard restore, pending-result dismissal and media resume, keeping their existing real-time defaults in the app. Tests await sleep registration, advance a virtual clock and await the actual task. Cancellation assertions also await completion. All related pending-result timeout tests use the same approach. The hotkey action test starts from an already-copied pending result; separate tests retain coverage of the failed-paste fallback pipeline. Its fixture uses a private pasteboard.
 
-The clock has regression tests for deadline ordering and cancellation before/after registration. A standalone harness passed 1,000 repetitions of each of these three cases. Final repeated app-suite and hosted CI results are pending.
+The clock has regression tests for deadline ordering and cancellation before/after registration. A standalone harness passed 1,000 repetitions of each of these three cases. Local validation of the final timing fixes (`c9c7526`):
+
+- Four affected suites: `xcodebuild test` with `-test-iterations 20 -run-tests-until-failure`; all 1,220 executions passed (61 tests per iteration).
+- Full suite: `xcodebuild test-without-building` with `-only-testing:StetTests -test-iterations 3 -run-tests-until-failure`; all 1,572 executions passed (524 per iteration).
+- No retry-on-failure option is enabled. The clock helper's three tests account for the increase from 521 to 524 tests.
+- The first deterministic run caught two incorrect assumptions in the rewritten tests: failed copy preserves the pending result when the deadline expires; successful copy cancels through an asynchronous state subscription. Both now wait for the actual behavior.
+- Local Xcode's Clang dependency scanner crashed twice before tests started during intermediate validation. Removing only the temporary Build/ModuleCache output resolved it; the subsequent incremental build and repetitions passed. No workflow fallback or automatic retry was added to conceal this tooling failure.
+
+## Final hosted validation
+
+The timing fixes at `c9c7526` passed [34466147590 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34466147590/attempts/1): build 116 s, tests 339 s, quality 20 s. All 524 tests executed and passed in 35.425 s. The test job had package/compiler caches but no incremental products; its build/test step took 266 s and saving the new incremental products took 17 s. The build job restored previous products and recompiled changed application inputs.
+
+The exact same commit passed again in [attempt 2](https://github.com/DengNaichen/Stet/actions/runs/34466147590/attempts/2), with all cache layers present:
+
+| Successful job measurement | PR #56 baseline | Final warm run | Reduction |
+| --- | ---: | ---: | ---: |
+| macOS Build | 349 s | 112 s | 68% |
+| macOS Tests | 355 s | 215 s | 39% |
+| Swift Quality | 18 s | 15 s | 17% |
+| Sum of successful job durations | 722 s | 342 s | 53% |
+
+These are job durations, not queue time, billed minutes or sequential workflow duration; build and tests run in parallel. The baseline combines retained successful jobs with its successful test rerun. Both final attempts executed the full 524-test suite. The warm build/test command steps took 61 s / 138 s; package restores took 14 s / 22 s and incremental restores 10 s / 17 s. Those transfer costs are included above.
+
+The earlier warm sample was faster (109 s / 168 s), demonstrating runner/network variation. Use the final measurements above rather than the best sample as the comparison. New toolchains, evicted caches and changed inputs can still require compilation; warm no-change timings are not a promise for every PR.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -21,10 +21,23 @@ Attempt 1 tests failed after 398 s on timing-sensitive tests. An unchanged rerun
 
 Keep the same checks, test suite, coverage, runner and Xcode selection. Separate dependency resolution so GitHub records its elapsed time. Cache SwiftPM sources and binary artifacts using manifests, lockfiles and exact toolchain/OS identity. Save packages before compilation so a test failure does not discard the download work.
 
-Enable Xcode's input-addressed Swift/Clang compilation cache, isolated by toolchain and build/test mode, with a per-commit key and compatible fallback. Cache compiler results even on test failure. Build products, test results, signing material and app data are not cached. Local Makefile behavior is unchanged unless `CI_XCODEBUILD_FLAGS` is supplied.
+Enable Xcode's input-addressed Swift/Clang compilation cache, isolated by toolchain and build/test mode, with a per-commit key and compatible fallback. Cache compiler results even on test failure. The first experiment cached only compiler results. The incremental follow-up also caches unsigned Build products and ModuleCache, validating tracked input SHA-256 hashes before restoring nanosecond mtimes. Test result logs, signing material and app data are not cached. Local Makefile behavior is unchanged unless `CI_XCODEBUILD_FLAGS` is supplied.
 
 The package cache stays in DerivedData/SourcePackages because `normalize-binary-frameworks.sh` locates the Sherpa framework there. Do not independently move that directory without updating its consumer.
 
 Validation: run the modified workflow cold, then rerun the same commit warm. Compare job elapsed times including cache transfer overhead, dependency resolution, compilation cache hits, and the number/result of executed tests. Follow with a changed-source run to check invalidation. No estimated speedup is a measured result.
 
 References: [Apple Xcode 26 release notes](https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-26-release-notes), [GitHub cache action](https://github.com/actions/cache), [GitHub cache scope](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
+
+## Intermediate measurements
+
+| Experiment | Build job | Test job | Result |
+| --- | ---: | ---: | --- |
+| Native cache cold, [34458876587 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34458876587/attempts/1) | 280 s | 524 s | 521 tests passed |
+| Native cache warm, same commit, attempt 2 | 176 s | 244 s | Existing clipboard timing test failed |
+| Skip redundant resolution, changed test source, [34460313988 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34460313988/attempts/1) | 154 s | 265 s | 521 tests passed; tests: 996 cache-hit and 15 cache-miss diagnostics |
+| Native + manifests fully warm, same commit, attempt 2 | 137 s | 246 s | 521 tests passed |
+
+The clipboard test raced a 100 ms timeout against polling on a loaded runner. It now checks cancellation on the captured task and awaits completion, without changing production behavior. The revised source passed both full-suite runs.
+
+Native caching leaves substantial build preparation and Swift test macro work even with zero compiler misses. The next experiment caches incremental products with content-checked source timestamps. Changed files retain fresh mtimes; removed/untracked paths and symlinks cannot be restored by cached metadata. The helper is covered by fixture tests, including same-length edits and nanosecond precision. Each CI job still invokes its original build/test command; test results are never used to skip execution.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -47,4 +47,8 @@ Native caching leaves substantial build preparation and Swift test macro work ev
 | Seed products from native caches, [34461659602 attempt 1](https://github.com/DengNaichen/Stet/actions/runs/34461659602/attempts/1) | 163 s | 184 s | 521 tests passed |
 | Same revision with incremental cache, attempt 2 | 109 s | 168 s | 521 tests passed; build has no SwiftCompile/SwiftDriver tasks |
 
-Incremental archives are approximately 476 MiB (build) / 501 MiB (tests), taking 12–14 seconds to restore in this sample. Total job times include that cost. Directory fingerprints are being strengthened to cover nested resource contents, with a real Swift test-source edit used for the final invalidation run.
+Incremental archives are approximately 476 MiB (build) / 501 MiB (tests), taking 12–14 seconds to restore in this sample. Total job times include that cost. Directory fingerprints cover nested resource contents, with fixture coverage for same-name edits and malformed cache metadata.
+
+The changed-source run [34462415559](https://github.com/DengNaichen/Stet/actions/runs/34462415559) passed all checks: build 126 s, tests 298 s, including cache uploads. The test-source edit was recompiled and all 521 tests ran. This is slower than a no-change rerun; do not advertise warm rerun timing as the cost of every code change.
+
+The final v2 namespace intentionally starts empty for a clean-cache benchmark, then an unchanged warm rerun. These final measurements are pending.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -1,0 +1,30 @@
+# macOS CI performance
+
+## Baseline — September 10, 2026
+
+Baseline: [PR #56 run 34456673443](https://github.com/DengNaichen/Stet/actions/runs/34456673443), commit `b5b84c05fdfae7e35e358023c5f058a02adfddab`, macos-26 ARM64, Xcode 26.6 (17F113). Job elapsed times include cache/setup/cleanup when present; phase measurements use timestamped logs.
+
+| Measurement | Baseline |
+| --- | ---: |
+| Swift Quality (attempt 1) | 18 s |
+| macOS Build (attempt 1) | 349 s |
+| Build: dependency resolution | 88 s |
+| macOS Tests (attempt 2) | 355 s |
+| Tests: dependency resolution | 66 s |
+| Tests: resolved packages to test start | 232 s |
+| Actual Swift Testing execution (521 tests) | 33.443 s |
+| Metal component installation | 4–5 s |
+
+Attempt 1 tests failed after 398 s on timing-sensitive tests. An unchanged rerun passed. Successful build/quality jobs were retained, not rerun; do not interpret the rerun's workflow duration as a fresh full pipeline measurement.
+
+## Experiment
+
+Keep the same checks, test suite, coverage, runner and Xcode selection. Separate dependency resolution so GitHub records its elapsed time. Cache SwiftPM sources and binary artifacts using manifests, lockfiles and exact toolchain/OS identity. Save packages before compilation so a test failure does not discard the download work.
+
+Enable Xcode's input-addressed Swift/Clang compilation cache, isolated by toolchain and build/test mode, with a per-commit key and compatible fallback. Cache compiler results even on test failure. Build products, test results, signing material and app data are not cached. Local Makefile behavior is unchanged unless `CI_XCODEBUILD_FLAGS` is supplied.
+
+The package cache stays in DerivedData/SourcePackages because `normalize-binary-frameworks.sh` locates the Sherpa framework there. Do not independently move that directory without updating its consumer.
+
+Validation: run the modified workflow cold, then rerun the same commit warm. Compare job elapsed times including cache transfer overhead, dependency resolution, compilation cache hits, and the number/result of executed tests. Follow with a changed-source run to check invalidation. No estimated speedup is a measured result.
+
+References: [Apple Xcode 26 release notes](https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-26-release-notes), [GitHub cache action](https://github.com/actions/cache), [GitHub cache scope](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -71,15 +71,15 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build/ci/SourcePackages
-          key: spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
+          key: spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
           restore-keys: |
-            spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-
+            spm-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-
 
       - name: Cache Swift package manifests
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/org.swift.swiftpm/manifests
-          key: spm-manifests-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
+          key: spm-manifests-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
 
       # On a hit, the build command validates/resolves the restored packages.
       # A separate resolve is only needed to save downloads before a cold build.
@@ -103,9 +103,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build/ci/CompilationCache.noindex
-          key: compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          key: compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
-            compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
+            compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
 
       - name: Restore incremental build
         id: incremental
@@ -115,9 +115,9 @@ jobs:
             .build/ci/Build
             .build/ci/ModuleCache.noindex
             .build/ci/source-mtimes.json
-          key: incremental-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          key: incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
-            incremental-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
+            incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
 
       - name: Validate incremental build inputs
         run: python3 scripts/ci-source-mtimes.py restore .build/ci/source-mtimes.json

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -25,9 +25,25 @@ jobs:
       - name: Run lint checks
         run: make lint
 
-  macos-build:
-    name: macOS Build
+  macos:
+    name: ${{ matrix.name }}
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS Build
+            target: ci-build
+          - name: macOS Tests
+            target: test
+    env:
+      CI_XCODEBUILD_FLAGS: >-
+        -derivedDataPath .build/ci
+        -onlyUsePackageVersionsFromResolvedFile
+        -skipPackageUpdates
+        -showBuildTimingSummary
+        COMPILATION_CACHE_ENABLE_CACHING=YES
+        COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS=YES
 
     steps:
       - uses: actions/checkout@v5
@@ -36,25 +52,53 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Install Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
+      - name: Identify toolchain
+        id: toolchain
+        run: |
+          fingerprint=$( { xcodebuild -version; xcrun --sdk macosx --show-sdk-build-version; sw_vers -buildVersion; } | shasum -a 256 | cut -d ' ' -f 1)
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
 
-      - name: Build macOS app
-        run: make ci-build
-
-  macos-tests:
-    name: macOS Tests
-    runs-on: macos-26
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: maxim-lobanov/setup-xcode@v1
+      - name: Restore Swift packages
+        id: packages
+        uses: actions/cache/restore@v5
         with:
-          xcode-version: latest-stable
+          path: .build/ci/SourcePackages
+          key: spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('**/Package.resolved', '**/Package.swift') }}
+
+      - name: Resolve Swift packages
+        run: >-
+          xcodebuild -resolvePackageDependencies
+          -project Stet.xcodeproj -scheme Stet
+          -derivedDataPath .build/ci
+          -onlyUsePackageVersionsFromResolvedFile -skipPackageUpdates
+
+      - name: Save Swift packages
+        if: steps.packages.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .build/ci/SourcePackages
+          key: ${{ steps.packages.outputs.cache-primary-key }}
+
+      - name: Restore compilation cache
+        id: compilation
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
+          key: compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
 
       - name: Install Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
 
-      - name: Run macOS tests
-        run: make test
+      - name: Build or test macOS app
+        run: make ${{ matrix.target }}
+
+      # Compiler results are reusable even if a later test fails. Never cache
+      # test results or skip test execution on a cache hit.
+      - name: Save compilation cache
+        if: ${{ !cancelled() && steps.compilation.outcome == 'success' && steps.compilation.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
+          key: ${{ steps.compilation.outputs.cache-primary-key }}

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -7,6 +7,11 @@ on:
       - main
       - "migration/**"
 
+# New commits supersede older PR runs; main and migration pushes still finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   quality:
     name: Swift Quality
@@ -63,9 +68,18 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build/ci/SourcePackages
-          key: spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('**/Package.resolved', '**/Package.swift') }}
+          key: spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
 
+      - name: Cache Swift package manifests
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm/manifests
+          key: spm-manifests-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
+
+      # On a hit, the build command validates/resolves the restored packages.
+      # A separate resolve is only needed to save downloads before a cold build.
       - name: Resolve Swift packages
+        if: steps.packages.outputs.cache-hit != 'true'
         run: >-
           xcodebuild -resolvePackageDependencies
           -project Stet.xcodeproj -scheme Stet

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install SwiftLint
         run: brew install swiftlint
 
+      - name: Test CI cache validation
+        run: python3 -m unittest discover -s scripts/tests -p 'test_ci_source_mtimes.py'
+
       - name: Run lint checks
         run: make lint
 
@@ -69,6 +72,8 @@ jobs:
         with:
           path: .build/ci/SourcePackages
           key: spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/Package.resolved', 'Stet.xcodeproj/**/Package.resolved') }}
+          restore-keys: |
+            spm-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-
 
       - name: Cache Swift package manifests
         uses: actions/cache@v5
@@ -102,6 +107,21 @@ jobs:
           restore-keys: |
             compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
 
+      - name: Restore incremental build
+        id: incremental
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            .build/ci/Build
+            .build/ci/ModuleCache.noindex
+            .build/ci/source-mtimes.json
+          key: incremental-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            incremental-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
+
+      - name: Validate incremental build inputs
+        run: python3 scripts/ci-source-mtimes.py restore .build/ci/source-mtimes.json
+
       - name: Install Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
 
@@ -116,3 +136,17 @@ jobs:
         with:
           path: .build/ci/CompilationCache.noindex
           key: ${{ steps.compilation.outputs.cache-primary-key }}
+
+      - name: Record incremental build inputs
+        if: success() && steps.incremental.outputs.cache-hit != 'true'
+        run: python3 scripts/ci-source-mtimes.py save .build/ci/source-mtimes.json
+
+      - name: Save incremental build
+        if: success() && steps.incremental.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            .build/ci/Build
+            .build/ci/ModuleCache.noindex
+            .build/ci/source-mtimes.json
+          key: ${{ steps.incremental.outputs.cache-primary-key }}

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -83,7 +83,7 @@ jobs:
         id: compilation
         uses: actions/cache/restore@v5
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
+          path: .build/ci/CompilationCache.noindex
           key: compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             compilation-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
@@ -100,5 +100,5 @@ jobs:
         if: ${{ !cancelled() && steps.compilation.outcome == 'success' && steps.compilation.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
+          path: .build/ci/CompilationCache.noindex
           key: ${{ steps.compilation.outputs.cache-primary-key }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 IOS_DEVELOPER_DIR ?= /Applications/Xcode-beta.app/Contents/Developer
+CI_XCODEBUILD_FLAGS ?=
+
 IOS_XCODEBUILD := $(IOS_DEVELOPER_DIR)/usr/bin/xcodebuild
 
 MACOS_SWIFT_DIRS := StetMac StetMacTests StetMacUITests StetVisuals
@@ -41,10 +43,10 @@ build:
 	xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' build
 
 ci-build:
-	xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build
+	xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' $(CI_XCODEBUILD_FLAGS) build
 
 test:
-	xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:StetTests test
+	xcodebuild -project Stet.xcodeproj -scheme Stet -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:StetTests $(CI_XCODEBUILD_FLAGS) test
 
 ios-bootstrap:
 	StetMobile/scripts/bootstrap-sherpa-runtime.sh

--- a/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
+++ b/StetMac/App/Workflows/MacAppSessionController+Dictation.swift
@@ -197,7 +197,7 @@
             clipboardPendingDismissTask?.cancel()
             clipboardPendingDismissTask = Task { @MainActor [weak self] in
                 guard let self else { return }
-                try? await Task.sleep(for: clipboardPendingAutoDismissDelay)
+                try? await clipboardPendingAutoDismissSleep(clipboardPendingAutoDismissDelay)
                 guard !Task.isCancelled else { return }
                 guard case .clipboardPending(let text) = dictationState else { return }
                 clipboardPendingDismissTask = nil

--- a/StetMac/App/Workflows/MacAppSessionController.swift
+++ b/StetMac/App/Workflows/MacAppSessionController.swift
@@ -36,6 +36,9 @@
         var copiedPendingResult: String?
         var clipboardPendingDismissTask: Task<Void, Never>?
         var clipboardPendingAutoDismissDelay: Duration = .seconds(4)
+        var clipboardPendingAutoDismissSleep: @Sendable (Duration) async throws -> Void = {
+            try await Task.sleep(for: $0)
+        }
         let hotkeyInteraction = MacDictationHotkeyInteraction()
         var previousDictationState: DictationState = .idle
         weak var presentationModel: (any MacAppPresentationModeling)?

--- a/StetMac/App/Workflows/MacDictationWorkflowController.swift
+++ b/StetMac/App/Workflows/MacDictationWorkflowController.swift
@@ -22,11 +22,12 @@
         private let interactionSoundPlayer: any InteractionSoundPlaying
         private let completionNotifier: (any MacDictationCompletionNotifying)?
         private let mediaResumeDelay: Duration
+        private let mediaResumeSleep: @Sendable (Duration) async throws -> Void
         private let startPromptActivationDeadline: Duration
 
         private weak var lastTargetApplication: NSRunningApplication?
         private(set) var activeRecordingSource: PrimaryActionSource?
-        private var mediaResumeTask: Task<Void, Never>?
+        private(set) var mediaResumeTask: Task<Void, Never>?
         private var startActivationTask: Task<Void, Never>?
         private var sessionStartDate: Date?
         private var pendingSessionDuration: TimeInterval?
@@ -42,7 +43,8 @@
             completionNotifier: (any MacDictationCompletionNotifying)? = nil,
             statsModel: DictationStatsModel? = nil,
             mediaResumeDelay: Duration = .seconds(1),
-            startPromptActivationDeadline: Duration = .milliseconds(350)
+            startPromptActivationDeadline: Duration = .milliseconds(350),
+            mediaResumeSleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
         ) {
             self.dictationViewModel = dictationViewModel
             self.captureCoordinator = captureCoordinator
@@ -53,6 +55,7 @@
             self.completionNotifier = completionNotifier
             self.statsModel = statsModel
             self.mediaResumeDelay = mediaResumeDelay
+            self.mediaResumeSleep = mediaResumeSleep
             self.startPromptActivationDeadline = startPromptActivationDeadline
         }
 
@@ -329,7 +332,7 @@
 
                 // Let macOS release capture-side routing before restoring external audio.
                 if delay > .zero {
-                    try? await Task.sleep(for: delay)
+                    try? await mediaResumeSleep(delay)
                 }
 
                 guard !Task.isCancelled,

--- a/StetMac/Core/Clipboard/PasteboardRestoreCoordinator.swift
+++ b/StetMac/Core/Clipboard/PasteboardRestoreCoordinator.swift
@@ -15,11 +15,16 @@
     @MainActor
     final class PasteboardRestoreCoordinator {
         private let restoreDelay: Duration
+        private let sleep: @Sendable (Duration) async throws -> Void
         private var pendingRestoreTask: Task<Void, Never>?
         private var pendingOriginalSnapshot: PasteboardSnapshot?
 
-        init(restoreDelay: Duration = .milliseconds(800)) {
+        init(
+            restoreDelay: Duration = .milliseconds(800),
+            sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+        ) {
             self.restoreDelay = restoreDelay
+            self.sleep = sleep
         }
 
         deinit {
@@ -42,21 +47,23 @@
             )
         }
 
-        func scheduleRestoreIfNeeded(on pasteboard: NSPasteboard) {
+        @discardableResult
+        func scheduleRestoreIfNeeded(on pasteboard: NSPasteboard) -> Task<Void, Never>? {
             scheduleRestoreIfNeeded(on: pasteboard, delayOverride: nil)
         }
 
+        @discardableResult
         func scheduleRestoreIfNeeded(
             on pasteboard: NSPasteboard,
             delayOverride: Duration?
-        ) {
+        ) -> Task<Void, Never>? {
             guard let snapshot = pendingOriginalSnapshot else {
                 emitPasteboardTrace(
                     stage: "schedule_restore_skipped",
                     pasteboard: pasteboard,
                     details: "reason=no_pending_original_snapshot"
                 )
-                return
+                return nil
             }
 
             let effectiveDelay = delayOverride ?? restoreDelay
@@ -68,10 +75,10 @@
                     "delayMs=\(durationMilliseconds(effectiveDelay)) originalItemCount=\(snapshot.itemCount) temporaryItemCount=\(temporarySnapshot.itemCount)"
             )
             pendingRestoreTask?.cancel()
-            pendingRestoreTask = Task { @MainActor [weak self] in
+            let restoreTask = Task { @MainActor [weak self] in
                 guard let self else { return }
 
-                try? await Task.sleep(for: effectiveDelay)
+                try? await sleep(effectiveDelay)
                 guard !Task.isCancelled else { return }
 
                 defer {
@@ -99,6 +106,8 @@
                     details: "restoredItemCount=\(snapshot.itemCount)"
                 )
             }
+            pendingRestoreTask = restoreTask
+            return restoreTask
         }
 
         func restoreImmediatelyIfNeeded(on pasteboard: NSPasteboard) {

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -354,20 +354,25 @@
             subject.session.cancelActiveCapture()
         }
 
-        @Test func hotkeyPreservesNewerClipboardAndCancelsOldTimeout() async {
+        @Test func hotkeyPreservesNewerClipboardAndCancelsOldTimeout() async throws {
             let subject = makeSubject()
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
-            subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
+            // Keep the timeout pending until the hotkey cancels it. A 100 ms
+            // deadline can expire before a busy CI runner observes the task.
+            subject.session.clipboardPendingAutoDismissDelay = .seconds(3_600)
             subject.textInjectionService.pasteOutcome = .verificationFailed
             subject.workflow.dictationViewModel.send(.transcriptionSucceeded("transcript A"))
             #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
+            defer { pendingDismiss.cancel() }
             subject.clipboardService.copy("new clipboard B", transient: false)
             let writesBeforeRestart = subject.clipboardService.copiedTexts
 
             subject.session.handleHotkeyPressed()
             #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .listening })
-            try? await Task.sleep(for: .milliseconds(200))
+            try #require(pendingDismiss.isCancelled)
+            await pendingDismiss.value
 
             #expect(subject.clipboardService.copiedTexts == writesBeforeRestart)
             #expect(subject.workflow.dictationViewModel.state == .listening)

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -373,6 +373,7 @@
             #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .listening })
             try #require(pendingDismiss.isCancelled)
             await pendingDismiss.value
+            #expect(subject.session.clipboardPendingDismissTask == nil)
 
             #expect(subject.clipboardService.copiedTexts == writesBeforeRestart)
             #expect(subject.workflow.dictationViewModel.state == .listening)

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -424,9 +424,8 @@
             subject.clipboardService.shouldFailCopy = true
 
             subject.session.performPrimaryAction()
-            try #require(pendingDismiss.isCancelled)
-            await pendingDismiss.value
             await clock.advance(by: delay)
+            await pendingDismiss.value
             #expect(subject.session.clipboardPendingDismissTask == nil)
 
             #expect(subject.workflow.dictationViewModel.state == .clipboardPending("transcript A"))
@@ -472,8 +471,9 @@
             let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
 
             subject.session.performPrimaryAction()
-            try #require(pendingDismiss.isCancelled)
+            // The reset is observed asynchronously by the state subscription.
             await pendingDismiss.value
+            #expect(pendingDismiss.isCancelled)
             await clock.advance(by: delay)
 
             #expect(subject.workflow.dictationViewModel.state == .idle)

--- a/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
+++ b/StetMacTests/App/Workflows/MacAppSessionControllerActionTests.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+    import AppKit
     import Combine
     import Foundation
     import StetVisuals
@@ -157,7 +158,7 @@
     @MainActor
     @Suite("Mac App Session Controller Action Behavior", .serialized)
     struct MacAppSessionControllerActionTests {
-        private func makeSubject() -> (
+        private func makeSubject(clock: TestClock? = nil) -> (
             session: MacAppSessionController,
             workflow: MacDictationWorkflowController,
             shell: FakeShellPresenter,
@@ -181,6 +182,7 @@
             let captureCoordinator = MacDictationCaptureCoordinator(
                 clipboardService: clipboardService,
                 textInjectionService: textInjectionService,
+                pasteboard: NSPasteboard(name: NSPasteboard.Name("StetTests.\(UUID().uuidString)")),
                 frontmostBundleIdentifierProvider: { nil }
             )
             let workflow = MacDictationWorkflowController(
@@ -214,6 +216,10 @@
                 defaults: defaults,
                 hotkeyRegistrar: hotkeyRegistrar
             )
+
+            if let clock {
+                session.clipboardPendingAutoDismissSleep = { try await clock.sleep(for: $0) }
+            }
 
             return (
                 session: session,
@@ -327,18 +333,25 @@
             #expect(subject.shell.isPanelVisible == false)
         }
 
-        @Test func autoDismissPreservesNewerClipboardContents() async {
-            let subject = makeSubject()
+        @Test func autoDismissPreservesNewerClipboardContents() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
             subject.textInjectionService.pasteOutcome = .verificationFailed
             subject.workflow.dictationViewModel.send(.transcriptionSucceeded("transcript A"))
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
             subject.clipboardService.copy("new clipboard B", transient: false)
             let writesBeforeDismiss = subject.clipboardService.copiedTexts
 
-            #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .idle })
+            await clock.advance(by: delay - .milliseconds(1))
+            #expect(subject.workflow.dictationViewModel.state == .clipboardPending("transcript A"))
+            await clock.advance(by: .milliseconds(1))
+            await pendingDismiss.value
+            #expect(subject.workflow.dictationViewModel.state == .idle)
             #expect(subject.clipboardService.copiedTexts == writesBeforeDismiss)
         }
 
@@ -355,15 +368,17 @@
         }
 
         @Test func hotkeyPreservesNewerClipboardAndCancelsOldTimeout() async throws {
-            let subject = makeSubject()
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
-            // Keep the timeout pending until the hotkey cancels it. A 100 ms
-            // deadline can expire before a busy CI runner observes the task.
-            subject.session.clipboardPendingAutoDismissDelay = .seconds(3_600)
-            subject.textInjectionService.pasteOutcome = .verificationFailed
-            subject.workflow.dictationViewModel.send(.transcriptionSucceeded("transcript A"))
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
+            // This action starts from an already-delivered pending result.
+            // Output failure mapping is covered by verificationFailureFallsBackToClipboardPendingSurface.
+            subject.clipboardService.copy("transcript A", transient: false)
+            subject.session.copiedPendingResult = "transcript A"
+            subject.workflow.dictationViewModel.send(.clipboardPending("transcript A"))
+            #expect(await clock.nextSleep() == .milliseconds(100))
             let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
             defer { pendingDismiss.cancel() }
             subject.clipboardService.copy("new clipboard B", transient: false)
@@ -379,6 +394,7 @@
             #expect(subject.workflow.dictationViewModel.state == .listening)
             #expect(subject.shell.isPanelVisible)
             #expect(await subject.speechService.counts().start == 1)
+            #expect(subject.textInjectionService.pasteTargets.isEmpty)
             subject.session.cancelActiveCapture()
         }
 
@@ -394,26 +410,33 @@
             subject.session.cancelActiveCapture()
         }
 
-        @Test func explicitCopyFailureAfterFallbackPreventsAutoDismiss() async {
-            let subject = makeSubject()
+        @Test func explicitCopyFailureAfterFallbackPreventsAutoDismiss() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
             subject.textInjectionService.pasteOutcome = .verificationFailed
             subject.workflow.dictationViewModel.send(.transcriptionSucceeded("transcript A"))
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
             subject.clipboardService.shouldFailCopy = true
 
             subject.session.performPrimaryAction()
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask == nil })
+            try #require(pendingDismiss.isCancelled)
+            await pendingDismiss.value
+            await clock.advance(by: delay)
+            #expect(subject.session.clipboardPendingDismissTask == nil)
 
             #expect(subject.workflow.dictationViewModel.state == .clipboardPending("transcript A"))
             #expect(subject.shell.isPanelVisible)
             #expect(subject.clipboardService.copiedTexts == ["transcript A", "transcript A", "transcript A"])
         }
 
-        @Test func clipboardPendingPanelAutoDismissesAfterDelay() async {
-            let subject = makeSubject()
+        @Test func clipboardPendingPanelAutoDismissesAfterDelay() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(300)
@@ -421,43 +444,60 @@
             subject.textInjectionService.pasteOutcome = .verificationFailed
             subject.workflow.dictationViewModel.send(.transcriptionSucceeded("needs copy"))
 
-            #expect(await TestSupport.eventually { subject.shell.isPanelVisible })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
+            #expect(subject.shell.isPanelVisible)
             #expect(subject.workflow.dictationViewModel.state == .clipboardPending("needs copy"))
 
-            #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .idle })
+            await clock.advance(by: delay - .milliseconds(1))
+            #expect(subject.workflow.dictationViewModel.state == .clipboardPending("needs copy"))
+            await clock.advance(by: .milliseconds(1))
+            await pendingDismiss.value
+            #expect(subject.workflow.dictationViewModel.state == .idle)
             #expect(subject.shell.hidePanelCallCount == 1)
             #expect(subject.shell.isPanelVisible == false)
             #expect(subject.clipboardService.copiedTexts == ["needs copy", "needs copy"])
         }
 
-        @Test func confirmingPendingCopyCancelsAutoDismiss() async {
-            let subject = makeSubject()
+        @Test func confirmingPendingCopyCancelsAutoDismiss() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
             subject.workflow.dictationViewModel.send(.clipboardPending("needs copy"))
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
 
             subject.session.performPrimaryAction()
-            try? await Task.sleep(for: .milliseconds(200))
+            try #require(pendingDismiss.isCancelled)
+            await pendingDismiss.value
+            await clock.advance(by: delay)
 
             #expect(subject.workflow.dictationViewModel.state == .idle)
             #expect(subject.clipboardService.copiedTexts == ["needs copy"])
             #expect(subject.shell.hidePanelCallCount == 1)
         }
 
-        @Test func startingCaptureCancelsPendingAutoDismiss() async {
-            let subject = makeSubject()
+        @Test func startingCaptureCancelsPendingAutoDismiss() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(100)
             subject.workflow.dictationViewModel.send(.clipboardPending("previous"))
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
 
             subject.workflow.dictationViewModel.send(.resetTapped)
             subject.session.startDictationCapture(from: .hotkey)
             #expect(await TestSupport.eventually { subject.workflow.dictationViewModel.state == .listening })
-            try? await Task.sleep(for: .milliseconds(200))
+            try #require(pendingDismiss.isCancelled)
+            await pendingDismiss.value
+            await clock.advance(by: delay)
 
             #expect(subject.workflow.dictationViewModel.state == .listening)
             #expect(subject.clipboardService.copiedTexts.isEmpty)
@@ -465,16 +505,21 @@
             subject.session.cancelActiveCapture()
         }
 
-        @Test func uncopiedPendingResultDoesNotAutoDismissOrCopy() async {
-            let subject = makeSubject()
+        @Test func uncopiedPendingResultDoesNotAutoDismissOrCopy() async throws {
+            let clock = TestClock()
+            let subject = makeSubject(clock: clock)
             let presentationModel = FakePresentationModel()
             subject.session.activate(presentationModel: presentationModel, showInDock: false)
             subject.session.clipboardPendingAutoDismissDelay = .milliseconds(50)
             subject.clipboardService.shouldFailCopy = true
             subject.workflow.dictationViewModel.send(.clipboardPending("needs copy"))
 
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask != nil })
-            #expect(await TestSupport.eventually { subject.session.clipboardPendingDismissTask == nil })
+            let delay = await clock.nextSleep()
+            #expect(delay == subject.session.clipboardPendingAutoDismissDelay)
+            let pendingDismiss = try #require(subject.session.clipboardPendingDismissTask)
+            await clock.advance(by: delay)
+            await pendingDismiss.value
+            #expect(subject.session.clipboardPendingDismissTask == nil)
             #expect(subject.clipboardService.copiedTexts.isEmpty)
             #expect(subject.workflow.dictationViewModel.state == .clipboardPending("needs copy"))
             #expect(subject.shell.isPanelVisible)

--- a/StetMacTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -98,7 +98,8 @@
             interactionSoundPlayer: TestInteractionSoundPlayer? = nil,
             completionNotifier: TestCompletionNotifier? = nil,
             frontmostBundleIdentifier: String? = nil,
-            mediaResumeDelay: Duration = .zero
+            mediaResumeDelay: Duration = .zero,
+            mediaResumeSleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
         ) -> (
             controller: MacDictationWorkflowController,
             viewModel: DictationViewModel,
@@ -143,7 +144,8 @@
                 interactionSoundPlayer: interactionSoundPlayer,
                 completionNotifier: completionNotifier,
                 mediaResumeDelay: mediaResumeDelay,
-                startPromptActivationDeadline: promptActivationDeadline
+                startPromptActivationDeadline: promptActivationDeadline,
+                mediaResumeSleep: mediaResumeSleep
             )
 
             return (
@@ -413,7 +415,8 @@
             #expect(subject.mediaPlaybackController.resumeCallCount == 1)
         }
 
-        @Test func listeningToProcessingTransitionDefersResumeUntilConfiguredDelayElapses() async {
+        @Test func listeningToProcessingTransitionDefersResumeUntilConfiguredDelayElapses() async throws {
+            let clock = TestClock()
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
             let speechService = ControllableSpeechService()
@@ -421,7 +424,8 @@
             let subject = makeController(
                 defaults: defaults,
                 speechService: speechService,
-                mediaResumeDelay: .milliseconds(120)
+                mediaResumeDelay: .milliseconds(120),
+                mediaResumeSleep: { try await clock.sleep(for: $0) }
             )
 
             subject.controller.startDictationCapture(source: .interface) {}
@@ -433,13 +437,20 @@
 
             #expect(subject.mediaPlaybackController.pauseCallCount == 1)
             #expect(subject.mediaPlaybackController.resumeCallCount == 0)
-            #expect(
-                await TestSupport.eventually(timeout: .milliseconds(400)) {
-                    subject.mediaPlaybackController.resumeCallCount == 1
-                })
+            let resumeTask = try #require(subject.controller.mediaResumeTask)
+            #expect(await clock.nextSleep() == .milliseconds(120))
+            await clock.advance(by: .milliseconds(119))
+            #expect(subject.mediaPlaybackController.resumeCallCount == 0)
+            await clock.advance(by: .milliseconds(1))
+            await resumeTask.value
+            #expect(subject.mediaPlaybackController.resumeCallCount == 1)
+            await speechService.setStopBehavior(.immediate("done"))
+            subject.controller.cancelActiveCapture()
+            await speechService.cancelRecording()
         }
 
-        @Test func processingToResultTransitionDoesNotCancelDeferredResume() async {
+        @Test func processingToResultTransitionDoesNotCancelDeferredResume() async throws {
+            let clock = TestClock()
             let defaults = TestSupport.makeUserDefaults()
             defaults.set(true, forKey: MacPreferences.pauseMediaDuringDictation)
             let speechService = ControllableSpeechService()
@@ -447,7 +458,8 @@
             let subject = makeController(
                 defaults: defaults,
                 speechService: speechService,
-                mediaResumeDelay: .milliseconds(120)
+                mediaResumeDelay: .milliseconds(120),
+                mediaResumeSleep: { try await clock.sleep(for: $0) }
             )
 
             subject.controller.startDictationCapture(source: .interface) {}
@@ -461,10 +473,16 @@
             subject.controller.handleStateTransition(from: .processing, to: .result("done"))
 
             #expect(subject.mediaPlaybackController.resumeCallCount == 0)
-            #expect(
-                await TestSupport.eventually(timeout: .milliseconds(400)) {
-                    subject.mediaPlaybackController.resumeCallCount == 1
-                })
+            let resumeTask = try #require(subject.controller.mediaResumeTask)
+            #expect(await clock.nextSleep() == .milliseconds(120))
+            await clock.advance(by: .milliseconds(119))
+            #expect(subject.mediaPlaybackController.resumeCallCount == 0)
+            await clock.advance(by: .milliseconds(1))
+            await resumeTask.value
+            #expect(subject.mediaPlaybackController.resumeCallCount == 1)
+            await speechService.setStopBehavior(.immediate("done"))
+            subject.controller.cancelActiveCapture()
+            await speechService.cancelRecording()
         }
 
         @Test func finishSoundDoesNotPlayWhenCaptureStops() async {

--- a/StetMacTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
+++ b/StetMacTests/Core/Clipboard/PasteboardRestoreCoordinatorTests.swift
@@ -8,242 +8,165 @@
     @MainActor
     @Suite("Pasteboard Restore Coordinator", .serialized)
     struct PasteboardRestoreCoordinatorTests {
-        private let restorationTimeout: Duration = .seconds(2)
+        @MainActor
+        private struct Subject {
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("StetTests.\(UUID().uuidString)"))
+            let clock = TestClock()
+            let clipboard: SystemClipboardService
+            let coordinator: PasteboardRestoreCoordinator
 
-        private func makePasteboard() -> NSPasteboard {
-            NSPasteboard(name: NSPasteboard.Name("StetTests.\(UUID().uuidString)"))
-        }
+            init(initialText: String? = "original") {
+                clipboard = SystemClipboardService(pasteboard: pasteboard)
+                let clock = clock
+                coordinator = PasteboardRestoreCoordinator(
+                    restoreDelay: .milliseconds(40), sleep: { try await clock.sleep(for: $0) })
+                pasteboard.clearContents()
+                if let initialText { pasteboard.setString(initialText, forType: .string) }
+            }
 
-        private func restoresOriginalClipboardEventually(_ pasteboard: NSPasteboard) async -> Bool {
-            await TestSupport.eventually(timeout: restorationTimeout) {
-                pasteboard.string(forType: .string) == "original"
+            func override(with text: String = "temporary") -> Task<Void, Never>? {
+                coordinator.prepareForTemporaryOverride(on: pasteboard)
+                clipboard.copy(text)
+                return coordinator.scheduleRestoreIfNeeded(on: pasteboard)
+            }
+
+            func finish(_ task: Task<Void, Never>?) async throws {
+                let task = try #require(task)
+                let delay = await clock.nextSleep()
+                #expect(delay == .milliseconds(40))
+                await clock.advance(by: delay)
+                await task.value
             }
         }
 
-        @Test func rapidSuccessiveOverridesRestoreOriginalClipboard() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .zero)
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("first")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("second")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        @Test func rapidSuccessiveOverridesRestoreOriginalClipboard() async throws {
+            let subject = Subject()
+            let first = subject.override(with: "first")
+            _ = await subject.clock.nextSleep()
+            let second = subject.override(with: "second")
+            try await subject.finish(second)
+            await first?.value
+            #expect(subject.pasteboard.string(forType: .string) == "original")
         }
 
-        @Test func userClipboardChangesAreNotOverwrittenByDelayedRestore() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            clipboard.copy("user-copy")
-
-            try? await Task.sleep(for: .milliseconds(80))
-
-            #expect(pasteboard.string(forType: .string) == "user-copy")
+        @Test func userClipboardChangesAreNotOverwrittenByDelayedRestore() async throws {
+            let subject = Subject()
+            let task = subject.override()
+            subject.clipboard.copy("user-copy")
+            try await subject.finish(task)
+            #expect(subject.pasteboard.string(forType: .string) == "user-copy")
         }
 
-        @Test func delayOverrideKeepsTemporaryClipboardUntilOverrideExpires() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(
-                on: pasteboard,
-                delayOverride: .milliseconds(120)
-            )
-
-            try? await Task.sleep(for: .milliseconds(70))
-            #expect(pasteboard.string(forType: .string) == "temporary")
-            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        @Test func delayOverrideKeepsTemporaryClipboardUntilOverrideExpires() async throws {
+            let subject = Subject()
+            subject.coordinator.prepareForTemporaryOverride(on: subject.pasteboard)
+            subject.clipboard.copy("temporary")
+            let task = try #require(
+                subject.coordinator.scheduleRestoreIfNeeded(
+                    on: subject.pasteboard, delayOverride: .milliseconds(120)))
+            #expect(await subject.clock.nextSleep() == .milliseconds(120))
+            await subject.clock.advance(by: .milliseconds(70))
+            #expect(subject.pasteboard.string(forType: .string) == "temporary")
+            await subject.clock.advance(by: .milliseconds(50))
+            await task.value
+            #expect(subject.pasteboard.string(forType: .string) == "original")
         }
 
-        @Test func delayOverrideStillSkipsRestoreAfterExternalClipboardChange() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(
-                on: pasteboard,
-                delayOverride: .milliseconds(120)
-            )
-
-            try? await Task.sleep(for: .milliseconds(60))
-            clipboard.copy("user-copy")
-
-            try? await Task.sleep(for: .milliseconds(100))
-
-            #expect(pasteboard.string(forType: .string) == "user-copy")
+        @Test func delayOverrideStillSkipsRestoreAfterExternalClipboardChange() async throws {
+            let subject = Subject()
+            subject.coordinator.prepareForTemporaryOverride(on: subject.pasteboard)
+            subject.clipboard.copy("temporary")
+            let task = try #require(
+                subject.coordinator.scheduleRestoreIfNeeded(
+                    on: subject.pasteboard, delayOverride: .milliseconds(120)))
+            #expect(await subject.clock.nextSleep() == .milliseconds(120))
+            await subject.clock.advance(by: .milliseconds(60))
+            subject.clipboard.copy("user-copy")
+            await subject.clock.advance(by: .milliseconds(60))
+            await task.value
+            #expect(subject.pasteboard.string(forType: .string) == "user-copy")
         }
 
-        @Test func discardPendingRestoreKeepsLatestClipboardValue() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            coordinator.discardPendingRestore()
-            clipboard.copy("final")
-
-            try? await Task.sleep(for: .milliseconds(80))
-
-            #expect(pasteboard.string(forType: .string) == "final")
+        @Test func discardPendingRestoreKeepsLatestClipboardValue() async throws {
+            let subject = Subject()
+            let task = try #require(subject.override())
+            _ = await subject.clock.nextSleep()
+            subject.coordinator.discardPendingRestore()
+            subject.clipboard.copy("final")
+            await task.value
+            await subject.clock.advance(by: .seconds(1))
+            #expect(task.isCancelled)
+            #expect(subject.pasteboard.string(forType: .string) == "final")
         }
 
-        @Test func restoringSameTemporaryContentsDoesNotCancelDelayedRestore() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary", transient: true)
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            let temporarySnapshot = PasteboardSnapshot.capture(from: pasteboard)
-            temporarySnapshot.restore(to: pasteboard)
-
-            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        @Test func restoringSameTemporaryContentsDoesNotCancelDelayedRestore() async throws {
+            let subject = Subject()
+            subject.coordinator.prepareForTemporaryOverride(on: subject.pasteboard)
+            subject.clipboard.copy("temporary", transient: true)
+            let task = subject.coordinator.scheduleRestoreIfNeeded(on: subject.pasteboard)
+            let snapshot = PasteboardSnapshot.capture(from: subject.pasteboard)
+            snapshot.restore(to: subject.pasteboard)
+            try await subject.finish(task)
+            #expect(subject.pasteboard.string(forType: .string) == "original")
         }
 
-        @Test func restoreSkippedWhenClipboardChangesExternally() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            pasteboard.clearContents()
-            pasteboard.setString("external-change", forType: .string)
-
-            try? await Task.sleep(for: .milliseconds(80))
-
-            #expect(pasteboard.string(forType: .string) == "external-change")
+        @Test func restoreSkippedWhenClipboardChangesExternally() async throws {
+            let subject = Subject()
+            let task = subject.override()
+            subject.pasteboard.clearContents()
+            subject.pasteboard.setString("external-change", forType: .string)
+            try await subject.finish(task)
+            #expect(subject.pasteboard.string(forType: .string) == "external-change")
         }
 
-        @Test func restorePreservesMultiItemPayloads() async {
-            let pasteboard = makePasteboard()
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            let item1 = NSPasteboardItem()
-            item1.setString("text1", forType: .string)
-            item1.setString("https://example.com", forType: .URL)
-
-            let item2 = NSPasteboardItem()
-            item2.setString("text2", forType: .string)
-
-            pasteboard.writeObjects([item1, item2])
-            #expect((pasteboard.pasteboardItems ?? []).count == 2)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            pasteboard.clearContents()
-            pasteboard.setString("temporary", forType: .string)
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            #expect(
-                await TestSupport.eventually(timeout: restorationTimeout) {
-                    let items = pasteboard.pasteboardItems ?? []
-                    return items.count == 2
-                        && items[0].string(forType: .string) == "text1"
-                        && items[0].string(forType: .URL) == "https://example.com"
-                        && items[1].string(forType: .string) == "text2"
-                })
+        @Test func restorePreservesMultiItemPayloads() async throws {
+            let subject = Subject(initialText: nil)
+            let first = NSPasteboardItem()
+            first.setString("text1", forType: .string)
+            first.setString("https://example.com", forType: .URL)
+            let second = NSPasteboardItem()
+            second.setString("text2", forType: .string)
+            subject.pasteboard.writeObjects([first, second])
+            #expect((subject.pasteboard.pasteboardItems ?? []).count == 2)
+            let task = subject.override()
+            try await subject.finish(task)
+            let items = try #require(subject.pasteboard.pasteboardItems)
+            try #require(items.count == 2)
+            #expect(items[0].string(forType: .string) == "text1")
+            #expect(items[0].string(forType: .URL) == "https://example.com")
+            #expect(items[1].string(forType: .string) == "text2")
         }
 
-        @Test func immediateRestoreOnFailureClearsPendingState() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            coordinator.restoreImmediatelyIfNeeded(on: pasteboard)
-
-            #expect(pasteboard.string(forType: .string) == "original")
-
-            clipboard.copy("after-immediate-restore")
-            try? await Task.sleep(for: .milliseconds(80))
-
-            #expect(pasteboard.string(forType: .string) == "after-immediate-restore")
+        @Test func immediateRestoreOnFailureClearsPendingState() async throws {
+            let subject = Subject()
+            let task = try #require(subject.override())
+            _ = await subject.clock.nextSleep()
+            subject.coordinator.restoreImmediatelyIfNeeded(on: subject.pasteboard)
+            #expect(subject.pasteboard.string(forType: .string) == "original")
+            subject.clipboard.copy("after-immediate-restore")
+            await task.value
+            await subject.clock.advance(by: .seconds(1))
+            #expect(task.isCancelled)
+            #expect(subject.pasteboard.string(forType: .string) == "after-immediate-restore")
         }
 
-        @Test func restoreHandlesEmptyClipboardGracefully() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            try? await Task.sleep(for: .milliseconds(80))
-
-            #expect(pasteboard.string(forType: .string) == nil)
-            #expect((pasteboard.pasteboardItems ?? []).isEmpty)
+        @Test func restoreHandlesEmptyClipboardGracefully() async throws {
+            let subject = Subject(initialText: nil)
+            let task = subject.override()
+            try await subject.finish(task)
+            #expect(subject.pasteboard.string(forType: .string) == nil)
+            #expect((subject.pasteboard.pasteboardItems ?? []).isEmpty)
         }
 
-        @Test func multiplePrepareCallsPreserveFirstSnapshot() async {
-            let pasteboard = makePasteboard()
-            let clipboard = SystemClipboardService(pasteboard: pasteboard)
-            let coordinator = PasteboardRestoreCoordinator(restoreDelay: .milliseconds(40))
-
-            pasteboard.clearContents()
-            pasteboard.setString("original", forType: .string)
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("first-temporary")
-
-            coordinator.prepareForTemporaryOverride(on: pasteboard)
-            clipboard.copy("second-temporary")
-            coordinator.scheduleRestoreIfNeeded(on: pasteboard)
-
-            #expect(await restoresOriginalClipboardEventually(pasteboard))
+        @Test func multiplePrepareCallsPreserveFirstSnapshot() async throws {
+            let subject = Subject()
+            subject.coordinator.prepareForTemporaryOverride(on: subject.pasteboard)
+            subject.clipboard.copy("first-temporary")
+            subject.coordinator.prepareForTemporaryOverride(on: subject.pasteboard)
+            subject.clipboard.copy("second-temporary")
+            let task = subject.coordinator.scheduleRestoreIfNeeded(on: subject.pasteboard)
+            try await subject.finish(task)
+            #expect(subject.pasteboard.string(forType: .string) == "original")
         }
     }
 #endif

--- a/StetMacTests/Support/TestClock.swift
+++ b/StetMacTests/Support/TestClock.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A clock advanced by tests, with observable sleep registration and cancellation.
+actor TestClock {
+    private struct Sleeper {
+        let deadline: Duration
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var now: Duration = .zero
+    private var sleepers: [UUID: Sleeper] = [:]
+    private var requests: [Duration] = []
+    private var observers: [CheckedContinuation<Duration, Never>] = []
+
+    var pendingSleepCount: Int { sleepers.count }
+
+    func sleep(for duration: Duration) async throws {
+        try Task.checkCancellation()
+        guard duration > .zero else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                sleepers[id] = Sleeper(deadline: now + duration, continuation: continuation)
+                if observers.isEmpty {
+                    requests.append(duration)
+                } else {
+                    observers.removeFirst().resume(returning: duration)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(id) }
+        }
+    }
+
+    func nextSleep() async -> Duration {
+        if !requests.isEmpty { return requests.removeFirst() }
+        return await withCheckedContinuation { observers.append($0) }
+    }
+
+    func advance(by duration: Duration) {
+        precondition(duration >= .zero)
+        now += duration
+        let ready = sleepers.filter { $0.value.deadline <= now }
+        for (id, sleeper) in ready {
+            sleepers.removeValue(forKey: id)
+            sleeper.continuation.resume()
+        }
+    }
+
+    private func cancel(_ id: UUID) {
+        sleepers.removeValue(forKey: id)?.continuation.resume(throwing: CancellationError())
+    }
+}

--- a/StetMacTests/Support/TestClockTests.swift
+++ b/StetMacTests/Support/TestClockTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@MainActor
+@Suite("Deterministic Test Clock")
+struct TestClockTests {
+    @Test func advanceResumesOnlyDueSleeps() async throws {
+        let clock = TestClock()
+        var secondFinished = false
+        let first = Task { try await clock.sleep(for: .milliseconds(100)) }
+        #expect(await clock.nextSleep() == .milliseconds(100))
+        let second = Task {
+            try await clock.sleep(for: .milliseconds(200))
+            secondFinished = true
+        }
+        #expect(await clock.nextSleep() == .milliseconds(200))
+        await clock.advance(by: .milliseconds(100))
+        try await first.value
+        #expect(!secondFinished)
+        await clock.advance(by: .milliseconds(100))
+        try await second.value
+        #expect(secondFinished)
+        #expect(await clock.pendingSleepCount == 0)
+    }
+
+    @Test func cancellationRemovesPendingSleep() async {
+        let clock = TestClock()
+        let task = Task { try await clock.sleep(for: .seconds(1)) }
+        _ = await clock.nextSleep()
+        task.cancel()
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(await clock.pendingSleepCount == 0)
+    }
+
+    @Test func cancellationBeforeRegistrationDoesNotPark() async {
+        let clock = TestClock()
+        let task = Task { try await clock.sleep(for: .seconds(1)) }
+        task.cancel()
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(await clock.pendingSleepCount == 0)
+    }
+}

--- a/scripts/ci-source-mtimes.py
+++ b/scripts/ci-source-mtimes.py
@@ -24,27 +24,37 @@ def tracked_inputs(root):
     return sorted(paths, key=str)
 
 
-def fingerprint(path):
+def fingerprint(path, cache=None):
+    cache = {} if cache is None else cache
+    if path in cache:
+        return cache[path]
     digest = hashlib.sha256()
-    if path.is_dir():
-        # Xcode also watches directory membership for assets and file groups.
-        digest.update(b"directory\0")
-        for name in sorted(child.name for child in path.iterdir()):
-            digest.update(name.encode() + b"\0")
+    if path.is_symlink():
+        # A directory hash includes link text, never the external target.
+        digest.update(b"symlink\0" + os.readlink(path).encode())
+    elif path.is_dir():
+        # A resource change must invalidate its containing directory even if
+        # membership is unchanged. Memoization hashes each file only once.
+        digest.update(b"directory-tree\0")
+        for child in sorted(path.iterdir(), key=lambda child: child.name):
+            digest.update(child.name.encode() + b"\0")
+            digest.update(fingerprint(child, cache).encode())
     else:
         digest.update(b"file\0")
         with path.open("rb") as source:
             for chunk in iter(lambda: source.read(1024 * 1024), b""):
                 digest.update(chunk)
-    return digest.hexdigest()
+    cache[path] = digest.hexdigest()
+    return cache[path]
 
 
 def save(root, manifest):
     entries = {}
+    hashes = {}
     for relative in tracked_inputs(root):
         path = root / relative
         entries[str(relative)] = {
-            "sha256": fingerprint(path),
+            "sha256": fingerprint(path, hashes),
             "mtime_ns": path.stat().st_mtime_ns,
         }
     manifest.parent.mkdir(parents=True, exist_ok=True)
@@ -56,14 +66,26 @@ def restore(root, manifest):
     if not manifest.is_file():
         print("No input timestamps cached; using a fresh build")
         return
-    entries = json.loads(manifest.read_text())
+    try:
+        entries = json.loads(manifest.read_text())
+        if not isinstance(entries, dict):
+            raise ValueError("Expected a timestamp map")
+    except (OSError, ValueError):
+        print("Invalid input timestamp cache; using fresh input timestamps")
+        return
     restored = 0
+    hashes = {}
     # Intersect with today's tracked inputs: removed/untracked paths and paths
     # outside the repository can never be restored from cache metadata.
     for relative in tracked_inputs(root):
         entry = entries.get(str(relative))
         path = root / relative
-        if entry and entry["sha256"] == fingerprint(path):
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("mtime_ns"), int)
+            and 0 <= entry["mtime_ns"] < 2**63
+            and entry.get("sha256") == fingerprint(path, hashes)
+        ):
             os.utime(path, ns=(path.stat().st_atime_ns, entry["mtime_ns"]))
             restored += 1
     print(f"Restored timestamps for {restored} unchanged build inputs")

--- a/scripts/ci-source-mtimes.py
+++ b/scripts/ci-source-mtimes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Restore Xcode input mtimes only when tracked inputs still have identical content."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import os
+import subprocess
+
+
+def tracked_inputs(root):
+    names = subprocess.check_output(["git", "ls-files", "-z"], cwd=root).decode().split("\0")
+    paths = set()
+    for name in filter(None, names):
+        relative = Path(name)
+        # Do not follow tracked symlinks or symlinked parent directories.
+        if any((root / part).is_symlink() for part in (relative, *relative.parents)):
+            continue
+        path = root / relative
+        if path.is_file():
+            paths.add(relative)
+            paths.update(parent for parent in relative.parents if parent != Path("."))
+    return sorted(paths, key=str)
+
+
+def fingerprint(path):
+    digest = hashlib.sha256()
+    if path.is_dir():
+        # Xcode also watches directory membership for assets and file groups.
+        digest.update(b"directory\0")
+        for name in sorted(child.name for child in path.iterdir()):
+            digest.update(name.encode() + b"\0")
+    else:
+        digest.update(b"file\0")
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save(root, manifest):
+    entries = {}
+    for relative in tracked_inputs(root):
+        path = root / relative
+        entries[str(relative)] = {
+            "sha256": fingerprint(path),
+            "mtime_ns": path.stat().st_mtime_ns,
+        }
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(json.dumps(entries, sort_keys=True))
+    print(f"Saved timestamps for {len(entries)} tracked build inputs")
+
+
+def restore(root, manifest):
+    if not manifest.is_file():
+        print("No input timestamps cached; using a fresh build")
+        return
+    entries = json.loads(manifest.read_text())
+    restored = 0
+    # Intersect with today's tracked inputs: removed/untracked paths and paths
+    # outside the repository can never be restored from cache metadata.
+    for relative in tracked_inputs(root):
+        entry = entries.get(str(relative))
+        path = root / relative
+        if entry and entry["sha256"] == fingerprint(path):
+            os.utime(path, ns=(path.stat().st_atime_ns, entry["mtime_ns"]))
+            restored += 1
+    print(f"Restored timestamps for {restored} unchanged build inputs")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("save", "restore"))
+    parser.add_argument("manifest", type=Path)
+    args = parser.parse_args()
+    {"save": save, "restore": restore}[args.operation](Path.cwd(), args.manifest)

--- a/scripts/tests/test_ci_source_mtimes.py
+++ b/scripts/tests/test_ci_source_mtimes.py
@@ -1,0 +1,60 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "ci_source_mtimes", Path(__file__).resolve().parents[1] / "ci-source-mtimes.py"
+)
+mtimes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mtimes)
+
+
+class SourceMtimeTests(unittest.TestCase):
+    def test_only_identical_tracked_inputs_restore_nanosecond_timestamps(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            source = root / "Sources"
+            source.mkdir()
+            original = 1_700_000_000_123_456_789
+            fresh = original + 10_000_000_000
+            for name in ("same.swift", "edited.swift", "deleted.swift"):
+                (source / name).write_text("original")
+                os.utime(source / name, ns=(original, original))
+            (source / "alias.swift").symlink_to("same.swift")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            manifest = root / "cache.json"
+            mtimes.save(root, manifest)
+            self.assertNotIn("Sources/alias.swift", json.loads(manifest.read_text()))
+            # Simulate a checkout and a same-length edit, including its mtime.
+            (source / "edited.swift").write_text("modified")
+            (source / "deleted.swift").unlink()
+            (source / "new.swift").write_text("new")
+            for path in (source / "same.swift", source / "edited.swift", source / "new.swift", source):
+                os.utime(path, ns=(fresh, fresh))
+            mtimes.restore(root, manifest)
+            self.assertEqual((source / "same.swift").stat().st_mtime_ns, original)
+            self.assertEqual((source / "edited.swift").stat().st_mtime_ns, fresh)
+            self.assertEqual((source / "new.swift").stat().st_mtime_ns, fresh)
+            self.assertEqual(source.stat().st_mtime_ns, fresh)
+            self.assertFalse((source / "deleted.swift").exists())
+
+    def test_missing_cache_and_untracked_cache_entries_do_not_modify_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            manifest = root / "cache.json"
+            mtimes.restore(root, manifest)
+            source = root / "untracked.swift"
+            source.write_text("same")
+            timestamp = source.stat().st_mtime_ns
+            manifest.write_text(json.dumps({
+                "untracked.swift": {"sha256": mtimes.fingerprint(source), "mtime_ns": 1},
+                "../outside.swift": {"sha256": mtimes.fingerprint(source), "mtime_ns": 1},
+            }))
+            mtimes.restore(root, manifest)
+            self.assertEqual(source.stat().st_mtime_ns, timestamp)

--- a/scripts/tests/test_ci_source_mtimes.py
+++ b/scripts/tests/test_ci_source_mtimes.py
@@ -58,3 +58,36 @@ class SourceMtimeTests(unittest.TestCase):
             }))
             mtimes.restore(root, manifest)
             self.assertEqual(source.stat().st_mtime_ns, timestamp)
+
+    def test_resource_edit_invalidates_directory_without_changing_membership(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            assets = root / "Assets.xcassets"
+            assets.mkdir()
+            resource = assets / "Contents.json"
+            resource.write_text('{"version":1}')
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            manifest = root / "cache.json"
+            mtimes.save(root, manifest)
+            resource.write_text('{"version":2}')
+            fresh = assets.stat().st_mtime_ns + 10_000_000_000
+            os.utime(assets, ns=(fresh, fresh))
+            os.utime(resource, ns=(fresh, fresh))
+            mtimes.restore(root, manifest)
+            self.assertEqual(assets.stat().st_mtime_ns, fresh)
+            self.assertEqual(resource.stat().st_mtime_ns, fresh)
+
+    def test_corrupt_timestamp_metadata_falls_back_to_fresh_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            source = root / "main.swift"
+            source.write_text("source")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            timestamp = source.stat().st_mtime_ns
+            manifest = root / "cache.json"
+            for contents in ("not JSON", "[]", '{"main.swift": {"mtime_ns": "invalid"}}'):
+                manifest.write_text(contents)
+                mtimes.restore(root, manifest)
+                self.assertEqual(source.stat().st_mtime_ns, timestamp)


### PR DESCRIPTION
Repeated macOS CI runs downloaded SwiftPM sources and binary frameworks again, then recompiled unchanged inputs. This change restores packages, compiler results and incremental build products while keeping the existing lint, build, full test suite and coverage checks. Package downloads are saved before compilation; test results never substitute for executing tests.

Cache keys include the exact Xcode/SDK/OS fingerprint and build/test mode. Unchanged tracked inputs regain their cached nanosecond timestamps only after SHA-256 validation; nested resource edits, same-length source edits, deleted paths and malformed metadata are covered by four fixture tests. A changed-source hosted run confirmed that the edited Swift test was recompiled. Local Makefile defaults remain unchanged.

The investigation also reproduced intermittent clipboard and media-delay test failures. These tests now observe sleep registration, advance a controllable clock and await actual task completion or cancellation. Production delay defaults are unchanged. Failed-paste integration coverage remains, while the hotkey action fixture starts from an already-delivered pending result and uses an isolated pasteboard.

Validation:
- All affected suites passed 20 repetitions: 1,220 test executions.
- The full suite passed three repetitions: 1,572 test executions (524 per run), with stop-on-failure and no failure retries.
- Test clock harness: 1,000 deadlines, 1,000 pending cancellations and 1,000 early cancellations passed.
- `make lint`, `actionlint`, four Python cache tests and `git diff --check` passed.

Measured cold/warm/changed-source results, including failed experiments and cache transfer overhead, are recorded in `.github/ci-performance.md`. Final source passed both hosted attempts of run 34466147590. The exact-commit warm comparison was build **349 → 112 s (68% less)** and test job **355 → 215 s (39% less)**, including cache transfer overhead. The sum of successful job durations fell from 722 to 342 s (53%); this is not sequential workflow time. Both attempts ran all 524 tests. Cold/changed-source runs can take longer, as documented.
