### PR TITLE
Expand optimistic paste compatibility list

### DIFF
--- a/StetMac/Resources/app-compatibility.json
+++ b/StetMac/Resources/app-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "revision": 1,
+  "revision": 2,
   "bundleIDs": [
     "com.microsoft.vscode",
     "com.microsoft.vscodeinsiders",
@@ -23,7 +23,15 @@
     "com.bytedance.macos.feishu",
     "com.larksuite.larkapp",
     "com.anthropic.claudefordesktop",
+    "com.figma.desktop",
+    "cn.trae.solo.app",
+    "com.trae.solo.app",
     "cn.trae.app",
+    "com.infcode.editor",
+    "com.baidu.baidunetdisk-mac",
+    "com.qoder.work",
+    "com.qoder.ide",
+    "io.open-design.desktop",
     "now.typeless.desktop",
     "app.motrix.native",
     "com.1password.1password",


### PR DESCRIPTION
Add Figma, TRAE SOLO (CN and global), InfCode, Baidu Netdisk, QoderWork, Qoder, and Open Design to the optimistic paste compatibility list. These apps can treat a successfully posted paste as completed when verification is unavailable or fails.

Increment the configuration revision from 1 to 2 so clients with dynamic compatibility updates can receive the additions after merge to main.

Validation: `python3 scripts/validate-app-compatibility.py --base-ref origin/main` (45 valid entries) and `git diff --check` passed. This change only updates the compatibility JSON; no app build was run.
