### PR TITLE
Scope CI by changed paths and remove duplicate Debug build

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,10 +4,57 @@
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `monorepo-ci.yml` | PR + push to `main`, `migration/**` | Swift lint/format, macOS build, macOS tests |
+| `monorepo-ci.yml` | PR + push to `main`, `migration/**` | Linux repository checks, affected Swift lint/format and macOS build/tests, aggregate result |
 | `macos-release.yml` | Tags `v*` + manual | Signed macOS release (runs at repository root) |
 | `macos-release-candidate.yml` | Manual | Release candidate build (runs at repository root) |
 
 Release jobs run at the repository root, where the scripts and Xcode project now live.
 
 macOS CI cache design, measured baseline, and cold/warm validation results: [CI performance](ci-performance.md).
+
+## Change-based CI scope
+
+Every event starts `Repository Checks` on Linux. It computes the complete Git
+diff with `scripts/ci-changes.py`, validates the compatibility list and revision,
+runs the CI helper regression tests, and checks harness entrypoints. Workflow
+changes also run actionlint 1.7.12. No workflow-level path filters are used.
+
+| Changed files | Additional jobs |
+| --- | --- |
+| `StetMac/Resources/app-compatibility.json`, root/docs/reference Markdown, agent docs | None |
+| macOS Swift files in `StetMac`, `StetMacTests`, `StetMacUITests`, `StetVisuals` | Swift Quality + macOS Tests |
+| macOS resources, Metal, entitlements, `Info.plist`, Xcode project, shared packages | macOS Tests |
+| iOS Swift files in the existing lint directories | Swift Quality |
+| Other iOS-only files | None; simulator builds remain local |
+| `.swiftlint.yml`, `.swift-format` | Swift Quality |
+| `Makefile`, main CI workflow, routing helper or its tests | Swift Quality + macOS Tests + actionlint |
+| Other workflows | actionlint on Linux |
+| Unclassified paths | Swift Quality + macOS Tests (conservative fallback) |
+
+Mixed changes run the union of affected jobs. Markdown inside macOS app/resource
+directories is conservatively treated as a build input. Shared packages keep
+their existing build/test coverage; this change does not expand the directories
+covered by `make lint` or add an iOS hosted build.
+
+`macOS Tests` runs `make test`, which builds the Debug app and dependencies before
+executing the full existing StetTests suite with coverage. The redundant standalone
+Debug build job is removed. Test cache keys remain compatible with the previous
+matrix's `test` entry. Release/RC builds are unchanged.
+
+PR routing uses the merge-base-to-head diff across all commits; builds still use
+GitHub's merged checkout. Compatibility revision validation uses the current PR
+base SHA. Pushes compare `before` to `after`, including all commits in the push;
+new branches inspect the full tree. Deleted and renamed paths are included, with
+no 300-file limit. Missing Git history fails the check rather than skipping jobs.
+PR and post-merge push checks both remain enabled to validate integration; both
+use the same routing, so a list-only merge never needs a macOS runner.
+
+`CI Result` always runs and requires repository checks plus every selected job to
+succeed. Intentionally unselected jobs must report `skipped`; missing outputs,
+failures, and cancellations fail the gate. Use **CI Result** as the required
+branch-protection check if protection is enabled; remove the retired **macOS
+Build** requirement. This workflow change does not edit repository protection.
+
+Local verification: `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`,
+`python3 scripts/validate-app-compatibility.py --base-ref origin/main`,
+`scripts/validate-agent-entrypoints`, and `actionlint`.

--- a/.github/ci-performance.md
+++ b/.github/ci-performance.md
@@ -1,5 +1,19 @@
 # macOS CI performance
 
+## Current routing — September 11, 2026
+
+The workflow now selects jobs by changed paths; see [CI scope](README.md#change-based-ci-scope).
+Compatibility-list and documentation changes use Linux checks without starting
+macOS runners. App changes run the existing full `make test` command, which builds
+the app; the duplicate standalone Debug build is removed. Existing test cache
+keys and test execution remain intact. PR and post-merge integration checks are
+both retained, using the same path routing.
+
+The measurements below describe the previous all-files, two-job build/test
+workflow. They are historical cache evidence, not measurements of this routing
+change. Do not infer a new wall-clock speedup from the removed job: jobs previously
+ran in parallel, and runner allocation and cache state still affect elapsed time.
+
 ## Baseline — September 10, 2026
 
 Baseline: [PR #56 run 34456673443](https://github.com/DengNaichen/Stet/actions/runs/34456673443), commit `b5b84c05fdfae7e35e358023c5f058a02adfddab`, macos-26 ARM64, Xcode 26.6 (17F113). Job elapsed times include cache/setup/cleanup when present; phase measurements use timestamped logs.

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -7,23 +7,62 @@ on:
       - main
       - "migration/**"
 
+permissions:
+  contents: read
+
 # New commits supersede older PR runs; main and migration pushes still finish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  quality:
-    name: Swift Quality
-    runs-on: macos-26
+  changes:
+    name: Repository Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      quality: ${{ steps.scope.outputs.quality }}
+      macos: ${{ steps.scope.outputs.macos }}
 
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 2
+          # Full history makes PR merge-base and multi-commit push diffs exact.
+          fetch-depth: 0
+
+      - name: Determine affected jobs
+        id: scope
+        run: python3 scripts/ci-changes.py
 
       - name: Validate app compatibility list
-        run: python3 scripts/validate-app-compatibility.py --base-ref HEAD^
+        env:
+          BASE_REF: ${{ steps.scope.outputs.base_ref }}
+        run: |
+          args=()
+          if [[ -n "$BASE_REF" ]]; then args+=(--base-ref "$BASE_REF"); fi
+          python3 scripts/validate-app-compatibility.py "${args[@]}"
+
+      - name: Test CI helpers
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
+      - name: Validate harness entrypoints
+        run: scripts/validate-agent-entrypoints
+
+      - name: Validate workflow syntax
+        if: steps.scope.outputs.workflows == 'true'
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
+  quality:
+    name: Swift Quality
+    needs: changes
+    if: needs.changes.outputs.quality == 'true'
+    runs-on: macos-26
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -32,23 +71,17 @@ jobs:
       - name: Install SwiftLint
         run: brew install swiftlint
 
-      - name: Test CI cache validation
-        run: python3 -m unittest discover -s scripts/tests -p 'test_ci_source_mtimes.py'
-
       - name: Run lint checks
         run: make lint
 
   macos:
-    name: ${{ matrix.name }}
+    # `make test` builds the Stet app and its dependencies before running tests.
+    # A separate Debug build would repeat the same compilation and cache I/O.
+    name: macOS Tests
+    needs: changes
+    if: needs.changes.outputs.macos == 'true'
     runs-on: macos-26
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macOS Build
-            target: ci-build
-          - name: macOS Tests
-            target: test
+    timeout-minutes: 30
     env:
       CI_XCODEBUILD_FLAGS: >-
         -derivedDataPath .build/ci
@@ -108,9 +141,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build/ci/CompilationCache.noindex
-          key: compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          key: compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-test-${{ github.sha }}
           restore-keys: |
-            compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
+            compilation-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-test-
 
       - name: Restore incremental build
         id: incremental
@@ -120,9 +153,9 @@ jobs:
             .build/ci/Build
             .build/ci/ModuleCache.noindex
             .build/ci/source-mtimes.json
-          key: incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-${{ github.sha }}
+          key: incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-test-${{ github.sha }}
           restore-keys: |
-            incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.target }}-
+            incremental-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-test-
 
       - name: Validate incremental build inputs
         run: python3 scripts/ci-source-mtimes.py restore .build/ci/source-mtimes.json
@@ -130,8 +163,8 @@ jobs:
       - name: Install Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
 
-      - name: Build or test macOS app
-        run: make ${{ matrix.target }}
+      - name: Build and test macOS app
+        run: make test
 
       # Compiler results are reusable even if a later test fails. Never cache
       # test results or skip test execution on a cache hit.
@@ -155,3 +188,28 @@ jobs:
             .build/ci/ModuleCache.noindex
             .build/ci/source-mtimes.json
           key: ${{ steps.incremental.outputs.cache-primary-key }}
+
+  result:
+    name: CI Result
+    needs: [changes, quality, macos]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every selected job to succeed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          assert needs["changes"]["result"] == "success", "Repository checks failed or were cancelled"
+          for name in ("quality", "macos"):
+              selected = needs["changes"]["outputs"][name]
+              assert selected in ("true", "false"), f"Missing CI selection: {name}"
+              expected = "success" if selected == "true" else "skipped"
+              actual = needs[name]["result"]
+              assert actual == expected, f"{name}: expected {expected}, got {actual}"
+          print("All selected checks passed.")
+          PY

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -28,9 +28,25 @@ macOS-only 目标（`ci-build`、`release-github`、`doctor` 等）见根 [`Make
 
 | CI job | 本地等价命令 |
 |--------|--------------|
+| Repository Checks（Linux，始终运行） | CI helper 单测、兼容名单校验、`scripts/validate-agent-entrypoints`；工作流改动时加 `actionlint` |
 | Swift Quality | `make lint` |
-| macOS Build | `make ci-build` |
-| macOS Tests | `make test` |
+| macOS Tests（包含 app 构建） | `make test` |
+| CI Result（Linux，始终运行） | 汇总：所有选中的任务必须成功，未选中的任务必须跳过 |
+
+`scripts/ci-changes.py` 按完整 Git diff 选择任务：名单和文档改动只跑
+Linux 检查，iOS Swift 改动跑现有 lint，macOS／共享包改动跑完整构建和
+测试。独立 Debug Build 与 `make test` 重复，已移除；本地 `make ci-build`
+仍可使用。具体路径、保守回退和 PR／push 差异语义见
+[CI 范围说明](../.github/README.md#change-based-ci-scope)。
+
+CI 配置的本地验证：
+
+```sh
+python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+python3 scripts/validate-app-compatibility.py --base-ref origin/main
+scripts/validate-agent-entrypoints
+actionlint
+```
 
 ### Release workflows
 

--- a/scripts/ci-changes.py
+++ b/scripts/ci-changes.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Choose CI jobs from the complete Git diff, without GitHub path-filter limits."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+
+
+COMPATIBILITY = "StetMac/Resources/app-compatibility.json"
+MACOS_ROOTS = ("StetMac/", "StetMacTests/", "StetMacUITests/", "StetVisuals/")
+IOS_SWIFT_ROOTS = (
+    "StetMobile/StetKeyboard/", "StetMobile/StetLiveActivity/",
+    "StetMobile/StetMobile/", "StetMobile/StetMobileTests/",
+    "StetMobile/StetMobileUITests/",
+)
+FULL_CI = {
+    "Makefile", ".github/workflows/monorepo-ci.yml",
+    "scripts/ci-changes.py", "scripts/tests/test_ci_changes.py",
+}
+
+
+def classify(paths):
+    selected = {"quality": False, "macos": False, "workflows": False}
+    for path in paths:
+        if path in FULL_CI:
+            selected.update(quality=True, macos=True, workflows=True)
+        elif path.startswith(".github/workflows/"):
+            selected["workflows"] = True
+        elif path in (".swiftlint.yml", ".swift-format"):
+            selected["quality"] = True
+        elif path == COMPATIBILITY:
+            # Validated on Linux, including revision monotonicity.
+            continue
+        elif path.startswith(MACOS_ROOTS):
+            selected["macos"] = True
+            selected["quality"] |= path.endswith(".swift")
+        elif path.startswith("StetMobile/"):
+            # iOS simulator builds remain a local Xcode Beta check.
+            selected["quality"] |= path.startswith(IOS_SWIFT_ROOTS) and path.endswith(".swift")
+        elif path.startswith(("docs/", "reference/", "research/", ".agents/", ".claude/", ".codex/", ".cursor/")):
+            continue
+        elif path.endswith(".md") or path in ("LICENSE", ".gitignore", "buildServer.json"):
+            continue
+        elif path.startswith(("Packages/", "Stet.xcodeproj/")) or path == "Info.plist":
+            selected["macos"] = True
+        elif path in ("scripts/validate-app-compatibility.py", "scripts/validate-agent-entrypoints"):
+            continue  # These execute on every run in Repository Checks.
+        elif path in ("scripts/ci-source-mtimes.py", "scripts/tests/test_ci_source_mtimes.py"):
+            selected["macos"] = True
+        else:
+            # New or unclassified inputs must not silently lose coverage.
+            selected.update(quality=True, macos=True)
+    return selected
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args])
+
+
+def plan(event_name, event):
+    if event_name == "pull_request":
+        base = event["pull_request"]["base"]["sha"]
+        head = event["pull_request"]["head"]["sha"]
+        # Compare the entire PR, not just its last commit. Check the merged
+        # configuration against the current base revision, not the merge-base.
+        diff_base = git("merge-base", base, head).decode().strip()
+    elif event_name == "push":
+        base = event["before"]
+        head = event["after"]
+        if not base.strip("0"):
+            # A new branch has no previous configuration. Check every file.
+            paths = os.fsdecode(git("ls-tree", "-r", "--name-only", "-z", head)).split("\0")[:-1]
+            return {**classify(paths), "base_ref": "", "paths": paths}
+        diff_base = base
+    else:
+        raise ValueError(f"Unsupported CI event: {event_name}")
+
+    # No rename detection: both the removed and added paths affect routing.
+    # NUL delimiters preserve spaces/newlines and there is no 300-file limit.
+    paths = os.fsdecode(git("diff", "--no-renames", "--name-only", "-z", diff_base, head, "--")).split("\0")[:-1]
+    return {**classify(paths), "base_ref": base, "paths": paths}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME"), required=False)
+    parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH"), required=False)
+    args = parser.parse_args()
+    result = plan(args.event_name, json.loads(Path(args.event_path).read_text()))
+    print(json.dumps(result, indent=2))
+    if output := os.environ.get("GITHUB_OUTPUT"):
+        with open(output, "a") as stream:
+            for name in ("quality", "macos", "workflows"):
+                stream.write(f"{name}={str(result[name]).lower()}\n")
+            stream.write(f"base_ref={result['base_ref']}\n")
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(summary, "a") as stream:
+            stream.write("## CI scope\n\nRepository Checks always run on Linux.\n\n")
+            for name in ("quality", "macos", "workflows"):
+                stream.write(f"- {name}: {'run' if result[name] else 'skip'}\n")
+            stream.write(f"\nCompared {len(result['paths'])} changed paths.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_ci_changes.py
+++ b/scripts/tests/test_ci_changes.py
@@ -1,0 +1,214 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci-changes.py"
+spec = importlib.util.spec_from_file_location("ci_changes", SCRIPT)
+changes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(changes)
+
+
+class RoutingTests(unittest.TestCase):
+    def test_lightweight_changes_do_not_allocate_macos(self):
+        for path in (
+            changes.COMPATIBILITY, "docs/specs/app-compatibility.md", "README.md",
+            "reference/apple-platform/index.md", ".github/README.md", "AGENTS.md",
+            "scripts/validate-app-compatibility.py", "scripts/validate-agent-entrypoints",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(changes.classify([path]), dict(quality=False, macos=False, workflows=False))
+
+    def test_runtime_inputs_and_unknown_paths_keep_build_and_test_coverage(self):
+        for path in (
+            "StetMac/Core/Service.swift", "StetMacTests/Example.swift",
+            "StetVisuals/Shader.metal", "StetMac/Resources/asset.png",
+            "StetMac/Resources/prompt.md", "StetMac/Stet.entitlements",
+            "Packages/StetEngine/Package.swift", "Packages/StetEngine/Sources/Engine.swift",
+            "Packages/StetEngine/Vendor/FunASRPackage/RuntimeSource/stet_funasr.cpp",
+            "Stet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+            "Stet.xcodeproj/xcshareddata/xcschemes/Stet.xcscheme", "Info.plist",
+            "scripts/normalize-binary-frameworks.sh", "scripts/ci-source-mtimes.py",
+            "NewModule/input.xyz",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(changes.classify([path])["macos"])
+
+    def test_ios_changes_do_not_build_macos(self):
+        for path in ("StetMobile/StetMobile/App.swift", "StetMobile/StetKeyboard/Keyboard.swift"):
+            self.assertEqual(changes.classify([path]), dict(quality=True, macos=False, workflows=False))
+        self.assertFalse(changes.classify(["StetMobile/StetMobile/Assets.xcassets/Contents.json"])["quality"])
+
+    def test_ci_routing_changes_exercise_full_pipeline(self):
+        for path in changes.FULL_CI:
+            self.assertEqual(changes.classify([path]), dict(quality=True, macos=True, workflows=True))
+        self.assertEqual(
+            changes.classify([".github/workflows/macos-release.yml"]),
+            dict(quality=False, macos=False, workflows=True),
+        )
+
+    def test_lint_configs_and_mixed_changes(self):
+        self.assertEqual(changes.classify([".swift-format"]), dict(quality=True, macos=False, workflows=False))
+        self.assertTrue(changes.classify([changes.COMPATIBILITY, "StetMac/App.swift"])["macos"])
+        self.assertTrue(changes.classify(["README.md", "StetMobile/StetMobile/App.swift"])["quality"])
+
+
+class GitDiffTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.name", "CI Test")
+        self.git("config", "user.email", "ci-test@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.write("README.md", "initial")
+        self.base = self.commit()
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], cwd=self.root, stderr=subprocess.PIPE).decode().strip()
+
+    def write(self, path, content="changed"):
+        file = self.root / path
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text(content)
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "-qm", "fixture")
+        return self.git("rev-parse", "HEAD")
+
+    def run_plan(self, event_name, event, success=True):
+        # Keep event/output files outside the fixture's Git tree.
+        with tempfile.TemporaryDirectory() as io_dir:
+            event_path = Path(io_dir) / "event.json"
+            event_path.write_text(json.dumps(event))
+            output = Path(io_dir) / "output"
+            env = {**os.environ, "GITHUB_OUTPUT": str(output), "GITHUB_STEP_SUMMARY": str(Path(io_dir) / "summary")}
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--event-name", event_name, "--event-path", str(event_path)],
+                cwd=self.root, env=env, text=True, capture_output=True,
+            )
+            if not success:
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(output.exists())
+                return
+            self.assertEqual(result.returncode, 0, result.stderr)
+            value = json.loads(result.stdout)
+            for name in ("quality", "macos", "workflows"):
+                self.assertIn(f"{name}={str(value[name]).lower()}\n", output.read_text())
+            return value
+
+    def test_pr_considers_all_commits_but_not_unrelated_base_changes(self):
+        self.git("checkout", "-qb", "feature")
+        self.write(changes.COMPATIBILITY)
+        self.commit()
+        self.write("docs/new.md")
+        head = self.commit()
+        self.git("checkout", "-q", "main")
+        self.write("StetMac/unrelated.swift")
+        current_base = self.commit()
+        self.git("merge", "--no-ff", "feature", "-m", "simulated PR checkout")
+        value = self.run_plan("pull_request", {"pull_request": {"base": {"sha": current_base}, "head": {"sha": head}}})
+        self.assertEqual(set(value["paths"]), {changes.COMPATIBILITY, "docs/new.md"})
+        self.assertEqual(value["base_ref"], current_base)
+        self.assertFalse(value["macos"])
+
+    def test_push_covers_every_commit_not_only_head_parent(self):
+        self.write("StetMac/App.swift")
+        self.commit()
+        self.write("docs/new.md")
+        head = self.commit()
+        value = self.run_plan("push", {"before": self.base, "after": head})
+        self.assertTrue(value["macos"])
+        self.assertTrue(value["quality"])
+
+    def test_multi_commit_push_cannot_hide_missing_compatibility_revision_bump(self):
+        config = dict(schemaVersion=1, revision=1, bundleIDs=["com.example.one"])
+        self.write(changes.COMPATIBILITY, json.dumps(config))
+        base = self.commit()
+        config["bundleIDs"].append("com.example.two")
+        self.write(changes.COMPATIBILITY, json.dumps(config))
+        self.commit()
+        self.write("docs/last-commit.md")
+        head = self.commit()
+        value = self.run_plan("push", {"before": base, "after": head})
+        result = subprocess.run(
+            ["python3", str(ROOT / "scripts/validate-app-compatibility.py"), "--base-ref", value["base_ref"]],
+            cwd=self.root, text=True, capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Increment revision", result.stderr)
+
+    def test_renamed_and_deleted_sources_still_trigger_tests(self):
+        self.write("StetMac/App.swift")
+        self.write("StetVisuals/old.metal")
+        base = self.commit()
+        self.git("mv", "StetMac/App.swift", "renamed.md")
+        self.git("rm", "StetVisuals/old.metal")
+        head = self.commit()
+        value = self.run_plan("push", {"before": base, "after": head})
+        self.assertEqual(set(value["paths"]), {"StetMac/App.swift", "renamed.md", "StetVisuals/old.metal"})
+        self.assertTrue(value["macos"])
+        self.assertTrue(value["quality"])
+
+    def test_large_diff_and_unusual_filenames(self):
+        for index in range(350):
+            self.write(f"docs/{index}.md")
+        self.write("StetMac/a file\nwith newline.swift")
+        head = self.commit()
+        value = self.run_plan("push", {"before": self.base, "after": head})
+        self.assertEqual(len(value["paths"]), 351)
+        self.assertIn("StetMac/a file\nwith newline.swift", value["paths"])
+        self.assertTrue(value["macos"])
+
+    def test_new_branch_and_empty_diff(self):
+        self.write("StetMac/App.swift")
+        head = self.commit()
+        value = self.run_plan("push", {"before": "0" * 40, "after": head})
+        self.assertTrue(value["macos"])
+        self.assertEqual(value["base_ref"], "")
+        value = self.run_plan("push", {"before": head, "after": head})
+        self.assertEqual(value["paths"], [])
+        self.assertFalse(value["macos"])
+
+    def test_missing_diff_ref_fails_instead_of_skipping_checks(self):
+        self.run_plan("push", {"before": "f" * 40, "after": self.base}, success=False)
+        self.run_plan("unknown", {}, success=False)
+
+
+class ResultGateTests(unittest.TestCase):
+    def test_actual_workflow_gate_rejects_failed_cancelled_or_missing_checks(self):
+        # Execute the workflow's real gate rather than a duplicate implementation.
+        workflow = (ROOT / ".github/workflows/monorepo-ci.yml").read_text()
+        code = textwrap.dedent(workflow.split("python3 - <<'PY'\n")[1].split("          PY")[0])
+        for plan_result, selected, job_result, passed in (
+            ("success", "true", "success", True),
+            ("success", "false", "skipped", True),
+            ("success", "true", "failure", False),
+            ("success", "true", "cancelled", False),
+            ("success", "true", "skipped", False),
+            ("success", "", "skipped", False),
+            ("failure", "false", "skipped", False),
+            ("cancelled", "false", "skipped", False),
+        ):
+            with self.subTest(plan_result=plan_result, selected=selected, job_result=job_result):
+                needs = {
+                    "changes": {"result": plan_result, "outputs": {"quality": selected, "macos": selected}},
+                    "quality": {"result": job_result}, "macos": {"result": job_result},
+                }
+                result = subprocess.run(
+                    ["python3", "-c", code], capture_output=True,
+                    env={**os.environ, "NEEDS_JSON": json.dumps(needs)},
+                )
+                self.assertEqual(result.returncode == 0, passed, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A compatibility-list or documentation change currently starts every macOS job, and the standalone Debug build repeats the application compilation already performed by `make test`.

Route jobs using a Linux repository-check job and the complete Git diff. List/docs changes stay on Linux; iOS Swift changes run the existing lint; macOS/shared inputs run the full existing build-and-test command. Unknown paths conservatively retain coverage. Remove the duplicate Debug build while preserving the test job's cache keys, coverage and complete test suite.

PR routing covers the whole branch via merge-base, while compatibility revisions are checked against the current base. Push routing covers `before` through `after`, including multiple commits, deletions and renames. Diff failures fail closed. Keep PR and post-merge integration runs, add workflow syntax checks and a final `CI Result` gate that rejects failed/cancelled/missing required jobs. Branch protection and release workflows are unchanged; iOS simulator builds remain local.

Validation:
- 17 CI-helper/regression tests passed, including real Git fixtures, large diffs, revision enforcement and execution of the actual result-gate code.
- Compatibility validator, harness entrypoint checks, actionlint 1.7.12 and `git diff --check` passed.
- Replaying the actual PR #64 diff selects no macOS or Swift Quality job.
- [Hosted full pipeline](https://github.com/DengNaichen/Stet/actions/runs/34561874842) passed all four checks on commit `7065c89`: repository checks 14s, Swift Quality 15s, macOS Tests 4m1s, CI Result 2s. The test log confirms 550 Swift tests in 82 suites plus the XCTest test passed.
- [Compatibility-only hosted probe](https://github.com/DengNaichen/Stet/actions/runs/34561945717) passed: repository checks 14s and CI Result 4s; Swift Quality and macOS Tests were both skipped. These are job durations, excluding queue time. Temporary PR #66 was closed without merging, and its branch/worktree were removed.

Maintainer note: if branch protection is enabled later, require `CI Result`; the redundant `macOS Build` check has been retired.
