### PR TITLE
CI verification: compatibility-only routing (do not merge)

### DIFF
--- a/StetMac/Resources/app-compatibility.json
+++ b/StetMac/Resources/app-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "revision": 2,
+  "revision": 3,
   "bundleIDs": [
     "com.microsoft.vscode",
     "com.microsoft.vscodeinsiders",


### PR DESCRIPTION
Temporary verification for #65. Only increments the compatibility revision to exercise Linux validation and skipped macOS jobs on GitHub Actions. This PR will be closed without merging after verification; it is not a published configuration update.