### PR TITLE
Simplify History with always-visible, color-coded transcripts

### DIFF
--- a/StetMac/Features/MacShell/Setting/MacHistorySettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacHistorySettingsView.swift
@@ -18,7 +18,6 @@
             return entries.filter {
                 ($0.rawText.lowercased().contains(q))
                     || ($0.llmText?.lowercased().contains(q) == true)
-                    || ($0.finalText?.lowercased().contains(q) == true)
                     || ($0.targetAppName?.lowercased().contains(q) == true)
                     || ($0.targetBundleID?.lowercased().contains(q) == true)
             }
@@ -108,7 +107,7 @@
             } else {
                 List(filtered, id: \.id) { entry in
                     HistoryEntryRow(entry: entry)
-                        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                        .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
                 }
                 .listStyle(.plain)
                 .macSettingsTracksTitleScroll()
@@ -158,107 +157,42 @@
     private struct HistoryEntryRow: View {
         let entry: HistoryEntry
 
-        @State private var isExpanded = false
-
         var body: some View {
-            VStack(alignment: .leading, spacing: 6) {
-                // Header row
-                HStack(spacing: 6) {
-                    statusBadge
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    Text(entry.timestamp, format: .dateTime.month(.twoDigits).day(.twoDigits))
                     if let appName = entry.targetAppName {
+                        Text("·")
                         Text(appName)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
                     }
-                    Spacer()
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
-                    } label: {
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .imageScale(.small)
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
                 }
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                // Primary text — always visible
-                Text(displayText)
-                    .font(.system(size: 13))
-                    .lineLimit(isExpanded ? nil : 2)
-                    .fixedSize(horizontal: false, vertical: isExpanded)
-
-                // Expanded detail
-                if isExpanded {
-                    expandedDetail
+                textStageRow(text: entry.rawText)
+                if let llm = entry.llmText {
+                    textStageRow(text: llm, isRefined: true)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
 
-        private var displayText: String {
-            entry.finalText ?? entry.llmText ?? entry.rawText
-        }
-
-        @ViewBuilder
-        private var statusBadge: some View {
-            let (label, color): (LocalizedStringKey, Color) = {
-                switch entry.status {
-                case .completed:
-                    return (LocalizedStringKey("Sent"), .green)
-                case .clipboardPending:
-                    return (LocalizedStringKey("Clipboard"), .orange)
-                case .processing:
-                    return (LocalizedStringKey("Transcribed"), .secondary)
-                case .notDelivered:
-                    return (LocalizedStringKey("Transcribed"), .secondary)
+        private func textStageRow(text: String, isRefined: Bool = false) -> some View {
+            let label: LocalizedStringKey = isRefined ? "LLM Refined" : "Transcription"
+            return Text(text)
+                .font(.system(size: 13))
+                .foregroundStyle(isRefined ? Color.primary : Color.secondary)
+                .lineSpacing(3)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+                .accessibilityLabel(Text("\(Text(label)): \(text)"))
+                .padding(.leading, 10)
+                .overlay(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(isRefined ? Color.accentColor : Color.secondary.opacity(0.35))
+                        .frame(width: 2)
+                        .accessibilityHidden(true)
                 }
-            }()
-            Text(label)
-                .font(.system(size: 10, weight: .medium))
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(color.opacity(0.15))
-                .foregroundStyle(color)
-                .clipShape(Capsule())
-        }
-
-        @ViewBuilder
-        private var expandedDetail: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                Divider()
-                textStageRow(label: LocalizedStringKey("Transcript"), text: entry.rawText)
-                if let llm = entry.llmText, llm != entry.rawText {
-                    textStageRow(label: LocalizedStringKey("LLM Refined"), text: llm)
-                }
-                if let final = entry.finalText {
-                    textStageRow(label: LocalizedStringKey("Delivered"), text: final)
-                }
-                if let bundleID = entry.targetBundleID {
-                    labeledRow(label: LocalizedStringKey("Target App"), value: bundleID)
-                }
-            }
-            .padding(.top, 2)
-        }
-
-        private func textStageRow(label: LocalizedStringKey, text: String) -> some View {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(label)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(text)
-                    .font(.system(size: 12))
-                    .textSelection(.enabled)
-            }
-        }
-
-        private func labeledRow(label: LocalizedStringKey, value: String) -> some View {
-            HStack(alignment: .top, spacing: 4) {
-                Text(label)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(value)
-                    .font(.caption)
-                    .textSelection(.enabled)
-            }
         }
     }
 #endif

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "Automatisch gelernt";
 "Manually added" = "Manuell hinzugefügt";
+
+/* History */
+"Transcription" = "Transkription";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -261,3 +261,6 @@
 "Update compatibility fixes for pasting into other apps." = "Update compatibility fixes for pasting into other apps.";
 "Updated" = "Updated";
 "Check failed. Using current list." = "Check failed. Using current list.";
+
+/* History */
+"Transcription" = "Transcription";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "Aprendido automáticamente";
 "Manually added" = "Añadido manualmente";
+
+/* History */
+"Transcription" = "Transcripción";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "Appris automatiquement";
 "Manually added" = "Ajouté manuellement";
+
+/* History */
+"Transcription" = "Transcription";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "Appreso automaticamente";
 "Manually added" = "Aggiunto manualmente";
+
+/* History */
+"Transcription" = "Trascrizione";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "自動学習";
 "Manually added" = "手動で追加";
+
+/* History */
+"Transcription" = "文字起こし";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "자동 학습";
 "Manually added" = "직접 추가";
+
+/* History */
+"Transcription" = "전사";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 
 "Automatically learned" = "Aprendido automaticamente";
 "Manually added" = "Adicionado manualmente";
+
+/* History */
+"Transcription" = "Transcrição";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -263,3 +263,6 @@
 "Update compatibility fixes for pasting into other apps." = "更新向其他应用粘贴文字时使用的兼容清单。";
 "Updated" = "已更新";
 "Check failed. Using current list." = "检查失败，继续使用当前清单。";
+
+/* History */
+"Transcription" = "转写";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -228,3 +228,6 @@
 "Update compatibility fixes for pasting into other apps." = "更新向其他應用程式貼上文字時使用的相容清單。";
 "Updated" = "已更新";
 "Check failed. Using current list." = "檢查失敗，繼續使用目前的清單。";
+
+/* History */
+"Transcription" = "轉寫";


### PR DESCRIPTION
History previously hid full transcripts behind an animated disclosure and repeated delivered text. This change shows each original transcript and optional LLM refinement in full, with selectable text and no expand/collapse interaction.

Original text uses gray styling; refined text uses the normal foreground with a theme-color rule. Visible stage headings and delivery badges are removed, while localized accessibility labels retain the stage names. Each entry shows only month/day and the target app when available. Search matches transcript/refined text and app metadata; stored delivery data and JSON export remain intact.

Validation:
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` passed (includes the unsigned macOS build).
- `make lint` and `git diff --check` passed.
- Visually checked the actual row component in a standalone SwiftUI fixture with raw-only, refined, identical-output, and multiline records; verified accessible stage labels.

The original disclosure latency root cause remains unverified; the disclosure interaction has been removed. The signed `make build` path is unavailable locally because the Debug provisioning profile is missing.
