### PR TITLE
Restore volume-responsive scaling on the watercolor orb

### DIFF
--- a/StetMac/Features/MacShell/DictationPanel/MacDictationPanelViewModel.swift
+++ b/StetMac/Features/MacShell/DictationPanel/MacDictationPanelViewModel.swift
@@ -5,12 +5,6 @@
 
     @MainActor
     final class MacDictationPanelViewModel: ObservableObject {
-        private enum CapsuleScaleTuning {
-            static let minimumListeningScale: CGFloat = 0.98
-            static let maximumListeningScale: CGFloat = 1.08
-            static let easingPower = 0.4
-        }
-
         private let appModel: any MacDictationPanelCoordinating
         private var cancellables = Set<AnyCancellable>()
 
@@ -19,10 +13,6 @@
         @Published private(set) var recordingLevel: Double
         @Published private(set) var visualSignals: MacDictationPanelVisualSignals
         @Published private(set) var detectedTargetApplication: AppInfo?
-
-        var capsuleScale: CGFloat {
-            Self.capsuleScale(for: state, recordingLevel: recordingLevel)
-        }
 
         var displayState: DictationState {
             Self.displayState(for: state, recordingLevel: recordingLevel)
@@ -63,23 +53,6 @@
                 return appModel.audioFeatures.scaled(by: 0.35)
             case .idle, .clipboardPending, .result, .error:
                 return .zero
-            }
-        }
-
-        private static func capsuleScale(
-            for state: DictationState,
-            recordingLevel: Double
-        ) -> CGFloat {
-            switch state {
-            case .starting, .listening:
-                let clampedLevel = max(0, min(recordingLevel, 1))
-                let easedLevel = pow(clampedLevel, CapsuleScaleTuning.easingPower)
-                let scaleRange =
-                    CapsuleScaleTuning.maximumListeningScale - CapsuleScaleTuning.minimumListeningScale
-
-                return CapsuleScaleTuning.minimumListeningScale + (CGFloat(easedLevel) * scaleRange)
-            case .processing, .idle, .clipboardPending, .result, .error:
-                return 1
             }
         }
 

--- a/StetMacTests/Features/MacShell/MacDictationPanelViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/MacDictationPanelViewModelTests.swift
@@ -136,33 +136,6 @@ struct MacDictationPanelViewModelTests {
         #expect(appModel.performPrimaryActionCallCount == 1)
     }
 
-    @Test func capsuleScaleTracksListeningLevelAndResetsOutsideCapture() async {
-        let appModel = StubPanelModel(
-            dictationState: .listening,
-            statusText: "Listening...",
-            recordingLevel: 0.0
-        )
-        let viewModel = MacDictationPanelViewModel(appModel: appModel)
-
-        #expect(abs(viewModel.capsuleScale - 0.98) < 0.001)
-
-        appModel.recordingLevel = 1.0
-        appModel.emitUpdate()
-
-        #expect(
-            await TestSupport.eventually {
-                abs(viewModel.capsuleScale - 1.08) < 0.001
-            })
-
-        appModel.dictationState = .processing
-        appModel.emitUpdate()
-
-        #expect(
-            await TestSupport.eventually {
-                abs(viewModel.capsuleScale - 1.0) < 0.001
-            })
-    }
-
     @Test func displayStateShowsListeningWhenStartingCaptureIsAlreadyLive() async {
         let appModel = StubPanelModel(
             dictationState: .starting,

--- a/StetMacTests/StetVisuals/MacWatercolorOrbMotionTests.swift
+++ b/StetMacTests/StetVisuals/MacWatercolorOrbMotionTests.swift
@@ -6,6 +6,44 @@
 
     @Suite("Watercolor Orb Motion")
     struct MacWatercolorOrbMotionTests {
+        @Test func voiceScalesTheWholeOrbWithTheLegacyCurveButKeepsButtonsStable() {
+            var motion = MacWatercolorOrbMotion()
+            motion.setState(.starting)
+            advance(&motion, seconds: 3, level: 0)
+            #expect(abs(motion.frame.orbScale - 0.98) < 0.001)
+
+            motion.setState(.listening)
+            advance(&motion, seconds: 1, level: 0.08)
+            #expect(abs(motion.frame.orbScale - (0.98 + pow(0.08, 0.4) * 0.1)) < 0.001)
+            advance(&motion, seconds: 1, level: 1)
+            #expect(abs(motion.frame.orbDiameter - 69.12) < 0.001)
+            #expect(motion.frame.buttonDiameter == 28)
+            #expect(motion.frame.scale == 1)
+            #expect(motion.frame.orbDiameter < 106)
+
+            let loud = motion.frame.orbScale
+            motion.advance(by: 0.025, level: 0)
+            #expect(motion.frame.orbScale < loud && motion.frame.orbScale > 1.06)
+            advance(&motion, seconds: 3, level: 0)
+            #expect(abs(motion.frame.orbScale - 0.98) < 0.001)
+        }
+
+        @Test func voiceScaleStaysBoundedAndStopsForReducedMotion() {
+            var motion = MacWatercolorOrbMotion()
+            motion.setState(.listening)
+            for level in [2.0, -1.0, .nan, .infinity, 0.5] {
+                advance(&motion, seconds: 1, level: level)
+                #expect(motion.frame.orbScale.isFinite)
+                #expect((0.98...1.08).contains(motion.frame.orbScale))
+            }
+            motion.setState(.listening, reduceMotion: true)
+            #expect(motion.frame.orbScale == 1)
+            advance(&motion, seconds: 1, level: 1)
+            #expect(motion.frame.orbScale == 1)
+            motion.setState(.processing, reduceMotion: true)
+            #expect(motion.frame.orbDiameter == 44)
+        }
+
         @Test func microphoneMappingMatchesBrowserWithoutChangingManualLevel() {
             let background = MacDictationCapsuleVisualSignals(
                 bands: [], estimatedSummary: .init(level: 0.45, flowX: 0, flowY: 0, groupedBands: .zero),
@@ -75,6 +113,7 @@
             #expect(quiet.frame.phase > entry)
             #expect(quiet.frame.anchor == entry)
             #expect(abs(quiet.frame.diameter - 44) < 0.001)
+            #expect(abs(quiet.frame.orbDiameter - 44) < 0.001)
             #expect(abs(quiet.frame.motion - 0.4) < 0.001)
             #expect(quiet.frame.idleWave.x == 0)
         }
@@ -94,6 +133,7 @@
             motion.setState(.processing)
             #expect(motion.frame.phase == entry.phase)
             #expect(motion.frame.diameter == entry.diameter)
+            #expect(motion.frame.orbDiameter == entry.orbDiameter)
             motion.advance(by: 0.025, level: 0)
             #expect(motion.frame.diameter > 44 && motion.frame.diameter < 64)
 

--- a/StetVisuals/MacWatercolorOrbMotion.swift
+++ b/StetVisuals/MacWatercolorOrbMotion.swift
@@ -11,6 +11,9 @@
         static let thinkingPeriod = 2.6
         static let thinkingMotion = 0.40
         static let frameInterval = 1.0 / 40.0
+        static let minimumListeningScale = 0.98
+        static let maximumListeningScale = 1.08
+        static let listeningScalePower = 0.4
     }
 
     struct MacWatercolorOrbFrame: Equatable {
@@ -19,6 +22,7 @@
         var tone = 0.0
         var thinkingBlend = 0.0
         var idleWave = SIMD3<Double>.zero
+        var listeningScale = 1.0
 
         var diameter: Double {
             MacWatercolorOrbPreset.diameter
@@ -30,6 +34,9 @@
         }
 
         var scale: Double { diameter / MacWatercolorOrbPreset.diameter }
+        // Voice scales only the orb. Thinking still contracts the whole arrangement.
+        var orbScale: Double { scale * (1 + (listeningScale - 1) * (1 - thinkingBlend)) }
+        var orbDiameter: Double { MacWatercolorOrbPreset.diameter * orbScale }
         var buttonDiameter: Double { MacWatercolorOrbLayout.buttonDiameter * scale }
     }
 
@@ -60,6 +67,7 @@
             }
             self.state = state
             self.reduceMotion = reduceMotion
+            if reduceMotion || !isVisible { frame.listeningScale = 1 }
             if reduceMotion {
                 frame.thinkingBlend = state == .processing ? 1 : 0
                 frame.idleWave = .zero
@@ -75,7 +83,16 @@
             // A suspended/occluded window must not fast-forward through a large paint displacement.
             let dt = min(elapsed, 0.05)
             let thinking = state == .processing
-            if !thinking { speechLevel = level.isFinite ? min(1, max(0, level)) : 0 }
+            if !thinking {
+                speechLevel = level.isFinite ? min(1, max(0, level)) : 0
+                let targetScale =
+                    MacWatercolorOrbPreset.minimumListeningScale
+                    + pow(speechLevel, MacWatercolorOrbPreset.listeningScalePower)
+                    * (MacWatercolorOrbPreset.maximumListeningScale - MacWatercolorOrbPreset.minimumListeningScale)
+                frame.listeningScale = follow(
+                    frame.listeningScale, targetScale, dt, targetScale > frame.listeningScale ? 0.055 : 0.32
+                )
+            }
             frame.thinkingBlend = follow(frame.thinkingBlend, thinking ? 1 : 0, dt, 0.115)
             cycle = (cycle + dt).truncatingRemainder(dividingBy: MacWatercolorOrbPreset.thinkingPeriod)
             let sine = Self.thinkingLevel(at: cycle)

--- a/StetVisuals/MacWatercolorOrbView.swift
+++ b/StetVisuals/MacWatercolorOrbView.swift
@@ -41,8 +41,8 @@
                 }
             }
             .frame(width: 64, height: 64)
-            // Scaling the complete paint preserves the approved granule size during Thinking.
-            .scaleEffect(frame.scale)
+            // Scale the complete paint for voice response and the Thinking transition.
+            .scaleEffect(frame.orbScale)
             .allowsHitTesting(false)
         }
 
@@ -84,7 +84,7 @@
                             .disabled(model.state == .processing)
 
                             Color.clear
-                                .frame(width: motion.frame.diameter, height: motion.frame.diameter)
+                                .frame(width: motion.frame.orbDiameter, height: motion.frame.orbDiameter)
                                 .stetGlassEffect(in: Circle())
                                 .stetGlassID("main", in: glassNamespace)
                                 .allowsHitTesting(false)

--- a/docs/specs/watercolor-orb.md
+++ b/docs/specs/watercolor-orb.md
@@ -38,7 +38,11 @@ approved browser colors rather than going through this derived palette mapping.
 - **Starting / listening:** 64 pt. Normalized audio level drives the
   approved response: energy attack 55 ms / release 320 ms; pigment tone attack
   120 ms / release 580 ms; velocity follows `1.25 × (1 + 4 × energy)` over 240 ms.
-  The orb and buttons do not scale with microphone volume.
+  The whole orb (paint and its glass backing) scales with microphone volume using
+  the former capsule curve, `0.98 + 0.10 × level^0.4`: approximately 62.72–69.12 pt.
+  Scale follows the input with a 55 ms attack / 320 ms release. Buttons and their
+  hit targets remain steady while listening. The voice contribution blends out
+  with the existing Thinking transition, which still reaches 44 pt.
 - **A pause while listening:** stays in listening. After at least 650 ms of
   quiet input and low residual energy, gentle waves blend in over 600 ms. Their
   amplitudes and speed vary every 2.8–4.6 seconds; both waves travel in the same


### PR DESCRIPTION
Restore the former capsule’s volume-dependent size response on the current watercolor orb. During capture, the orb paint and glass backing follow the 0.98–1.08 scale curve with a 55 ms attack and 320 ms release. Buttons stay steady, and the voice contribution fades out during the existing transition to the 44 pt Thinking state.

Move the unused capsule scaling logic into the orb motion driver, update the visual spec, and cover scale bounds, invalid input, quiet/loud response, stable controls, transition continuity, and Reduce Motion.

Validation:
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test`: 551 tests in 82 suites passed, including the unsigned app build.
- `make lint` and `git diff --check`: passed.
- Native preview linked to the production StetVisuals framework: verified quiet/loud orb sizes, stable buttons, and loud speech → Thinking.
- Live microphone input and an installed release were not exercised; preview input was synthetic.
