### PR TITLE
Retire Whisper and download models from China-reachable hosts

### DIFF
--- a/Packages/StetEngine/Sources/StetCore/ModelDownloadMirror.swift
+++ b/Packages/StetEngine/Sources/StetCore/ModelDownloadMirror.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Rewrites Hugging Face model URLs onto China-reachable hosts and keeps the
+/// official host as fallback. GitHub releases stay as extra fallbacks.
+///
+/// ModelScope is used only for repositories verified to publish the same
+/// filenames. The sherpa-onnx speaker `.onnx` is not one of those.
+public enum ModelDownloadMirror: Sendable {
+    public static let huggingFaceOrigin = "huggingface.co"
+    public static let huggingFaceChinaOrigin = "hf-mirror.com"
+    public static let modelScopeOrigin = "www.modelscope.cn"
+
+    /// Hugging Face repos that host the same files on ModelScope.
+    private static let modelScopeRepos: Set<String> = [
+        "FunAudioLLM/Fun-ASR-Nano-GGUF",
+        "FunAudioLLM/fsmn-vad-GGUF",
+    ]
+
+    private static let chinaTimeZoneIdentifiers: Set<String> = [
+        "Asia/Shanghai",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "PRC",
+    ]
+
+    public static let urlSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        return URLSession(configuration: configuration)
+    }()
+
+    public static func prefersChinaMirrors(
+        locale: Locale = .current,
+        timeZone: TimeZone = .current
+    ) -> Bool {
+        if locale.region?.identifier == "CN" {
+            return true
+        }
+        return chinaTimeZoneIdentifiers.contains(timeZone.identifier)
+    }
+
+    public static func rewriting(_ url: URL, host: String) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.host = host
+        return components.url
+    }
+
+    public static func modelScopeURL(for huggingFaceURL: URL) -> URL? {
+        guard huggingFaceURL.host == huggingFaceOrigin else { return nil }
+        let parts = huggingFaceURL.path.split(separator: "/").map(String.init)
+        guard parts.count >= 5, parts[2] == "resolve" else { return nil }
+        let repo = "\(parts[0])/\(parts[1])"
+        guard modelScopeRepos.contains(repo) else { return nil }
+        let file = parts[4...].joined(separator: "/")
+        return URL(string: "https://\(modelScopeOrigin)/models/\(repo)/resolve/master/\(file)")
+    }
+
+    public static func candidates(
+        for official: URL,
+        prefersChina: Bool = prefersChinaMirrors()
+    ) -> [URL] {
+        guard official.host == huggingFaceOrigin else { return [official] }
+        let modelScope = modelScopeURL(for: official)
+        let mirror = rewriting(official, host: huggingFaceChinaOrigin)
+        if prefersChina {
+            return uniqued([modelScope, mirror, official].compactMap { $0 })
+        }
+        return uniqued([official, mirror].compactMap { $0 })
+    }
+
+    public static func candidates(
+        huggingFace official: URL,
+        github: URL,
+        prefersChina: Bool = prefersChinaMirrors()
+    ) -> [URL] {
+        let fromHuggingFace = candidates(for: official, prefersChina: prefersChina)
+        if prefersChina {
+            return uniqued(fromHuggingFace + [github])
+        }
+        return uniqued([github] + fromHuggingFace)
+    }
+
+    private static func uniqued(_ urls: [URL]) -> [URL] {
+        var seen = Set<URL>()
+        return urls.filter { seen.insert($0).inserted }
+    }
+}

--- a/Packages/StetEngine/Sources/StetCore/StoredTranscriptionEngine.swift
+++ b/Packages/StetEngine/Sources/StetCore/StoredTranscriptionEngine.swift
@@ -1,15 +1,16 @@
 import Foundation
 
+/// On-device engines the user can select. Retired raw values such as
+/// `localWhisper` and `sherpaOnnxSenseVoice` are not cases; loaders persist
+/// `.default` instead.
 public enum StoredTranscriptionEngine: String, CaseIterable, Sendable {
-    case fluidAudio
     case funASRNano
-    case localWhisper
+    case fluidAudio
 
     public var displayName: String {
         switch self {
-        case .fluidAudio: return "Parakeet V3"
         case .funASRNano: return "Fun-ASR Nano"
-        case .localWhisper: return "Whisper"
+        case .fluidAudio: return "Parakeet V3"
         }
     }
 

--- a/Packages/StetEngine/Sources/StetCore/TranscriptionEngine.swift
+++ b/Packages/StetEngine/Sources/StetCore/TranscriptionEngine.swift
@@ -3,13 +3,11 @@ import Foundation
 public enum TranscriptionEngine: Equatable, Sendable {
     case fluidAudio
     case funASRNano
-    case localWhisper(languageHint: String?)
 
     public var displayName: String {
         switch self {
         case .fluidAudio: "Parakeet V3"
         case .funASRNano: "Fun-ASR Nano"
-        case .localWhisper: "Whisper"
         }
     }
 }

--- a/Packages/StetEngine/Tests/StetCoreTests/ModelDownloadMirrorTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/ModelDownloadMirrorTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import StetCore
+
+struct ModelDownloadMirrorTests {
+    private let huggingFace = URL(
+        string: "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF/resolve/main/funasr-encoder-f16.gguf"
+    )!
+    private let vad = URL(
+        string: "https://huggingface.co/FunAudioLLM/fsmn-vad-GGUF/resolve/main/fsmn-vad.gguf"
+    )!
+    private let whisper = URL(
+        string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin"
+    )!
+    private let speaker = URL(
+        string:
+            "https://huggingface.co/csukuangfj/speaker-embedding-models/resolve/main/3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx"
+    )!
+    private let github = URL(
+        string:
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/model.onnx"
+    )!
+
+    @Test func chinaFunASRPrefersModelScopeThenHfMirror() {
+        let urls = ModelDownloadMirror.candidates(for: huggingFace, prefersChina: true)
+        #expect(urls.map(\.host) == ["www.modelscope.cn", "hf-mirror.com", "huggingface.co"])
+        #expect(
+            urls[0].absoluteString
+                == "https://www.modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-GGUF/resolve/master/funasr-encoder-f16.gguf"
+        )
+        #expect(urls[1].path == huggingFace.path)
+        #expect(urls[2] == huggingFace)
+    }
+
+    @Test func chinaMapsVadOntoModelScope() {
+        let urls = ModelDownloadMirror.candidates(for: vad, prefersChina: true)
+        #expect(urls.first?.host == "www.modelscope.cn")
+        #expect(urls.first?.path.hasSuffix("/fsmn-vad.gguf") == true)
+    }
+
+    @Test func overseasPrefersOfficialHuggingFaceThenMirror() {
+        let urls = ModelDownloadMirror.candidates(for: huggingFace, prefersChina: false)
+        #expect(urls.map(\.host) == ["huggingface.co", "hf-mirror.com"])
+    }
+
+    @Test func whisperHasNoModelScopeCopy() {
+        #expect(ModelDownloadMirror.modelScopeURL(for: whisper) == nil)
+        let urls = ModelDownloadMirror.candidates(for: whisper, prefersChina: true)
+        #expect(urls.map(\.host) == ["hf-mirror.com", "huggingface.co"])
+    }
+
+    @Test func speakerOnnxHasNoModelScopeCopy() {
+        #expect(ModelDownloadMirror.modelScopeURL(for: speaker) == nil)
+        let urls = ModelDownloadMirror.candidates(
+            huggingFace: speaker,
+            github: github,
+            prefersChina: true
+        )
+        #expect(urls.map(\.host) == ["hf-mirror.com", "huggingface.co", "github.com"])
+    }
+
+    @Test func nonHuggingFaceURLsStayUnchanged() {
+        #expect(ModelDownloadMirror.candidates(for: github, prefersChina: true) == [github])
+    }
+
+    @Test func chinaSpeakerDownloadsTryHuggingFaceBeforeGitHub() {
+        let urls = ModelDownloadMirror.candidates(
+            huggingFace: huggingFace,
+            github: github,
+            prefersChina: true
+        )
+        #expect(urls.map(\.host) == ["www.modelscope.cn", "hf-mirror.com", "huggingface.co", "github.com"])
+    }
+
+    @Test func overseasSpeakerDownloadsTryGitHubBeforeHuggingFace() {
+        let urls = ModelDownloadMirror.candidates(
+            huggingFace: huggingFace,
+            github: github,
+            prefersChina: false
+        )
+        #expect(urls.map(\.host) == ["github.com", "huggingface.co", "hf-mirror.com"])
+    }
+
+    @Test func prefersChinaWhenRegionIsChina() throws {
+        let locale = Locale(identifier: "en_CN")
+        let timeZone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        #expect(ModelDownloadMirror.prefersChinaMirrors(locale: locale, timeZone: timeZone))
+    }
+
+    @Test func prefersChinaWhenTimeZoneIsShanghai() throws {
+        let locale = Locale(identifier: "en_US")
+        let timeZone = try #require(TimeZone(identifier: "Asia/Shanghai"))
+        #expect(ModelDownloadMirror.prefersChinaMirrors(locale: locale, timeZone: timeZone))
+    }
+
+    @Test func doesNotPreferChinaForUnitedStates() throws {
+        let locale = Locale(identifier: "en_US")
+        let timeZone = try #require(TimeZone(identifier: "America/New_York"))
+        #expect(!ModelDownloadMirror.prefersChinaMirrors(locale: locale, timeZone: timeZone))
+    }
+}

--- a/Packages/StetEngine/Tests/StetCoreTests/StoredTranscriptionEngineTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/StoredTranscriptionEngineTests.swift
@@ -4,9 +4,10 @@ import Testing
 
 @Suite("Stored Transcription Engine")
 struct StoredTranscriptionEngineTests {
-    @Test func supportedCasesAndDefaultExcludeRetiredSenseVoice() {
-        #expect(StoredTranscriptionEngine.allCases == [.fluidAudio, .funASRNano, .localWhisper])
+    @Test func supportedCasesExcludeRetiredEngines() {
+        #expect(StoredTranscriptionEngine.allCases == [.funASRNano, .fluidAudio])
         #expect(StoredTranscriptionEngine.default == .funASRNano)
         #expect(StoredTranscriptionEngine(rawValue: "sherpaOnnxSenseVoice") == nil)
+        #expect(StoredTranscriptionEngine(rawValue: "localWhisper") == nil)
     }
 }

--- a/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
+++ b/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
@@ -73,10 +73,7 @@ struct DictationPipelineFactory: Sendable {
         case .direct(let direct):
             transcriptionService = try makeLocalTranscriptionService()
 
-            transcriptionLanguageCode =
-                snapshot.transcriptionEngine == .localWhisper
-                ? nil
-                : snapshot.transcriptionPrimaryLanguage
+            transcriptionLanguageCode = snapshot.transcriptionPrimaryLanguage
             preferredSpellings = direct.preferredSpellings
             promptProvider = Self.makePromptProvider(preferredSpellings: preferredSpellings)
             usesAudienceAwareLocalPrompts = true

--- a/StetMac/Core/DictationPipeline/LocalTranscriptionServiceFactory.swift
+++ b/StetMac/Core/DictationPipeline/LocalTranscriptionServiceFactory.swift
@@ -1,14 +1,14 @@
-import Foundation
-import StetCore
-import os
+#if os(macOS)
+    import Foundation
+    import StetCore
+    import os
 
-/// Deep module for selecting and preparing the local transcription engine.
-/// Its interface is one configuration in, one ready service out; fallback and diagnostics stay local.
-struct LocalTranscriptionServiceFactory: Sendable {
-    nonisolated static func make(
-        configuration: any ModelStorageConfiguration = UserDefaultsModelStorage()
-    ) throws -> any AudioFileTranscriptionService {
-        #if os(macOS)
+    /// Deep module for selecting and preparing the local transcription engine.
+    /// Parakeet falls back to Fun-ASR Nano; Fun-ASR has no further fallback.
+    struct LocalTranscriptionServiceFactory: Sendable {
+        nonisolated static func make(
+            configuration: any ModelStorageConfiguration = UserDefaultsModelStorage()
+        ) throws -> any AudioFileTranscriptionService {
             let stored = configuration.transcriptionEngine
             let logger = Logger(
                 subsystem: Bundle.main.bundleIdentifier ?? "com.openwhispr.Stet",
@@ -18,41 +18,17 @@ struct LocalTranscriptionServiceFactory: Sendable {
 
             switch stored {
             case .fluidAudio:
-                return try makeWithFallback(logger: logger, configuration: configuration) {
-                    try FluidAudioTranscriptionService()
+                do {
+                    return try FluidAudioTranscriptionService()
+                } catch {
+                    logger.warning(
+                        "Selected transcription engine unavailable (\(error.localizedDescription)); falling back to Fun-ASR Nano."
+                    )
+                    return try FunASRNanoTranscriptionService()
                 }
             case .funASRNano:
-                return try makeWithFallback(logger: logger, configuration: configuration) {
-                    try FunASRNanoTranscriptionService()
-                }
-            case .localWhisper:
-                return try LocalWhisperTranscriptionService(
-                    modelManager: LocalWhisperModelManager(configuration: configuration)
-                )
-            }
-        #else
-            return try LocalWhisperTranscriptionService(
-                modelManager: LocalWhisperModelManager(configuration: configuration)
-            )
-        #endif
-    }
-
-    #if os(macOS)
-        private nonisolated static func makeWithFallback(
-            logger: Logger,
-            configuration: any ModelStorageConfiguration,
-            makePrimary: () throws -> any AudioFileTranscriptionService
-        ) throws -> any AudioFileTranscriptionService {
-            do {
-                return try makePrimary()
-            } catch {
-                logger.warning(
-                    "Selected transcription engine unavailable (\(error.localizedDescription)); falling back to local whisper."
-                )
-                return try LocalWhisperTranscriptionService(
-                    modelManager: LocalWhisperModelManager(configuration: configuration)
-                )
+                return try FunASRNanoTranscriptionService()
             }
         }
-    #endif
-}
+    }
+#endif

--- a/StetMac/Core/FluidAudio/FluidAudioModelManager.swift
+++ b/StetMac/Core/FluidAudio/FluidAudioModelManager.swift
@@ -1,5 +1,6 @@
 import FluidAudio
 import Foundation
+import StetCore
 
 /// Manages the NVIDIA Parakeet V3 multilingual model via the FluidAudio SPM
 /// package. Scope is intentionally narrow: a single hardcoded version (`v3`),
@@ -11,12 +12,19 @@ struct FluidAudioModelManager: Sendable {
 
     nonisolated init() {}
 
+    nonisolated static func configureDownloadRegistry() {
+        if ModelDownloadMirror.prefersChinaMirrors() {
+            ModelRegistry.baseURL = "https://\(ModelDownloadMirror.huggingFaceChinaOrigin)"
+        }
+    }
+
     nonisolated func isModelDownloaded() -> Bool {
         let cacheDirectory = AsrModels.defaultCacheDirectory(for: Self.version)
         return AsrModels.modelsExist(at: cacheDirectory, version: Self.version)
     }
 
     func downloadModel() async throws {
+        Self.configureDownloadRegistry()
         _ = try await AsrModels.downloadAndLoad(version: Self.version)
     }
 

--- a/StetMac/Core/FluidAudio/FluidAudioPassiveSpeechAnalyzer.swift
+++ b/StetMac/Core/FluidAudio/FluidAudioPassiveSpeechAnalyzer.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
     @preconcurrency import FluidAudio
     import Foundation
+    import StetCore
 
     nonisolated enum PassiveVoiceActivityEvent: Equatable, Sendable {
         case speechStarted(sampleIndex: Int)
@@ -72,6 +73,7 @@
             speechEndSilence: TimeInterval = 1.0,
             sortformerConfig: SortformerConfig = .default
         ) async throws -> FluidAudioPassiveSpeechAnalyzer {
+            FluidAudioModelManager.configureDownloadRegistry()
             let vadManager = try await VadManager(
                 config: VadConfig(defaultThreshold: vadProbabilityThreshold)
             )

--- a/StetMac/Core/FluidAudio/FluidAudioTranscriptionService.swift
+++ b/StetMac/Core/FluidAudio/FluidAudioTranscriptionService.swift
@@ -13,7 +13,7 @@
         nonisolated var errorDescription: String? {
             switch self {
             case .modelNotDownloaded:
-                return "Parakeet model is not downloaded. Open Settings → Local Whisper → Download to install it."
+                return "Parakeet model is not downloaded. Open Settings → Local Transcription and download it."
             case .audioPreparationFailed:
                 return "Stet could not prepare audio for Parakeet transcription."
             case .transcriptionFailed(let message):

--- a/StetMac/Core/FunASR/FunASRNanoModelManager.swift
+++ b/StetMac/Core/FunASR/FunASRNanoModelManager.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
     import Foundation
     import StetASR
+    import StetCore
 
     enum FunASRNanoModelError: LocalizedError, Equatable, Sendable {
         case modelDirectoryUnavailable
@@ -77,8 +78,30 @@
                 }
             self.downloadProvider =
                 downloadProvider ?? { url in
-                    try await URLSession.shared.download(from: url)
+                    try await Self.downloadUsingMirrors(official: url)
                 }
+        }
+
+        private static func downloadUsingMirrors(official: URL) async throws -> (URL, URLResponse) {
+            var lastError: Error?
+            for url in ModelDownloadMirror.candidates(for: official) {
+                do {
+                    let (file, response) = try await ModelDownloadMirror.urlSession.download(from: url)
+                    if let httpResponse = response as? HTTPURLResponse,
+                        (200...299).contains(httpResponse.statusCode)
+                    {
+                        return (file, response)
+                    }
+                    try? FileManager.default.removeItem(at: file)
+                    lastError = FunASRNanoModelError.invalidDownloadResponse(
+                        url,
+                        statusCode: (response as? HTTPURLResponse)?.statusCode
+                    )
+                } catch {
+                    lastError = error
+                }
+            }
+            throw lastError ?? FunASRNanoModelError.invalidDownloadResponse(official, statusCode: nil)
         }
 
         nonisolated func modelFiles() throws -> FunASRNanoModelFiles {

--- a/StetMac/Core/LocalWhisper/LocalWhisperModelManager.swift
+++ b/StetMac/Core/LocalWhisper/LocalWhisperModelManager.swift
@@ -332,7 +332,15 @@ struct LocalWhisperModelManager: Sendable {
         _ url: URL,
         progressSink: LocalWhisperDownloadProgressSink
     ) async throws -> URL {
-        try await downloadFile(from: url, progressSink: progressSink)
+        var lastError: Error = LocalWhisperError.downloadFailed(url)
+        for candidate in ModelDownloadMirror.candidates(for: url) {
+            do {
+                return try await downloadFile(from: candidate, progressSink: progressSink)
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError
     }
 }
 
@@ -368,6 +376,7 @@ private final class ProgressReportingDownloadCoordinator: NSObject, URLSessionDo
             self.continuation = continuation
 
             let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = 30
             let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
             self.session = session
 
@@ -401,6 +410,18 @@ private final class ProgressReportingDownloadCoordinator: NSObject, URLSessionDo
         downloadTask: URLSessionDownloadTask,
         didFinishDownloadingTo location: URL
     ) {
+        if let httpResponse = downloadTask.response as? HTTPURLResponse,
+            !(200...299).contains(httpResponse.statusCode)
+        {
+            resumeIfNeeded(
+                with: LocalWhisperError.invalidDownloadResponse(
+                    requestURL,
+                    statusCode: httpResponse.statusCode
+                )
+            )
+            return
+        }
+
         do {
             let fileManager = FileManager.default
             if fileManager.fileExists(atPath: stagedDownloadURL.path) {

--- a/StetMac/Core/LocalWhisper/LocalWhisperWarmupCoordinator.swift
+++ b/StetMac/Core/LocalWhisper/LocalWhisperWarmupCoordinator.swift
@@ -61,21 +61,6 @@
         func activateIfNeeded() {
             guard !hasActivated else { return }
             hasActivated = true
-
-            guard configuration.transcriptionEngine == .localWhisper else {
-                return
-            }
-
-            scheduleWarmup(after: startupWarmupDelay)
-            wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
-                forName: NSWorkspace.didWakeNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.scheduleWarmup(after: self?.startupWarmupDelay ?? 3)
-                }
-            }
         }
 
         func warmup() async throws {
@@ -102,10 +87,6 @@
         }
 
         private func performWarmupIfPossible(logMessage: StaticString) async throws {
-            guard configuration.transcriptionEngine == .localWhisper else {
-                return
-            }
-
             guard let sampleURL = sampleURLProvider() else {
                 return
             }

--- a/StetMac/Core/Speech/SpeakerEmbeddingModelManager.swift
+++ b/StetMac/Core/Speech/SpeakerEmbeddingModelManager.swift
@@ -4,6 +4,7 @@
     import FluidAudio
     import Foundation
     import StetASR
+    import StetCore
 
     struct SpeakerEnrollmentEmbedding: Sendable {
         let model: SpeakerEmbeddingModelIdentity
@@ -29,9 +30,13 @@
 
     actor SpeakerEmbeddingModelManager {
         private static let modelFileName = "3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx"
-        private static let modelDownloadURL = URL(
+        private static let githubModelDownloadURL = URL(
             string:
                 "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/\(modelFileName)"
+        )!
+        private static let huggingFaceModelDownloadURL = URL(
+            string:
+                "https://huggingface.co/csukuangfj/speaker-embedding-models/resolve/main/\(modelFileName)"
         )!
 
         private var loadedRecognizer: SpeakerEmbeddingRecognizer?
@@ -78,18 +83,34 @@
             }
 
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            let (temporaryURL, response) = try await URLSession.shared.download(from: modelDownloadURL)
-            guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
-                try? FileManager.default.removeItem(at: temporaryURL)
-                throw SpeakerEmbeddingModelManagerError.modelDownloadFailed
+            var lastError: Error = SpeakerEmbeddingModelManagerError.modelDownloadFailed
+            let downloadURLs = ModelDownloadMirror.candidates(
+                huggingFace: huggingFaceModelDownloadURL,
+                github: githubModelDownloadURL
+            )
+            for url in downloadURLs {
+                do {
+                    let (temporaryURL, response) = try await ModelDownloadMirror.urlSession.download(from: url)
+                    guard let response = response as? HTTPURLResponse,
+                        (200...299).contains(response.statusCode)
+                    else {
+                        try? FileManager.default.removeItem(at: temporaryURL)
+                        lastError = SpeakerEmbeddingModelManagerError.modelDownloadFailed
+                        continue
+                    }
+                    do {
+                        try FileManager.default.moveItem(at: temporaryURL, to: destination)
+                    } catch {
+                        try? FileManager.default.removeItem(at: temporaryURL)
+                        lastError = error
+                        continue
+                    }
+                    return destination
+                } catch {
+                    lastError = error
+                }
             }
-            do {
-                try FileManager.default.moveItem(at: temporaryURL, to: destination)
-            } catch {
-                try? FileManager.default.removeItem(at: temporaryURL)
-                throw error
-            }
-            return destination
+            throw lastError
         }
     }
 

--- a/StetMac/Features/MacShell/AudioSetting/MacAudioSettingsViewModel.swift
+++ b/StetMac/Features/MacShell/AudioSetting/MacAudioSettingsViewModel.swift
@@ -26,10 +26,6 @@
             }
         }
 
-        @Published private(set) var isWhisperDownloaded = false
-        @Published private(set) var isWhisperDownloading = false
-        @Published private(set) var whisperErrorMessage: String?
-
         @Published private(set) var isParakeetDownloaded = false
         @Published private(set) var isParakeetDownloading = false
         @Published private(set) var parakeetErrorMessage: String?
@@ -55,7 +51,6 @@
         private let extractEnrollmentEmbedding: @Sendable (URL) async throws -> SpeakerEnrollmentEmbedding
         private var enrollmentEmbeddings: [SpeakerEnrollmentEmbedding] = []
 
-        private let localWhisperModelManager: LocalWhisperModelManager
         private let fluidAudioModelManager: FluidAudioModelManager
         private let funASRNanoModelManager: FunASRNanoModelManager
 
@@ -63,7 +58,6 @@
             deviceManager: AudioDeviceSelectionManager = .shared,
             microphoneTestService: MicrophoneTestService = DefaultMicrophoneTestService.shared,
             settingsStore: DictationSettingsStore = DictationSettingsStore(),
-            configuration: any ModelStorageConfiguration = UserDefaultsModelStorage(),
             speakerProfileStore: SpeakerProfileStore = SpeakerProfileStore(),
             extractEnrollmentEmbedding: (@Sendable (URL) async throws -> SpeakerEnrollmentEmbedding)? = nil
         ) {
@@ -77,7 +71,6 @@
                 extractEnrollmentEmbedding ?? { url in
                     try await defaultEmbeddingService.extract(from: url)
                 }
-            self.localWhisperModelManager = LocalWhisperModelManager(configuration: configuration)
             self.fluidAudioModelManager = FluidAudioModelManager()
             self.funASRNanoModelManager = FunASRNanoModelManager()
         }
@@ -87,7 +80,6 @@
             deviceManager.refreshDevices()
             AudioDeviceChangeMonitor.shared.startMonitoring()
 
-            isWhisperDownloaded = (try? localWhisperModelManager.defaultModelReady()) ?? false
             isParakeetDownloaded = fluidAudioModelManager.isModelDownloaded()
             isFunASRNanoDownloaded = funASRNanoModelManager.isModelDownloaded()
             localTranscriptionEngine = settingsStore.loadTranscriptionEngine()
@@ -200,27 +192,6 @@
             isProcessingEnrollment = false
         }
 
-        func downloadWhisperModel() {
-            guard !isWhisperDownloading, !isWhisperDownloaded else { return }
-            isWhisperDownloading = true
-            whisperErrorMessage = nil
-
-            Task { [localWhisperModelManager] in
-                do {
-                    try await localWhisperModelManager.installDefaultModel()
-                    await MainActor.run {
-                        self.isWhisperDownloaded = (try? localWhisperModelManager.defaultModelReady()) ?? false
-                        self.isWhisperDownloading = false
-                    }
-                } catch {
-                    await MainActor.run {
-                        self.whisperErrorMessage = error.localizedDescription
-                        self.isWhisperDownloading = false
-                    }
-                }
-            }
-        }
-
         func downloadParakeetModel() {
             guard !isParakeetDownloading, !isParakeetDownloaded else { return }
             isParakeetDownloading = true
@@ -261,10 +232,6 @@
                     }
                 }
             }
-        }
-
-        func openWhisperFolder() {
-            revealInFinder(urlProvider: { try self.localWhisperModelManager.defaultModelURL() })
         }
 
         func openParakeetFolder() {

--- a/StetMac/Features/MacShell/AudioSetting/MacTranscriptionSettingsView.swift
+++ b/StetMac/Features/MacShell/AudioSetting/MacTranscriptionSettingsView.swift
@@ -26,7 +26,7 @@
 
                         if viewModel.localTranscriptionEngine == .fluidAudio, !viewModel.isParakeetDownloaded {
                             Text(
-                                "Parakeet model isn't downloaded yet. Stet will fall back to Whisper until you download it below."
+                                "Parakeet model isn't downloaded yet. Stet will fall back to Fun-ASR Nano until you download it below."
                             )
                             .font(.system(size: 11))
                             .foregroundStyle(.orange)
@@ -36,7 +36,7 @@
                             !viewModel.isFunASRNanoDownloaded
                         {
                             Text(
-                                "Fun-ASR Nano isn't downloaded yet. Stet will fall back to Whisper until you download it below."
+                                "Fun-ASR Nano isn't downloaded yet. Download it below before dictating."
                             )
                             .font(.system(size: 11))
                             .foregroundStyle(.orange)
@@ -46,12 +46,12 @@
 
                         VStack(spacing: 12) {
                             TranscriptionModelRow(
-                                name: "Whisper",
-                                isDownloaded: viewModel.isWhisperDownloaded,
-                                isDownloading: viewModel.isWhisperDownloading,
-                                errorMessage: viewModel.whisperErrorMessage,
-                                onDownload: { viewModel.downloadWhisperModel() },
-                                onReveal: { viewModel.openWhisperFolder() }
+                                name: "Fun-ASR Nano (Chinese / English / Japanese)",
+                                isDownloaded: viewModel.isFunASRNanoDownloaded,
+                                isDownloading: viewModel.isFunASRNanoDownloading,
+                                errorMessage: viewModel.funASRNanoErrorMessage,
+                                onDownload: { viewModel.downloadFunASRNanoModel() },
+                                onReveal: { viewModel.openFunASRNanoFolder() }
                             )
 
                             Divider()
@@ -63,17 +63,6 @@
                                 errorMessage: viewModel.parakeetErrorMessage,
                                 onDownload: { viewModel.downloadParakeetModel() },
                                 onReveal: { viewModel.openParakeetFolder() }
-                            )
-
-                            Divider()
-
-                            TranscriptionModelRow(
-                                name: "Fun-ASR Nano (Chinese / English / Japanese)",
-                                isDownloaded: viewModel.isFunASRNanoDownloaded,
-                                isDownloading: viewModel.isFunASRNanoDownloading,
-                                errorMessage: viewModel.funASRNanoErrorMessage,
-                                onDownload: { viewModel.downloadFunASRNanoModel() },
-                                onReveal: { viewModel.openFunASRNanoFolder() }
                             )
                         }
                     }

--- a/StetMac/Features/Onboarding/OnboardingViewModel.swift
+++ b/StetMac/Features/Onboarding/OnboardingViewModel.swift
@@ -42,7 +42,6 @@
         private let coordinator: any MacPermissionsCoordinating
         private let settingsStore: DictationSettingsStore
         private let credentialValidationService: any ProviderCredentialValidating
-        private let localWhisperModelManager: LocalWhisperModelManager
         private let fluidAudioModelManager: FluidAudioModelManager
         private let funASRNanoModelManager: FunASRNanoModelManager
         private var cancellables = Set<AnyCancellable>()
@@ -51,14 +50,12 @@
             coordinator: any MacPermissionsCoordinating,
             settingsStore: DictationSettingsStore = DictationSettingsStore(),
             credentialValidationService: (any ProviderCredentialValidating)? = nil,
-            localWhisperModelManager: LocalWhisperModelManager = LocalWhisperModelManager(),
             fluidAudioModelManager: FluidAudioModelManager = FluidAudioModelManager(),
             funASRNanoModelManager: FunASRNanoModelManager = FunASRNanoModelManager()
         ) {
             self.coordinator = coordinator
             self.settingsStore = settingsStore
             self.credentialValidationService = credentialValidationService ?? ProviderCredentialValidationService()
-            self.localWhisperModelManager = localWhisperModelManager
             self.fluidAudioModelManager = fluidAudioModelManager
             self.funASRNanoModelManager = funASRNanoModelManager
 
@@ -319,49 +316,6 @@
                         try? await LocalParakeetContextManager.shared.loadModel(version: .v3) { version in
                             try await AsrModels.loadFromCache(configuration: nil, version: version)
                         }
-                    }
-
-                case .localWhisper:
-                    if try localWhisperModelManager.defaultModelReady() {
-                        try localWhisperModelManager.removeDefaultEncoderIfPresent()
-                        localWhisperModelManager.saveCustomModelPath(nil)
-                        engineDownloadFraction = 1
-                        engineDownloadState = .ready
-                        settingsStore.saveTranscriptionEngine(.localWhisper)
-                        return
-                    }
-
-                    engineDownloadState = .running(stageText: "Checking existing assets...")
-                    try await localWhisperModelManager.installDefaultModel(
-                        progress: { [weak self] stage in
-                            Task { @MainActor [weak self, stage] in
-                                let stageText =
-                                    switch stage {
-                                    case .checkingExistingAssets: "Checking assets..."
-                                    case .downloadingModel: "Downloading Whisper..."
-                                    case .ready: "Ready"
-                                    }
-                                self?.engineDownloadState = .running(stageText: stageText)
-                            }
-                        },
-                        downloadProgress: { [weak self] fraction, completed, total in
-                            Task { @MainActor [weak self, fraction, completed, total] in
-                                self?.engineDownloadFraction = fraction
-                                self?.engineBytesCompleted = completed
-                                self?.engineBytesTotal = total
-                            }
-                        }
-                    )
-
-                    localWhisperModelManager.saveCustomModelPath(nil)
-                    engineDownloadFraction = 1
-                    engineDownloadState = .ready
-                    settingsStore.saveTranscriptionEngine(.localWhisper)
-
-                    // Trigger proactive high-priority background warm-up for Whisper
-                    Task.detached(priority: .userInitiated) { [localWhisperModelManager] in
-                        try? await localWhisperModelManager.installDefaultAssets()
-                        try? await LocalWhisperWarmupCoordinator.shared.warmup()
                     }
 
                 case .funASRNano:

--- a/StetMac/Features/Onboarding/Steps/OnboardingLanguageStep.swift
+++ b/StetMac/Features/Onboarding/Steps/OnboardingLanguageStep.swift
@@ -94,7 +94,7 @@
                         Image(
                             systemName: viewModel.transcriptionEngine == .fluidAudio
                                 ? "bolt.fill"
-                                : (viewModel.transcriptionEngine == .funASRNano ? "waveform" : "cpu")
+                                : "waveform"
                         )
                         .font(.title2)
                         .foregroundStyle(.blue)
@@ -106,9 +106,7 @@
                             Text(
                                 viewModel.transcriptionEngine == .fluidAudio
                                     ? "Optimized for speed and accuracy in these languages."
-                                    : (viewModel.transcriptionEngine == .funASRNano
-                                        ? "Fast local transcription for Chinese, English, and Japanese."
-                                        : "Highly accurate multilingual engine.")
+                                    : "Fast local transcription for Chinese, English, and Japanese."
                             )
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/StetMac/Shared/Utilities/DictationSettingsStore.swift
+++ b/StetMac/Shared/Utilities/DictationSettingsStore.swift
@@ -356,7 +356,11 @@ struct DictationSettingsStore: Sendable {
         guard let raw = defaultsStore.string(forKey: MacPreferences.transcriptionEngine) else {
             return .default
         }
-        return StoredTranscriptionEngine(rawValue: raw) ?? .default
+        if let engine = StoredTranscriptionEngine(rawValue: raw) {
+            return engine
+        }
+        saveTranscriptionEngine(.default)
+        return .default
     }
 
     nonisolated func saveTranscriptionEngine(_ engine: StoredTranscriptionEngine) {

--- a/StetMac/StetApp.swift
+++ b/StetMac/StetApp.swift
@@ -20,6 +20,7 @@ struct StetApp: App {
 
         init() {
             AnalyticsService.initialize()
+            FluidAudioModelManager.configureDownloadRegistry()
             let compatibilityStore = AppCompatibilityStore.live()
             _compatibilityStore = StateObject(wrappedValue: compatibilityStore)
             let appModel = MacAppModel(compatibilityStore: compatibilityStore)

--- a/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
+++ b/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
@@ -429,21 +429,13 @@ struct EngineSelectionRegressionTests {
         #expect(defaults.string(forKey: MacPreferences.transcriptionEngine) == "funASRNano")
     }
 
-    @Test func makePipelinePassesNilLanguageCodeToWhisper() async throws {
-        let local = RecordingTranscriptionService(result: "ok")
-        let factory = DictationPipelineFactory(
-            makeLocalTranscriptionService: { local },
-            makeRewriteService: { _, _ in RecordingRewriteService() }
-        )
-        let snapshot = makeSnapshot(
-            transcriptionPrimaryLanguage: "zh",
-            transcriptionSecondaryLanguage: nil,
-            transcriptionEngine: .localWhisper
-        )
+    @Test func retiredWhisperStoredEngineMigratesToNano() {
+        let defaults = TestSupport.makeUserDefaults()
+        defaults.set("localWhisper", forKey: MacPreferences.transcriptionEngine)
+        let storage = UserDefaultsModelStorage(defaults: defaults)
 
-        let pipeline = try await factory.makePipeline(from: snapshot)
-
-        #expect(pipeline.transcriptionLanguageCode == nil)
+        #expect(storage.transcriptionEngine == .funASRNano)
+        #expect(defaults.string(forKey: MacPreferences.transcriptionEngine) == "funASRNano")
     }
 }
 

--- a/StetMacTests/Core/LocalWhisper/LocalWhisperWarmupCoordinatorTests.swift
+++ b/StetMacTests/Core/LocalWhisper/LocalWhisperWarmupCoordinatorTests.swift
@@ -19,7 +19,6 @@
             try Data("sample".utf8).write(to: sampleURL)
 
             let configuration = UserDefaultsModelStorage(defaults: TestSupport.makeUserDefaults())
-            configuration.saveTranscriptionEngine(.localWhisper)
             let createdServices = CreatedWarmServices()
             let coordinator = LocalWhisperWarmupCoordinator(
                 configuration: configuration,
@@ -56,7 +55,6 @@
             try Data("sample".utf8).write(to: sampleURL)
 
             let configuration = UserDefaultsModelStorage(defaults: TestSupport.makeUserDefaults())
-            configuration.saveTranscriptionEngine(.localWhisper)
             let createdServices = CreatedWarmServices()
             let coordinator = LocalWhisperWarmupCoordinator(
                 configuration: configuration,

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -265,29 +265,25 @@ struct ConfigurableSpeechServiceTests {
         await service.cancelRecording()
     }
 
-    @Test func localWhisperModelMissingFailsBeforeCaptureStarts() async throws {
+    @Test func missingLocalModelFailsBeforeCaptureStarts() async throws {
         let (store, _, _) = try makeSettingsStore(
             rewriteProvider: .openAI,
             openAIAPIKey: "sk-test"
         )
         let capture = TestAudioCaptureService(audioFileURL: makeAudioFileURL())
+        let missingAssets = [URL(fileURLWithPath: "/tmp/funasr-encoder-f16.gguf")]
         let service = ConfigurableSpeechService(
             settingsStore: store,
             pipelineFactory: DictationPipelineFactory(
                 makeLocalTranscriptionService: {
-                    throw LocalWhisperError.modelMissing(
-                        expectedURL: URL(fileURLWithPath: "/tmp/ggml-large-v3-turbo-q5_0.bin")
-                    )
+                    throw FunASRNanoModelError.missingAssets(missingAssets)
                 },
                 makeRewriteService: { _, _ in RecordingRewriteService() }
             ),
             captureService: capture
         )
 
-        await #expect(
-            throws: LocalWhisperError.modelMissing(
-                expectedURL: URL(fileURLWithPath: "/tmp/ggml-large-v3-turbo-q5_0.bin"))
-        ) {
+        await #expect(throws: FunASRNanoModelError.missingAssets(missingAssets)) {
             try await service.startRecording()
         }
 

--- a/StetMacTests/Features/MacShell/AudioSetting/MacAudioSettingsViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/AudioSetting/MacAudioSettingsViewModelTests.swift
@@ -15,9 +15,8 @@
 
             #expect(
                 viewModel.localTranscriptionEngineOptions == [
-                    .fluidAudio,
                     .funASRNano,
-                    .localWhisper,
+                    .fluidAudio,
                 ]
             )
         }
@@ -28,21 +27,39 @@
                 defaults: defaults,
                 secretStore: TestSecretStore()
             )
-            settingsStore.saveTranscriptionEngine(.localWhisper)
+            settingsStore.saveTranscriptionEngine(.funASRNano)
             let viewModel = MacAudioSettingsViewModel(
-                settingsStore: settingsStore,
-                configuration: UserDefaultsModelStorage(defaults: defaults)
+                settingsStore: settingsStore
             )
 
             viewModel.onAppear()
             defer { viewModel.onDisappear() }
 
-            #expect(viewModel.localTranscriptionEngine == .localWhisper)
-            #expect(settingsStore.loadTranscriptionEngine() == .localWhisper)
+            #expect(viewModel.localTranscriptionEngine == .funASRNano)
+            #expect(settingsStore.loadTranscriptionEngine() == .funASRNano)
 
             viewModel.localTranscriptionEngine = .fluidAudio
 
             #expect(settingsStore.loadTranscriptionEngine() == .fluidAudio)
+        }
+
+        @Test func retiredWhisperEngineMigratesToNano() {
+            let defaults = TestSupport.makeUserDefaults()
+            defaults.set("localWhisper", forKey: MacPreferences.transcriptionEngine)
+            let settingsStore = DictationSettingsStore(
+                defaults: defaults,
+                secretStore: TestSecretStore()
+            )
+            let viewModel = MacAudioSettingsViewModel(
+                settingsStore: settingsStore
+            )
+
+            viewModel.onAppear()
+            defer { viewModel.onDisappear() }
+
+            #expect(viewModel.localTranscriptionEngine == .funASRNano)
+            #expect(settingsStore.loadTranscriptionEngine() == .funASRNano)
+            #expect(defaults.string(forKey: MacPreferences.transcriptionEngine) == "funASRNano")
         }
 
         @Test func passiveListeningDefaultsOnAndPersistsExplicitChanges() {
@@ -52,8 +69,7 @@
                 secretStore: TestSecretStore()
             )
             let viewModel = MacAudioSettingsViewModel(
-                settingsStore: settingsStore,
-                configuration: UserDefaultsModelStorage(defaults: defaults)
+                settingsStore: settingsStore
             )
 
             viewModel.onAppear()

--- a/scripts/speaker_verification_probe.py
+++ b/scripts/speaker_verification_probe.py
@@ -31,10 +31,19 @@ from typing import Any, Sequence
 
 
 MODEL_NAME = "3dspeaker_speech_campplus_sv_zh-cn_16k-common.onnx"
-MODEL_URL = (
+HF_MODEL_URL = (
+    "https://huggingface.co/csukuangfj/speaker-embedding-models/resolve/main/"
+    f"{MODEL_NAME}"
+)
+HF_MIRROR_URL = (
+    "https://hf-mirror.com/csukuangfj/speaker-embedding-models/resolve/main/"
+    f"{MODEL_NAME}"
+)
+GITHUB_MODEL_URL = (
     "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
     f"speaker-recongition-models/{MODEL_NAME}"
 )
+MODEL_URLS = (HF_MIRROR_URL, HF_MODEL_URL, GITHUB_MODEL_URL)
 DEFAULT_MODEL_PATH = Path.home() / "Library" / "Caches" / "StetSpeakerProbe" / MODEL_NAME
 
 
@@ -154,12 +163,18 @@ def ensure_model(model: Path | None) -> Path:
     DEFAULT_MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
     partial = DEFAULT_MODEL_PATH.with_suffix(".part")
     print(f"Downloading speaker model to {DEFAULT_MODEL_PATH}")
-    try:
-        urllib.request.urlretrieve(MODEL_URL, partial)
-        partial.replace(DEFAULT_MODEL_PATH)
-    except Exception:
-        partial.unlink(missing_ok=True)
-        raise
+    last_error: Exception | None = None
+    for model_url in MODEL_URLS:
+        try:
+            urllib.request.urlretrieve(model_url, partial)
+            partial.replace(DEFAULT_MODEL_PATH)
+            last_error = None
+            break
+        except Exception as error:
+            last_error = error
+            partial.unlink(missing_ok=True)
+    if last_error is not None:
+        raise last_error
     return DEFAULT_MODEL_PATH
 
 


### PR DESCRIPTION
## Summary
- Remove Whisper from the selectable engines, settings, onboarding, and fallback path. Fun-ASR Nano is the default and last local fallback; existing `localWhisper` settings migrate to it.
- Download Fun-ASR, Parakeet, and speaker-embedding models from region-aware hosts: mainland China tries ModelScope and hf-mirror before Hugging Face; other regions still prefer the official host.

## Test plan
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (552 StetTests)
- [x] `swift test` in `Packages/StetEngine` (66 tests)
- [ ] On a China-region Mac (or `Asia/Shanghai` timezone), start onboarding and confirm Fun-ASR downloads from ModelScope/hf-mirror instead of hanging on huggingface.co
- [ ] Confirm Settings → Local Transcription lists only Fun-ASR Nano and Parakeet V3, with Fun-ASR as default
- [ ] With a leftover `localWhisper` UserDefaults value, launch Settings and confirm it migrates to Fun-ASR Nano
- [ ] Select Parakeet without the model downloaded and confirm dictation falls back to Fun-ASR Nano rather than Whisper


Made with [Cursor](https://cursor.com)