### PR TITLE
Import glossaries and cap Fun-ASR Nano hotwords

### DIFF
--- a/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
+++ b/Packages/StetEngine/Sources/StetCore/DictationHistoryService.swift
@@ -6,6 +6,7 @@ import SwiftData
 public protocol DictationHistoryRecording: AnyObject {
     func recordRaw(_ text: String)
     func recordLLM(_ text: String)
+    func recordRawWithoutHotwords(_ text: String)
     @discardableResult
     func commitPending() -> UUID?
 }
@@ -26,6 +27,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
     /// Ephemeral value type that accumulates data across the three pipeline stages.
     private struct PendingSession {
         var rawText: String
+        var rawTextWithoutHotwords: String?
         var llmText: String?
         var finalText: String?
         var targetBundleID: String?
@@ -45,6 +47,8 @@ public final class DictationHistoryService: DictationHistoryRecording {
     private let container: ModelContainer?
     private var initializationError: Error?
     private var pending: PendingSession?
+    private var lastCommittedEntryID: UUID?
+    private var stagedRawTextWithoutHotwords: String?
 
     // MARK: - Init
 
@@ -101,11 +105,39 @@ public final class DictationHistoryService: DictationHistoryRecording {
             return
         }
         pending = PendingSession(rawText: trimmed)
+        lastCommittedEntryID = nil
+        if let staged = stagedRawTextWithoutHotwords {
+            pending?.rawTextWithoutHotwords = staged
+            stagedRawTextWithoutHotwords = nil
+        }
     }
 
     /// Called after the LLM transformer runs. Updates the pending session.
     public func recordLLM(_ text: String) {
         pending?.llmText = text
+    }
+
+    public func recordRawWithoutHotwords(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if var session = pending {
+            session.rawTextWithoutHotwords = trimmed
+            pending = session
+            if let id = session.persistedEntryID {
+                updateRawTextWithoutHotwords(id: id, text: trimmed)
+            }
+            return
+        }
+        if let id = lastCommittedEntryID {
+            updateRawTextWithoutHotwords(id: id, text: trimmed)
+            return
+        }
+        stagedRawTextWithoutHotwords = trimmed
+    }
+
+    /// Drops a no-hotword transcript that arrived before `recordRaw` for this utterance.
+    public func discardUncommittedNoHotwordTranscript() {
+        stagedRawTextWithoutHotwords = nil
     }
 
     /// Immediately persists the pending session with `.processing` status.
@@ -117,6 +149,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
         guard var session = pending else { return nil }
         let id = UUID()
         session.persistedEntryID = id
+        lastCommittedEntryID = id
         pending = session
         persistEntry(from: session, id: id, status: .processing)
         return id
@@ -140,6 +173,8 @@ public final class DictationHistoryService: DictationHistoryRecording {
     /// Call this when a capture is cancelled or results in an empty transcription.
     public func discardPendingSession() {
         pending = nil
+        lastCommittedEntryID = nil
+        stagedRawTextWithoutHotwords = nil
     }
 
     // MARK: - Query API
@@ -242,6 +277,7 @@ public final class DictationHistoryService: DictationHistoryRecording {
         guard let container else { return }
 
         let rawText = session.rawText
+        let rawTextWithoutHotwords = session.rawTextWithoutHotwords
         let llmText = session.llmText
         let timestamp = session.timestamp
 
@@ -251,11 +287,32 @@ public final class DictationHistoryService: DictationHistoryRecording {
                 id: id,
                 timestamp: timestamp,
                 rawText: rawText,
+                rawTextWithoutHotwords: rawTextWithoutHotwords,
                 llmText: llmText,
                 status: status
             )
             context.insert(entry)
             try? context.save()
+        }
+    }
+
+    private func updateRawTextWithoutHotwords(id: UUID, text: String) {
+        guard let container else { return }
+
+        Task.detached(priority: .background) {
+            for _ in 0..<20 {
+                let context = ModelContext(container)
+                var descriptor = FetchDescriptor<HistoryEntry>(
+                    predicate: #Predicate { $0.id == id }
+                )
+                descriptor.fetchLimit = 1
+                if let entry = try? context.fetch(descriptor).first {
+                    entry.rawTextWithoutHotwords = text
+                    try? context.save()
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
         }
     }
 

--- a/Packages/StetEngine/Sources/StetCore/DictionaryModel.swift
+++ b/Packages/StetEngine/Sources/StetCore/DictionaryModel.swift
@@ -4,6 +4,36 @@ public extension Notification.Name {
     static let dictionaryDidSync = Notification.Name("StetCore.DictionaryDidSync")
 }
 
+public struct DictionaryImportResult: Equatable, Sendable {
+    public let addedCount: Int
+    public let skippedCount: Int
+
+    public init(addedCount: Int, skippedCount: Int) {
+        self.addedCount = addedCount
+        self.skippedCount = skippedCount
+    }
+}
+
+public enum DictionaryImportError: Error, Equatable, LocalizedError {
+    case fileTooLarge(byteCount: Int)
+    case dictionaryWouldExceedLimit
+    case unreadable
+    case empty
+
+    public var errorDescription: String? {
+        switch self {
+        case .fileTooLarge:
+            return "This file is too large to import. Use a file smaller than 512 KB."
+        case .dictionaryWouldExceedLimit:
+            return "Importing these terms would make the synced dictionary too large."
+        case .unreadable:
+            return "Stet could not read that file as text."
+        case .empty:
+            return "That file does not contain any dictionary terms."
+        }
+    }
+}
+
 /// `UserDefaults` supports access from multiple threads and tasks, but is not
 /// declared `Sendable` by Foundation. Keep that unchecked boundary limited to
 /// the enabled-flag operations used by `DictionaryModel`.
@@ -180,6 +210,55 @@ public struct DictionaryModel: Sendable {
         syncedStore.updateRecords {
             GlossaryEntry.merging($0, terms: Self.words(from: rawInput), source: .manual)
         }.map(\.term)
+    }
+
+    public static let maximumImportFileByteCount = 512_000
+    public static let maximumStoredUTF8ByteCount = 800_000
+
+    public func importEntries(from rawInput: String) throws -> DictionaryImportResult {
+        let incoming = Self.words(from: rawInput)
+        guard !incoming.isEmpty else { throw DictionaryImportError.empty }
+        let existing = loadRecords()
+        let existingKeys = Set(existing.map { Self.lookupKey(for: $0.term) })
+        let uniqueIncoming = incoming.filter { !existingKeys.contains(Self.lookupKey(for: $0)) }
+        let merged = existing + uniqueIncoming.map { GlossaryEntry(term: $0, source: .manual) }
+        guard Self.encodedUTF8ByteCount(of: merged) <= Self.maximumStoredUTF8ByteCount else {
+            throw DictionaryImportError.dictionaryWouldExceedLimit
+        }
+        if !uniqueIncoming.isEmpty {
+            _ = addEntries(from: uniqueIncoming.joined(separator: "\n"))
+        }
+        return DictionaryImportResult(
+            addedCount: uniqueIncoming.count,
+            skippedCount: incoming.count - uniqueIncoming.count
+        )
+    }
+
+    public static func importText(from data: Data) throws -> String {
+        guard data.count <= maximumImportFileByteCount else {
+            throw DictionaryImportError.fileTooLarge(byteCount: data.count)
+        }
+        let text: String
+        if let utf8 = String(data: data, encoding: .utf8) {
+            text = utf8
+        } else if let utf16 = String(data: data, encoding: .utf16) {
+            text = utf16
+        } else {
+            throw DictionaryImportError.unreadable
+        }
+        return text.replacingOccurrences(of: "\u{FEFF}", with: "")
+    }
+
+    static func encodedUTF8ByteCount(of records: [GlossaryEntry]) -> Int {
+        let terms = records.map(\.term)
+        let sources = Dictionary(uniqueKeysWithValues: records.map { ($0.term, $0.source.rawValue) })
+        let termsSize =
+            (try? PropertyListSerialization.data(fromPropertyList: terms, format: .binary, options: 0).count)
+            ?? 0
+        let sourcesSize =
+            (try? PropertyListSerialization.data(fromPropertyList: sources, format: .binary, options: 0).count)
+            ?? 0
+        return termsSize + sourcesSize
     }
 
     @discardableResult

--- a/Packages/StetEngine/Sources/StetCore/FunASRNanoHotwordPrompt.swift
+++ b/Packages/StetEngine/Sources/StetCore/FunASRNanoHotwordPrompt.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Caps the Fun-ASR Nano hotword prompt so a large glossary cannot overflow
+/// the 512-token prefix batch. Rewrite still receives the full dictionary.
+public enum FunASRNanoHotwordPrompt: Sendable {
+    public static let maximumTermCount = 50
+    public static let maximumJoinedCharacterCount = 400
+
+    public static func selectedTerms(from records: [GlossaryEntry]) -> [String] {
+        let ordered =
+            records.filter { $0.source == .manual } + records.filter { $0.source != .manual }
+        var selected: [String] = []
+        var joined = ""
+        for record in ordered {
+            let next = selected.isEmpty ? record.term : joined + ", " + record.term
+            guard next.count <= maximumJoinedCharacterCount else { continue }
+            selected.append(record.term)
+            joined = next
+            if selected.count == maximumTermCount { break }
+        }
+        return selected
+    }
+
+    public static func makePrompt(from records: [GlossaryEntry]) -> String? {
+        let terms = selectedTerms(from: records)
+        guard !terms.isEmpty else { return nil }
+        return terms.joined(separator: ", ")
+    }
+
+    public static func records(from preferredSpellings: [String]) -> [GlossaryEntry] {
+        preferredSpellings.map { GlossaryEntry(term: $0, source: .manual) }
+    }
+}

--- a/Packages/StetEngine/Sources/StetCore/HistoryEntry.swift
+++ b/Packages/StetEngine/Sources/StetCore/HistoryEntry.swift
@@ -84,6 +84,10 @@ public final class HistoryEntry {
     /// Raw transcript from the selected ASR engine.
     public var rawText: String
 
+    /// Fun-ASR Nano transcript of the same audio with an empty hotword prompt.
+    /// Nil when the engine is not Nano or the background pass was skipped.
+    public var rawTextWithoutHotwords: String?
+
     /// LLM-refined text, if a rewrite transformer was active. Nil when rewrite is off.
     public var llmText: String?
 
@@ -127,6 +131,7 @@ public final class HistoryEntry {
         id: UUID = UUID(),
         timestamp: Date = Date(),
         rawText: String,
+        rawTextWithoutHotwords: String? = nil,
         llmText: String? = nil,
         finalText: String? = nil,
         targetBundleID: String? = nil,
@@ -142,6 +147,7 @@ public final class HistoryEntry {
         self.id = id
         self.timestamp = timestamp
         self.rawText = rawText
+        self.rawTextWithoutHotwords = rawTextWithoutHotwords
         self.llmText = llmText
         self.finalText = finalText
         self.targetBundleID = targetBundleID
@@ -177,6 +183,7 @@ extension HistoryEntry {
         public let id: UUID
         public let timestamp: Date
         public let rawText: String
+        public let rawTextWithoutHotwords: String?
         public let llmText: String?
         public let finalText: String?
         public let targetBundleID: String?
@@ -193,6 +200,7 @@ extension HistoryEntry {
             self.id = entry.id
             self.timestamp = entry.timestamp
             self.rawText = entry.rawText
+            self.rawTextWithoutHotwords = entry.rawTextWithoutHotwords
             self.llmText = entry.llmText
             self.finalText = entry.finalText
             self.targetBundleID = entry.targetBundleID

--- a/Packages/StetEngine/Tests/StetCoreTests/DictationHistoryServiceTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/DictationHistoryServiceTests.swift
@@ -68,6 +68,7 @@ struct DictationHistoryServiceTests {
         #expect(entry.captureStartedAt == entry.timestamp)
         #expect(entry.captureEndedAt == nil)
         #expect(entry.speakerRegions.isEmpty)
+        #expect(entry.rawTextWithoutHotwords == nil)
     }
 
     @Test func passiveCapturePersistsOrderedRegionsAndExportOmitsBiometricTemplates() throws {
@@ -274,6 +275,77 @@ struct DictationHistoryServiceTests {
                 speakerRegions: outside
             )
         }
+    }
+
+    @Test func noHotwordTranscriptAttachesBeforeCommit() async throws {
+        let service = try makeService()
+        service.recordRaw("with hotwords")
+        service.recordRawWithoutHotwords("without hotwords")
+        let id = try #require(service.commitPending())
+
+        let entry = try await waitForEntry(in: service, id: id)
+        #expect(entry.rawText == "with hotwords")
+        #expect(entry.rawTextWithoutHotwords == "without hotwords")
+        #expect(entry.llmText == nil)
+    }
+
+    @Test func noHotwordTranscriptAttachesAfterCommitAndUpdateFinal() async throws {
+        let service = try makeService()
+        service.recordRaw("with hotwords")
+        let id = try #require(service.commitPending())
+        _ = try await waitForEntry(in: service, id: id)
+        service.updateFinal(
+            "delivered",
+            targetBundleID: "com.example.editor",
+            targetAppName: "Editor"
+        )
+        service.recordRawWithoutHotwords("without hotwords")
+
+        let entry = try await waitForEntry(in: service, id: id) {
+            $0.rawTextWithoutHotwords == "without hotwords"
+        }
+        #expect(entry.rawText == "with hotwords")
+        #expect(entry.rawTextWithoutHotwords == "without hotwords")
+        #expect(entry.finalText == "delivered")
+    }
+
+    @Test func nextRecordRawDoesNotReceivePreviousNoHotwordTranscript() async throws {
+        let service = try makeService()
+        service.recordRaw("first")
+        let firstID = try #require(service.commitPending())
+        _ = try await waitForEntry(in: service, id: firstID)
+        service.updateFinal("first delivered", targetBundleID: nil, targetAppName: nil)
+        service.recordRaw("second")
+        service.recordRawWithoutHotwords("second without")
+        let secondID = try #require(service.commitPending())
+
+        let first = try await waitForEntry(in: service, id: firstID)
+        let second = try await waitForEntry(in: service, id: secondID)
+        #expect(first.rawTextWithoutHotwords == nil)
+        #expect(second.rawTextWithoutHotwords == "second without")
+    }
+
+    private func waitForEntry(
+        in service: DictationHistoryService,
+        id: UUID,
+        timeout: Duration = .seconds(2),
+        matching: ((HistoryEntry) -> Bool)? = nil
+    ) async throws -> HistoryEntry {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if let entry = try service.fetchRecent().first(where: { $0.id == id }),
+                matching?(entry) ?? true
+            {
+                return entry
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let entry = try #require(service.fetchRecent().first(where: { $0.id == id }))
+        if let matching {
+            #expect(matching(entry))
+        }
+        return entry
     }
 
     private func makeService() throws -> DictationHistoryService {

--- a/Packages/StetEngine/Tests/StetCoreTests/DictionaryModelTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/DictionaryModelTests.swift
@@ -84,4 +84,45 @@ struct DictionaryModelTests {
 
         #expect(subject.loadEntries() == ["Cursor", "OpenAI"])
     }
+
+    @Test func importMergesManualTermsAndReportsDuplicates() throws {
+        let defaults = UserDefaults(suiteName: "StetCoreTests.Import.\(UUID().uuidString)")!
+        let subject = DictionaryModel(
+            defaults: defaults,
+            entriesKey: "dictionary.entries.\(UUID().uuidString)"
+        )
+        subject.addAutomaticEntries(["python"])
+        let result = try subject.importEntries(from: "Python, Stet\nCursor")
+        #expect(result.addedCount == 2)
+        #expect(result.skippedCount == 1)
+        #expect(
+            subject.loadRecords() == [
+                .init(term: "python", source: .automatic),
+                .init(term: "Stet", source: .manual),
+                .init(term: "Cursor", source: .manual),
+            ])
+        subject.clear()
+    }
+
+    @Test func importRejectsEmptyTextAndOversizedFiles() throws {
+        let defaults = UserDefaults(suiteName: "StetCoreTests.ImportLimits.\(UUID().uuidString)")!
+        let subject = DictionaryModel(
+            defaults: defaults,
+            entriesKey: "dictionary.entries.\(UUID().uuidString)"
+        )
+        #expect(throws: DictionaryImportError.empty) {
+            try subject.importEntries(from: "  , \n ")
+        }
+        let oversized = Data(repeating: 0x61, count: DictionaryModel.maximumImportFileByteCount + 1)
+        #expect(throws: DictionaryImportError.fileTooLarge(byteCount: oversized.count)) {
+            _ = try DictionaryModel.importText(from: oversized)
+        }
+        let text = try DictionaryModel.importText(from: Data("\u{FEFF}OpenAI, Groq".utf8))
+        #expect(DictionaryModel.words(from: text) == ["OpenAI", "Groq"])
+        let oversizedDictionary = String(repeating: "a", count: DictionaryModel.maximumStoredUTF8ByteCount)
+        #expect(throws: DictionaryImportError.dictionaryWouldExceedLimit) {
+            try subject.importEntries(from: oversizedDictionary)
+        }
+        subject.clear()
+    }
 }

--- a/Packages/StetEngine/Tests/StetCoreTests/FunASRNanoHotwordPromptTests.swift
+++ b/Packages/StetEngine/Tests/StetCoreTests/FunASRNanoHotwordPromptTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import StetCore
+
+struct FunASRNanoHotwordPromptTests {
+    @Test func prefersManualTermsAndCapsCount() {
+        let automatic = (1...40).map { GlossaryEntry(term: "a\($0)", source: .automatic) }
+        let manual = (1...15).map { GlossaryEntry(term: "M\($0)", source: .manual) }
+        let terms = FunASRNanoHotwordPrompt.selectedTerms(from: automatic + manual)
+        #expect(terms.count == FunASRNanoHotwordPrompt.maximumTermCount)
+        #expect(terms.prefix(15).elementsEqual(manual.map(\.term)))
+        #expect(terms.contains("a1"))
+        #expect(!terms.contains("a40"))
+    }
+
+    @Test func stopsBeforeJoinedPromptExceedsCharacterBudget() throws {
+        let long = String(repeating: "A", count: 80)
+        let records = (1...20).map { GlossaryEntry(term: "\(long)\($0)", source: .manual) }
+        let terms = FunASRNanoHotwordPrompt.selectedTerms(from: records)
+        let prompt = try #require(FunASRNanoHotwordPrompt.makePrompt(from: records))
+        #expect(terms.count < 20)
+        #expect(prompt.count <= FunASRNanoHotwordPrompt.maximumJoinedCharacterCount)
+        #expect(FunASRNanoHotwordPrompt.makePrompt(from: []) == nil)
+    }
+}

--- a/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
+++ b/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
@@ -11,11 +11,13 @@ struct DictationPipeline: Sendable {
     let rewriteProvider: DictationProvider?
     let preferredSpellings: [String]
     let usesAudienceAwareLocalPrompts: Bool
+    let recordsNoHotwordTranscript: Bool
 }
 
 struct DictationPipelineFactory: Sendable {
     var makeLocalTranscriptionService: @Sendable () throws -> any AudioFileTranscriptionService
     var makeRewriteService: @Sendable (RewriteProviderConfiguration, URLSession) -> any TextRewriteService
+    var recordsNoHotwordTranscript: Bool?
 
     init(
         makeLocalTranscriptionService: @escaping @Sendable () throws -> any AudioFileTranscriptionService,
@@ -23,10 +25,12 @@ struct DictationPipelineFactory: Sendable {
             @escaping @Sendable (
                 RewriteProviderConfiguration,
                 URLSession
-            ) -> any TextRewriteService
+            ) -> any TextRewriteService,
+        recordsNoHotwordTranscript: Bool? = nil
     ) {
         self.makeLocalTranscriptionService = makeLocalTranscriptionService
         self.makeRewriteService = makeRewriteService
+        self.recordsNoHotwordTranscript = recordsNoHotwordTranscript
     }
 
     static func live(configuration: any ModelStorageConfiguration = UserDefaultsModelStorage()) -> Self {
@@ -78,7 +82,14 @@ struct DictationPipelineFactory: Sendable {
                 ? nil
                 : snapshot.transcriptionPrimaryLanguage
             preferredSpellings = direct.preferredSpellings
-            promptProvider = Self.makePromptProvider(preferredSpellings: preferredSpellings)
+            let records =
+                snapshot.personalDictionaryRecords.isEmpty
+                ? FunASRNanoHotwordPrompt.records(from: preferredSpellings)
+                : snapshot.personalDictionaryRecords
+            promptProvider = Self.makePromptProvider(
+                records: records,
+                engine: snapshot.transcriptionEngine
+            )
             usesAudienceAwareLocalPrompts = true
 
             if direct.rewriteEnabled, let rewriteConfiguration = direct.rewriteConfiguration {
@@ -97,7 +108,9 @@ struct DictationPipelineFactory: Sendable {
             rewriteService: rewriteService,
             rewriteProvider: rewriteProvider,
             preferredSpellings: preferredSpellings,
-            usesAudienceAwareLocalPrompts: usesAudienceAwareLocalPrompts
+            usesAudienceAwareLocalPrompts: usesAudienceAwareLocalPrompts,
+            recordsNoHotwordTranscript: recordsNoHotwordTranscript
+                ?? Self.usesFunASRNano(transcriptionService)
         )
     }
 
@@ -111,17 +124,41 @@ struct DictationPipelineFactory: Sendable {
     nonisolated static func makeTranscriptionPrompt(
         preferredSpellings: [String]
     ) -> String? {
-        guard !preferredSpellings.isEmpty else { return nil }
-        return preferredSpellings.joined(separator: ", ")
+        makeTranscriptionPrompt(
+            records: FunASRNanoHotwordPrompt.records(from: preferredSpellings),
+            engine: .fluidAudio
+        )
+    }
+
+    nonisolated static func makeTranscriptionPrompt(
+        records: [GlossaryEntry],
+        engine: StoredTranscriptionEngine
+    ) -> String? {
+        switch engine {
+        case .funASRNano:
+            return FunASRNanoHotwordPrompt.makePrompt(from: records)
+        case .fluidAudio, .localWhisper:
+            guard !records.isEmpty else { return nil }
+            return records.map(\.term).joined(separator: ", ")
+        }
     }
 
     private nonisolated static func makePromptProvider(
-        preferredSpellings: [String]
+        records: [GlossaryEntry],
+        engine: StoredTranscriptionEngine
     ) -> (@Sendable () async -> String?)? {
-        guard let prompt = makeTranscriptionPrompt(preferredSpellings: preferredSpellings) else {
+        guard let prompt = makeTranscriptionPrompt(records: records, engine: engine) else {
             return nil
         }
 
         return { prompt }
+    }
+
+    nonisolated static func usesFunASRNano(_ service: any AudioFileTranscriptionService) -> Bool {
+        #if os(macOS)
+            return service is FunASRNanoTranscriptionService
+        #else
+            return false
+        #endif
     }
 }

--- a/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
+++ b/StetMac/Core/DictationPipeline/DictationPipelineFactory.swift
@@ -26,7 +26,7 @@ struct DictationPipelineFactory: Sendable {
                 RewriteProviderConfiguration,
                 URLSession
             ) -> any TextRewriteService,
-        recordsNoHotwordTranscript: Bool? = nil
+        recordsNoHotwordTranscript: Bool? = false
     ) {
         self.makeLocalTranscriptionService = makeLocalTranscriptionService
         self.makeRewriteService = makeRewriteService
@@ -53,7 +53,8 @@ struct DictationPipelineFactory: Sendable {
                 case .remote:
                     return OpenAIRewriteService(configuration: configuration, session: session)
                 }
-            }
+            },
+            recordsNoHotwordTranscript: nil
         )
     }
 
@@ -110,7 +111,7 @@ struct DictationPipelineFactory: Sendable {
             preferredSpellings: preferredSpellings,
             usesAudienceAwareLocalPrompts: usesAudienceAwareLocalPrompts,
             recordsNoHotwordTranscript: recordsNoHotwordTranscript
-                ?? Self.usesFunASRNano(transcriptionService)
+                ?? (snapshot.transcriptionEngine == .funASRNano)
         )
     }
 
@@ -152,13 +153,5 @@ struct DictationPipelineFactory: Sendable {
         }
 
         return { prompt }
-    }
-
-    nonisolated static func usesFunASRNano(_ service: any AudioFileTranscriptionService) -> Bool {
-        #if os(macOS)
-            return service is FunASRNanoTranscriptionService
-        #else
-            return false
-        #endif
     }
 }

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -43,6 +43,9 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     private var retiringPrewarmTasks: [Task<Void, Never>] = []
     private var nextCaptureSessionID: UInt64 = 0
     private var invalidatedThroughCaptureSessionID: UInt64 = 0
+    private var noHotwordPassTask: Task<Void, Never>?
+    private var noHotwordPassGeneration: UInt64 = 0
+    private let recordNoHotwordTranscript: @Sendable (String) async -> Void
 
     init(
         settingsStore: DictationSettingsStore = DictationSettingsStore(),
@@ -53,7 +56,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         captureService: (any AudioCaptureService)? = nil,
         captureServiceFactory: (@Sendable () -> any AudioCaptureService)? = nil,
         beginActiveCapture: (@Sendable () async -> Void)? = nil,
-        resumePassiveCapture: (@Sendable () async -> Void)? = nil
+        resumePassiveCapture: (@Sendable () async -> Void)? = nil,
+        recordNoHotwordTranscript: (@Sendable (String) async -> Void)? = nil
     ) {
         precondition(
             captureService == nil || captureServiceFactory == nil,
@@ -70,6 +74,12 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         self.audioPostProcessor = audioPostProcessor ?? DefaultAudioPostProcessor()
         self.beginActiveCapture = beginActiveCapture
         self.resumePassiveCapture = resumePassiveCapture
+        self.recordNoHotwordTranscript =
+            recordNoHotwordTranscript ?? { text in
+                await MainActor.run {
+                    DictationHistoryService.shared.recordRawWithoutHotwords(text)
+                }
+            }
         if let captureService {
             self.captureServiceFactory = { captureService }
             self.reusableCaptureService = captureService
@@ -101,6 +111,12 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
     }
 
     private func startRecording(activateRecordingWindow: Bool) async throws {
+        if noHotwordPassTask != nil {
+            noHotwordPassTask?.cancel()
+            await MainActor.run {
+                DictationHistoryService.shared.discardUncommittedNoHotwordTranscript()
+            }
+        }
         let sessionID = try beginCaptureSession()
         // Recheck after every wait: another cancellation may have been queued.
         while let cancellationTask { await cancellationTask.value }
@@ -293,6 +309,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
         await DictationLatencyProbe.shared.beginSession(audioDurationSeconds: processedCaptureResult.duration)
         let processingStartedAt = ProcessInfo.processInfo.systemUptime
 
+        await waitForNoHotwordPass()
+
         var transcriptionPrompt: String? = nil
         if let provider = pipeline.promptProvider {
             transcriptionPrompt = await provider()
@@ -409,6 +427,16 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
                 "DictationSummary totalProcessingMs=\(Self.formatMilliseconds(totalProcessingMs)) audioDurationSeconds=\(Self.formatDurationSeconds(processedCaptureResult.duration)) finalTextChars=\(trimmedTranscript.count) rewriteEnabled=\(pipeline.rewriteService != nil)"
             )
 
+            if pipeline.recordsNoHotwordTranscript {
+                cleanupURLs.remove(processedCaptureResult.url)
+                startNoHotwordPass(
+                    audioURL: processedCaptureResult.url,
+                    languageCode: pipeline.transcriptionLanguageCode,
+                    duration: processedCaptureResult.duration,
+                    transcriptionService: pipeline.transcriptionService
+                )
+            }
+
             return SpeechTranscriptionResult(
                 rawText: wasRewritten ? intermediateTranscript : trimmedTranscript,
                 text: trimmedTranscript,
@@ -467,7 +495,8 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
     private func scheduleContextCleanupIfIdle() {
         guard activeCaptureSessionID == nil, processingSessions.isEmpty,
-            cancellationTask == nil, contextCleanupTask == nil
+            cancellationTask == nil, contextCleanupTask == nil,
+            noHotwordPassTask == nil
         else { return }
         let prewarms = retiringPrewarmTasks
         retiringPrewarmTasks.removeAll()
@@ -482,6 +511,48 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
             #endif
             contextCleanupTask = nil
         }
+    }
+
+    private func waitForNoHotwordPass() async {
+        await noHotwordPassTask?.value
+    }
+
+    private func startNoHotwordPass(
+        audioURL: URL,
+        languageCode: String?,
+        duration: TimeInterval?,
+        transcriptionService: any AudioFileTranscriptionService
+    ) {
+        noHotwordPassGeneration += 1
+        let generation = noHotwordPassGeneration
+        let record = recordNoHotwordTranscript
+        noHotwordPassTask = Task {
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+            if !Task.isCancelled {
+                do {
+                    let result = try await transcriptionService.transcribe(
+                        audioFileAt: audioURL,
+                        languageCode: languageCode,
+                        prompt: nil,
+                        audioDurationSeconds: duration
+                    )
+                    let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !Task.isCancelled, !text.isEmpty {
+                        await record(text)
+                    }
+                } catch {
+                    // The user-facing transcript already succeeded. Skip quietly.
+                }
+            }
+            await self.finishNoHotwordPass(generation: generation)
+        }
+    }
+
+    private func finishNoHotwordPass(generation: UInt64) {
+        if noHotwordPassGeneration == generation {
+            noHotwordPassTask = nil
+        }
+        scheduleContextCleanupIfIdle()
     }
 
     private func resumePassiveCaptureIfNeeded() async {

--- a/StetMac/Core/Speech/ConfigurableSpeechService.swift
+++ b/StetMac/Core/Speech/ConfigurableSpeechService.swift
@@ -429,6 +429,7 @@ actor ConfigurableSpeechService: SpeechService, AudioLevelSource {
 
             if pipeline.recordsNoHotwordTranscript {
                 cleanupURLs.remove(processedCaptureResult.url)
+                logger.info("Starting background no-hotword transcription.")
                 startNoHotwordPass(
                     audioURL: processedCaptureResult.url,
                     languageCode: pipeline.transcriptionLanguageCode,

--- a/StetMac/Features/MacShell/Dictionary/DictionaryView.swift
+++ b/StetMac/Features/MacShell/Dictionary/DictionaryView.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
     import SwiftUI
     import StetCore
+    import UniformTypeIdentifiers
 
     struct DictionaryView: View {
         @ObservedObject var viewModel: DictionaryViewModel
@@ -18,6 +19,7 @@
         @State private var editingEntry: String?
         @State private var entryDraft = ""
         @State private var clearConfirmation = ""
+        @State private var isImportingFile = false
 
         private var entryDraftBinding: Binding<String> {
             Binding(
@@ -53,6 +55,11 @@
                     HStack {
                         Text("\(viewModel.entries.count) words and phrases").foregroundStyle(.secondary)
                         Spacer()
+                        Button {
+                            isImportingFile = true
+                        } label: {
+                            Label("Import…", systemImage: "square.and.arrow.down")
+                        }
                         Button {
                             openEditor()
                         } label: {
@@ -129,6 +136,31 @@
                 }
             }
             .onAppear { viewModel.load() }
+            .fileImporter(
+                isPresented: $isImportingFile,
+                allowedContentTypes: [.plainText, .commaSeparatedText, .utf8PlainText],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let url = urls.first else { return }
+                    viewModel.importEntries(from: url)
+                case .failure(let error):
+                    viewModel.importAlert = .failure(error.localizedDescription)
+                }
+            }
+            .alert(
+                viewModel.importAlert?.title ?? "Import Dictionary",
+                isPresented: Binding(
+                    get: { viewModel.importAlert != nil },
+                    set: { if !$0 { viewModel.importAlert = nil } }
+                ),
+                presenting: viewModel.importAlert
+            ) { _ in
+                Button("OK") { viewModel.importAlert = nil }
+            } message: { alert in
+                Text(alert.message)
+            }
         }
 
         private func openEditor(_ entry: String? = nil) {

--- a/StetMac/Features/MacShell/Dictionary/DictionaryViewModel.swift
+++ b/StetMac/Features/MacShell/Dictionary/DictionaryViewModel.swift
@@ -16,6 +16,34 @@
             records.first { $0.term == term }?.source ?? .manual
         }
         @Published var draft = ""
+        @Published var importAlert: ImportAlert?
+
+        enum ImportAlert: Equatable, Identifiable {
+            case success(added: Int, skipped: Int)
+            case failure(String)
+
+            var id: String {
+                switch self {
+                case .success(let added, let skipped):
+                    return "success-\(added)-\(skipped)"
+                case .failure(let message):
+                    return "failure-\(message)"
+                }
+            }
+
+            var title: String { "Import Dictionary" }
+
+            var message: String {
+                switch self {
+                case .success(let added, let skipped) where skipped == 0:
+                    return added == 1 ? "Added 1 term." : "Added \(added) terms."
+                case .success(let added, let skipped):
+                    return "Added \(added), skipped \(skipped) duplicate\(skipped == 1 ? "" : "s")."
+                case .failure(let message):
+                    return message
+                }
+            }
+        }
 
         init(dictionaryModel: DictionaryModel = DictionaryModel()) {
             self.dictionaryModel = dictionaryModel
@@ -81,6 +109,26 @@
         func clearEntries() {
             dictionaryModel.clear()
             records = []
+        }
+
+        func importEntries(from url: URL) {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+            do {
+                let data = try Data(contentsOf: url)
+                let text = try DictionaryModel.importText(from: data)
+                let result = try dictionaryModel.importEntries(from: text)
+                records = dictionaryModel.loadRecords()
+                importAlert = .success(added: result.addedCount, skipped: result.skippedCount)
+            } catch let error as DictionaryImportError {
+                importAlert = .failure(error.localizedDescription ?? "Stet could not import that file.")
+            } catch {
+                importAlert = .failure(error.localizedDescription)
+            }
         }
     }
 #endif

--- a/StetMac/Shared/Utilities/DictationSettingsStore.swift
+++ b/StetMac/Shared/Utilities/DictationSettingsStore.swift
@@ -42,6 +42,7 @@ struct DictationSettingsSnapshot: Sendable {
     let shouldPauseMediaDuringDictation: Bool
     let rewriteProviderConfiguration: RewriteProviderConfiguration?
     let personalDictionary: [String]
+    let personalDictionaryRecords: [GlossaryEntry]
     let interactionSoundsEnabled: Bool
     let dictationCompletionNotificationsEnabled: Bool
     let interactionSoundPreset: InteractionSoundPreset
@@ -125,7 +126,8 @@ struct DictationSettingsStore: Sendable {
         let rewriteAPIKey = loadAPIKey(for: rewriteProvider)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let selectedModel = loadSelectedModel(for: rewriteProvider)
-        let personalDictionary = loadPersonalDictionaryEnabled() ? loadPersonalDictionary() : []
+        let personalDictionaryRecords = loadPersonalDictionaryEnabled() ? dictionaryModel.loadRecords() : []
+        let personalDictionary = personalDictionaryRecords.map(\.term)
         let interactionSoundsEnabled =
             defaultsStore.object(forKey: MacPreferences.interactionSoundsEnabled) as? Bool ?? true
         let dictationCompletionNotificationsEnabled =
@@ -178,6 +180,7 @@ struct DictationSettingsStore: Sendable {
             shouldPauseMediaDuringDictation: shouldPauseMediaDuringDictation,
             rewriteProviderConfiguration: rewriteConfiguration,
             personalDictionary: personalDictionary,
+            personalDictionaryRecords: personalDictionaryRecords,
             interactionSoundsEnabled: interactionSoundsEnabled,
             dictationCompletionNotificationsEnabled: dictationCompletionNotificationsEnabled,
             interactionSoundPreset: interactionSoundPreset,

--- a/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
+++ b/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
@@ -453,6 +453,22 @@ struct LogicPrimitiveTests {
         #expect(pipeline.preferredSpellings == terms)
         #expect(pipeline.recordsNoHotwordTranscript == false)
     }
+
+    @Test func makePipelineRecordsNoHotwordTranscriptForFunASRNanoWhenUnspecified() async throws {
+        let factory = DictationPipelineFactory(
+            makeLocalTranscriptionService: { RecordingTranscriptionService(result: "direct") },
+            makeRewriteService: { _, _ in RecordingRewriteService() },
+            recordsNoHotwordTranscript: nil
+        )
+
+        let nano = try await factory.makePipeline(from: makeSnapshot(transcriptionEngine: .funASRNano))
+        let parakeet = try await factory.makePipeline(from: makeSnapshot(transcriptionEngine: .fluidAudio))
+        let whisper = try await factory.makePipeline(from: makeSnapshot(transcriptionEngine: .localWhisper))
+
+        #expect(nano.recordsNoHotwordTranscript)
+        #expect(parakeet.recordsNoHotwordTranscript == false)
+        #expect(whisper.recordsNoHotwordTranscript == false)
+    }
 }
 
 // MARK: - Local transcription engine routing

--- a/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
+++ b/StetMacTests/Core/DictationPipeline/DictationPipelineTests.swift
@@ -22,6 +22,7 @@ private func makeSnapshot(
         ),
     rewriteEnabled: Bool = false,
     personalDictionary: [String] = [],
+    personalDictionaryRecords: [GlossaryEntry]? = nil,
     transcriptionPrimaryLanguage: String = "en",
     transcriptionSecondaryLanguage: String? = nil,
     transcriptionEngine: StoredTranscriptionEngine = .funASRNano
@@ -34,6 +35,8 @@ private func makeSnapshot(
         shouldPauseMediaDuringDictation: false,
         rewriteProviderConfiguration: rewriteProviderConfiguration,
         personalDictionary: personalDictionary,
+        personalDictionaryRecords: personalDictionaryRecords
+            ?? personalDictionary.map { GlossaryEntry(term: $0, source: .manual) },
         interactionSoundsEnabled: true,
         dictationCompletionNotificationsEnabled: true,
         interactionSoundPreset: .soft,
@@ -380,6 +383,75 @@ struct LogicPrimitiveTests {
 
     @Test func makeTranscriptionPromptReturnsNilWithoutPreferredSpellings() {
         #expect(DictationPipelineFactory.makeTranscriptionPrompt(preferredSpellings: []) == nil)
+    }
+
+    @Test func makePipelineCapsFunASRNanoPromptAndKeepsFullRewriteSpellings() async throws {
+        let terms = (1...80).map { "term\($0)" }
+        let local = RecordingTranscriptionService(result: "direct")
+        let factory = DictationPipelineFactory(
+            makeLocalTranscriptionService: { local },
+            makeRewriteService: { _, _ in RecordingRewriteService() }
+        )
+        let snapshot = makeSnapshot(
+            personalDictionary: terms,
+            transcriptionEngine: .funASRNano
+        )
+
+        let pipeline = try await factory.makePipeline(from: snapshot)
+        let prompt = try #require(await pipeline.promptProvider?())
+        let expected = try #require(
+            FunASRNanoHotwordPrompt.makePrompt(
+                from: terms.map { GlossaryEntry(term: $0, source: .manual) }
+            )
+        )
+
+        #expect(prompt == expected)
+        #expect(prompt.split(separator: ", ").count <= FunASRNanoHotwordPrompt.maximumTermCount)
+        #expect(prompt.count <= FunASRNanoHotwordPrompt.maximumJoinedCharacterCount)
+        #expect(pipeline.preferredSpellings == terms)
+        #expect(pipeline.recordsNoHotwordTranscript == false)
+    }
+
+    @Test func makePipelinePrefersManualDictionaryTermsInFunASRNanoPrompt() async throws {
+        let automatic = (1...40).map { GlossaryEntry(term: "a\($0)", source: .automatic) }
+        let manual = (1...15).map { GlossaryEntry(term: "M\($0)", source: .manual) }
+        let records = automatic + manual
+        let local = RecordingTranscriptionService(result: "direct")
+        let factory = DictationPipelineFactory(
+            makeLocalTranscriptionService: { local },
+            makeRewriteService: { _, _ in RecordingRewriteService() }
+        )
+        let snapshot = makeSnapshot(
+            personalDictionary: records.map(\.term),
+            personalDictionaryRecords: records,
+            transcriptionEngine: .funASRNano
+        )
+
+        let pipeline = try await factory.makePipeline(from: snapshot)
+        let prompt = try #require(await pipeline.promptProvider?())
+
+        #expect(prompt == FunASRNanoHotwordPrompt.makePrompt(from: records))
+        #expect(pipeline.preferredSpellings == records.map(\.term))
+    }
+
+    @Test func makePipelineDoesNotCapFluidAudioPrompt() async throws {
+        let terms = (1...80).map { "term\($0)" }
+        let local = RecordingTranscriptionService(result: "direct")
+        let factory = DictationPipelineFactory(
+            makeLocalTranscriptionService: { local },
+            makeRewriteService: { _, _ in RecordingRewriteService() }
+        )
+        let snapshot = makeSnapshot(
+            personalDictionary: terms,
+            transcriptionEngine: .fluidAudio
+        )
+
+        let pipeline = try await factory.makePipeline(from: snapshot)
+        let prompt = try #require(await pipeline.promptProvider?())
+
+        #expect(prompt == terms.joined(separator: ", "))
+        #expect(pipeline.preferredSpellings == terms)
+        #expect(pipeline.recordsNoHotwordTranscript == false)
     }
 }
 

--- a/StetMacTests/Core/MCP/MCPTranscriptionCoordinatorTests.swift
+++ b/StetMacTests/Core/MCP/MCPTranscriptionCoordinatorTests.swift
@@ -233,6 +233,7 @@ private func makeMCPSnapshot(
                 apiKey: "sk-test"
             ) : nil,
         personalDictionary: personalDictionary,
+        personalDictionaryRecords: personalDictionary.map { GlossaryEntry(term: $0, source: .manual) },
         interactionSoundsEnabled: true,
         dictationCompletionNotificationsEnabled: true,
         interactionSoundPreset: .soft,

--- a/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
+++ b/StetMacTests/Core/Speech/ConfigurableSpeechServiceTests.swift
@@ -1398,6 +1398,112 @@ struct ConfigurableSpeechServiceTests {
         #expect(instructions.contains("Keep the correction local."))
         #expect(instructions.contains("Never translate any word, phrase, clause, sentence, or language span."))
     }
+
+    @Test func stopRecordingQueuesNoHotwordPassThenDeletesAudio() async throws {
+        let audioFileURL = makeAudioFileURL()
+        let recorder = NoHotwordTranscriptRecorder()
+        let direct = TestTranscriptionService(result: "with hotwords")
+        await direct.setNilPromptOutcome(.success("without hotwords"))
+        let (store, _, _) = try makeSettingsStore(preferredSpellings: ["OpenAI", "Groq"])
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() },
+                recordsNoHotwordTranscript: true
+            ),
+            captureService: TestAudioCaptureService(audioFileURL: audioFileURL),
+            recordNoHotwordTranscript: { text in
+                await recorder.record(text)
+            }
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.text == "with hotwords")
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
+                await recorder.texts() == ["without hotwords"]
+            }
+        )
+        #expect(await direct.callCount() == 2)
+        #expect(await direct.prompts() == ["OpenAI, Groq", nil])
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
+                !FileManager.default.fileExists(atPath: audioFileURL.path)
+            }
+        )
+    }
+
+    @Test func noHotwordPassFailureDoesNotSurfaceToTheUser() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+        let recorder = NoHotwordTranscriptRecorder()
+        let direct = TestTranscriptionService(result: "with hotwords")
+        await direct.setNilPromptOutcome(.failure(TestError.expected))
+        let (store, _, _) = try makeSettingsStore(preferredSpellings: ["Stet"])
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() },
+                recordsNoHotwordTranscript: true
+            ),
+            captureService: TestAudioCaptureService(audioFileURL: audioFileURL),
+            recordNoHotwordTranscript: { text in
+                await recorder.record(text)
+            }
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        #expect(result.text == "with hotwords")
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
+                await direct.callCount() == 2
+            }
+        )
+        #expect(await recorder.texts().isEmpty)
+    }
+
+    @Test func startRecordingCancelsInFlightNoHotwordPass() async throws {
+        let audioFileURL = makeAudioFileURL()
+        defer { try? FileManager.default.removeItem(at: audioFileURL) }
+        let recorder = NoHotwordTranscriptRecorder()
+        let nilPromptGate = TestSuspensionGate()
+        let direct = TestTranscriptionService(result: "with hotwords")
+        await direct.setNilPromptOutcome(.success("without hotwords"))
+        await direct.setNilPromptGate(nilPromptGate)
+        let (store, _, _) = try makeSettingsStore(preferredSpellings: ["Stet"])
+        let service = ConfigurableSpeechService(
+            settingsStore: store,
+            pipelineFactory: DictationPipelineFactory(
+                makeLocalTranscriptionService: { direct },
+                makeRewriteService: { _, _ in RecordingRewriteService() },
+                recordsNoHotwordTranscript: true
+            ),
+            captureService: TestAudioCaptureService(audioFileURL: audioFileURL),
+            recordNoHotwordTranscript: { text in
+                await recorder.record(text)
+            }
+        )
+
+        try await service.startRecording()
+        _ = try await service.stopRecording()
+        try #require(await TestSupport.eventuallyAsync(timeout: .seconds(2)) { await nilPromptGate.hasWaiter })
+
+        try await service.startRecording()
+        #expect(await nilPromptGate.observedCancellation)
+        await nilPromptGate.open()
+        #expect(
+            await TestSupport.eventuallyAsync(timeout: .seconds(2)) {
+                await direct.callCount() == 2
+            }
+        )
+        #expect(await recorder.texts().isEmpty)
+    }
 }
 
 extension ConfigurableSpeechServiceTests {
@@ -1540,6 +1646,18 @@ private final class CountingAudioCaptureFactory: @unchecked Sendable {
     }
 }
 
+private actor NoHotwordTranscriptRecorder {
+    private var recordedTexts: [String] = []
+
+    func record(_ text: String) {
+        recordedTexts.append(text)
+    }
+
+    func texts() -> [String] {
+        recordedTexts
+    }
+}
+
 private actor TestTranscriptionService: AudioFileTranscriptionService {
     enum Outcome: Sendable {
         case success(String)
@@ -1548,10 +1666,15 @@ private actor TestTranscriptionService: AudioFileTranscriptionService {
 
     private(set) var outcome: Outcome
     private var gate: TestSuspensionGate?
+    private var nilPromptGate: TestSuspensionGate?
+    private var nilPromptOutcome: Outcome?
 
     func setGate(_ gate: TestSuspensionGate) { self.gate = gate }
+    func setNilPromptGate(_ gate: TestSuspensionGate) { nilPromptGate = gate }
+    func setNilPromptOutcome(_ outcome: Outcome) { nilPromptOutcome = outcome }
     private var callCountValue = 0
     private var lastInvocationValue: (fileURL: URL, languageCode: String?, prompt: String?, duration: TimeInterval?)?
+    private var promptsValue: [String?] = []
 
     init(result: String) {
         self.outcome = .success(result)
@@ -1575,7 +1698,20 @@ private actor TestTranscriptionService: AudioFileTranscriptionService {
         lastInvocationValue = (
             fileURL: fileURL, languageCode: languageCode, prompt: prompt, duration: audioDurationSeconds
         )
+        promptsValue.append(prompt)
         #expect(!fileURL.path.isEmpty)
+        if prompt == nil {
+            await nilPromptGate?.wait()
+            try Task.checkCancellation()
+            if let nilPromptOutcome {
+                switch nilPromptOutcome {
+                case .success(let value):
+                    return TranscriptionResult(text: value, languageCode: languageCode)
+                case .failure(let error):
+                    throw error
+                }
+            }
+        }
         await gate?.wait()
 
         switch outcome {
@@ -1588,6 +1724,10 @@ private actor TestTranscriptionService: AudioFileTranscriptionService {
 
     func callCount() -> Int {
         callCountValue
+    }
+
+    func prompts() -> [String?] {
+        promptsValue
     }
 
     func lastInvocation() -> (fileURL: URL, languageCode: String?, prompt: String?, duration: TimeInterval?)? {

--- a/StetMacTests/Features/Dictation/DictationViewModelTests.swift
+++ b/StetMacTests/Features/Dictation/DictationViewModelTests.swift
@@ -494,6 +494,8 @@ private final class HistoryRecordingSpy: DictationHistoryRecording {
         llmTexts.append(text)
     }
 
+    func recordRawWithoutHotwords(_ text: String) {}
+
     func commitPending() -> UUID? {
         commitCount += 1
         return UUID()

--- a/StetMacTests/Features/MacShell/Dictionary/DictionaryViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/Dictionary/DictionaryViewModelTests.swift
@@ -105,5 +105,19 @@
             #expect(subject.model.loadEntries().isEmpty)
             #expect(subject.model.loadIsEnabled() == false)
         }
+
+        @Test func importFromTextFileMergesAndReportsCounts() throws {
+            let subject = makeViewModel(defaults: TestSupport.makeUserDefaults())
+            defer { subject.model.clear() }
+            subject.model.addAutomaticEntries(["python"])
+            subject.viewModel.load()
+            let url = TestSupport.temporaryFileURL("glossary", ext: "txt")
+            try Data("Python, Stet\nCursor\n".utf8).write(to: url)
+            subject.viewModel.importEntries(from: url)
+            #expect(subject.viewModel.entries == ["python", "Stet", "Cursor"])
+            #expect(subject.viewModel.source(for: "python") == .automatic)
+            #expect(subject.viewModel.source(for: "Stet") == .manual)
+            #expect(subject.viewModel.importAlert == .success(added: 2, skipped: 1))
+        }
     }
 #endif


### PR DESCRIPTION
## Summary
- Let the macOS dictionary import a `.txt` or CSV glossary, merge into the existing list, skip duplicates, and keep existing manual/automatic provenance (#70).
- Cap Fun-ASR Nano hotword injection at 50 terms / 400 characters so a large dictionary cannot overflow the 512-token prompt batch; rewrite still gets the full glossary (#71).
- After the user already has text, run a background Nano pass with an empty hotword prompt and store it on `HistoryEntry.rawTextWithoutHotwords` for later eviction. This does not drop hotwords yet (#72).

Closes #70
Closes #71
Closes #72

## Test plan
- [ ] Settings → Text → Dictionary: Import a txt/CSV file and confirm added vs skipped counts; duplicates keep their original source
- [ ] Import a large glossary, dictate with Fun-ASR Nano, and confirm transcription still succeeds (prompt is capped)
- [ ] Confirm rewrite still sees the full dictionary
- [ ] Dictate once with Nano, then check History for `rawTextWithoutHotwords` after a short delay; confirm the WAV is not kept
- [ ] Start a second dictation quickly and confirm it is not blocked on the background pass
- [ ] Switch to FluidAudio/Whisper and confirm those prompts are not capped


Made with [Cursor](https://cursor.com)