### PR TITLE
Add Settings Overview for dictation usage

### DIFF
--- a/Stet.xcodeproj/project.pbxproj
+++ b/Stet.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		E5E0E5E0E5E0E5E0E5E00009 /* StetASR in Frameworks */ = {isa = PBXBuildFile; productRef = E5E0E5E0E5E0E5E0E5E00008 /* StetASR */; };
 		F1A0B0010000000000000001 /* StetVisuals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1A0B0010000000000000003 /* StetVisuals.framework */; };
 		F1A0B001000000000000000E /* StetVisuals.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F1A0B0010000000000000003 /* StetVisuals.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A2C0DE010000000000000001 /* HeatmapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A2C0DE010000000000000002 /* HeatmapKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +127,7 @@
 				E5E0E5E0E5E0E5E0E5E00006 /* StetAI in Frameworks */,
 				E5E0E5E0E5E0E5E0E5E00007 /* StetRewrite in Frameworks */,
 				E5E0E5E0E5E0E5E0E5E00009 /* StetASR in Frameworks */,
+				A2C0DE010000000000000001 /* HeatmapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,6 +224,7 @@
 				E5E0E5E0E5E0E5E0E5E00003 /* StetAI */,
 				E5E0E5E0E5E0E5E0E5E00004 /* StetRewrite */,
 				E5E0E5E0E5E0E5E0E5E00008 /* StetASR */,
+				A2C0DE010000000000000002 /* HeatmapKit */,
 			);
 			productName = Stet;
 			productReference = 6D29DC7D2F5FA23000267DEA /* Stet.app */;
@@ -344,6 +347,7 @@
 				6DCB53132F6DB36500358FE5 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				6DC0CD012F9DD8BE00696D0F /* XCRemoteSwiftPackageReference "SwiftSDK" */,
 				E5E0E5E0E5E0E5E0E5E00001 /* XCLocalSwiftPackageReference "Packages/StetEngine" */,
+				A2C0DE010000000000000003 /* XCRemoteSwiftPackageReference "HeatmapKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6D29DC7E2F5FA23000267DEA /* Products */;
@@ -988,6 +992,14 @@
 				minimumVersion = 0.4.7;
 			};
 		};
+		A2C0DE010000000000000003 /* XCRemoteSwiftPackageReference "HeatmapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jacklv-coder/HeatmapKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1060,6 +1072,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E5E0E5E0E5E0E5E0E5E00001 /* XCLocalSwiftPackageReference "Packages/StetEngine" */;
 			productName = StetASR;
+		};
+		A2C0DE010000000000000002 /* HeatmapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A2C0DE010000000000000003 /* XCRemoteSwiftPackageReference "HeatmapKit" */;
+			productName = HeatmapKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Stet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f3634ee1797f717cd3f44163aff8cb3ba539c6789100d2a4d3ddae7402a2da1d",
+  "originHash" : "a3bb550a1c6b13ada312fc107a4476ed31d0514b0a24b71d4014dd5cfd0da97a",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -17,6 +17,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "0346057d8245b5e7ace6965d499f85d93e803ef1"
+      }
+    },
+    {
+      "identity" : "heatmapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jacklv-coder/HeatmapKit",
+      "state" : {
+        "revision" : "7494afca307d45acfcbab9bbc45e5bd4915cdd31",
+        "version" : "0.5.1"
       }
     },
     {

--- a/StetMac/App/Workflows/MacDictationWorkflowController.swift
+++ b/StetMac/App/Workflows/MacDictationWorkflowController.swift
@@ -25,7 +25,9 @@
         private let mediaResumeSleep: @Sendable (Duration) async throws -> Void
         private let startPromptActivationDeadline: Duration
 
-        private weak var lastTargetApplication: NSRunningApplication?
+        private var lastTargetApplication: NSRunningApplication?
+        private var lastTargetBundleID: String?
+        private var lastTargetAppName: String?
         private(set) var activeRecordingSource: PrimaryActionSource?
         private(set) var mediaResumeTask: Task<Void, Never>?
         private var startActivationTask: Task<Void, Never>?
@@ -211,7 +213,12 @@
             if let duration = pendingSessionDuration {
                 let wordCount = Self.countWords(in: text)
                 statsModel?.record(
-                    startedAt: Date().addingTimeInterval(-duration), durationSeconds: duration, wordCount: wordCount)
+                    startedAt: Date().addingTimeInterval(-duration),
+                    durationSeconds: duration,
+                    wordCount: wordCount,
+                    targetBundleID: lastTargetBundleID,
+                    targetAppName: lastTargetAppName
+                )
 
                 AnalyticsService.track(
                     "dictation_completed",
@@ -256,8 +263,8 @@
         func finalizePendingResultHistory(_ text: String) {
             DictationHistoryService.shared.updateFinal(
                 text,
-                targetBundleID: lastTargetApplication?.bundleIdentifier,
-                targetAppName: lastTargetApplication?.localizedName,
+                targetBundleID: lastTargetBundleID,
+                targetAppName: lastTargetAppName,
                 status: .clipboardPending
             )
         }
@@ -271,6 +278,8 @@
             }
 
             lastTargetApplication = frontmostApplication
+            lastTargetBundleID = frontmostApplication.bundleIdentifier
+            lastTargetAppName = frontmostApplication.localizedName
         }
 
         private var settingsSnapshot: DictationSettingsSnapshot {

--- a/StetMac/Features/MacShell/Setting/MacDictationActivityHeatmapView.swift
+++ b/StetMac/Features/MacShell/Setting/MacDictationActivityHeatmapView.swift
@@ -1,0 +1,90 @@
+#if os(macOS)
+    import HeatmapKit
+    import SwiftUI
+
+    struct MacDictationActivityHeatmapView: View {
+        let contributions: [Date: Double]
+        var now: Date = Date()
+        var calendar: Calendar = .current
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Last 12 months")
+                    .font(.headline)
+
+                heatmap
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                legend
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(MacUI.Surfaces.selection)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+
+        private var heatmap: some View {
+            let today = calendar.startOfDay(for: now)
+            let start = calendar.date(byAdding: .day, value: -364, to: today) ?? today
+            return CalendarHeatmap(
+                contributions: contributions,
+                dateRange: start...today
+            )
+            .levels(.orange)
+            .cellSize(14)
+            .cellSpacing(3)
+            .cellCornerRadius(2)
+            .firstWeekday(Weekday(rawValue: calendar.firstWeekday) ?? .sunday)
+            .showMonthLabels(true)
+            .showWeekdayLabels(true)
+            .fitToWidth(minCellSize: 10)
+            .tooltipOnTap(tooltip)
+            .accessibilityCellLabel(tooltip)
+        }
+
+        private var legend: some View {
+            HStack(spacing: 4) {
+                Spacer(minLength: 0)
+                Text("Less")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                ForEach(0..<5, id: \.self) { level in
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(legendFill(for: level))
+                        .frame(width: 11, height: 11)
+                }
+                Text("More")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        private func legendFill(for level: Int) -> Color {
+            switch level {
+            case 1:
+                return MacUI.Brand.orange.opacity(0.28)
+            case 2:
+                return MacUI.Brand.orange.opacity(0.48)
+            case 3:
+                return MacUI.Brand.orange.opacity(0.72)
+            case 4:
+                return MacUI.Brand.orange
+            default:
+                return MacUI.Surfaces.ink.opacity(0.08)
+            }
+        }
+
+        private func tooltip(date: Date, value: Double) -> String {
+            let day = date.formatted(date: .abbreviated, time: .omitted)
+            let words = Int(value.rounded())
+            if words <= 0 {
+                return "No dictation on \(day)"
+            }
+            let label = words == 1 ? "1 word" : "\(words) words"
+            return "\(day): \(label)"
+        }
+    }
+#endif

--- a/StetMac/Features/MacShell/Setting/MacDictationAppUsageView.swift
+++ b/StetMac/Features/MacShell/Setting/MacDictationAppUsageView.swift
@@ -1,0 +1,101 @@
+#if os(macOS)
+    import AppKit
+    import SwiftUI
+
+    struct MacDictationAppUsageView: View {
+        let apps: [DictationAppUsage]
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("By app")
+                    .font(.headline)
+
+                if apps.isEmpty {
+                    Text("App breakdown starts after your next dictation.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(apps) { app in
+                            row(for: app)
+                        }
+                    }
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(MacUI.Surfaces.selection)
+            )
+        }
+
+        private func row(for app: DictationAppUsage) -> some View {
+            HStack(alignment: .center, spacing: 10) {
+                icon(for: app)
+                    .frame(width: 24, height: 24)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(app.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(MacUI.Surfaces.ink)
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Text(app.formattedWordCount)
+                            .font(.system(size: 13, weight: .semibold, design: .rounded))
+                            .foregroundStyle(MacUI.Surfaces.ink)
+                    }
+
+                    HStack(spacing: 8) {
+                        shareBar(share: app.share)
+                        Text(app.formattedSessionCount)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .fixedSize()
+                    }
+                }
+            }
+        }
+
+        private func shareBar(share: Double) -> some View {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(MacUI.Surfaces.ink.opacity(0.08))
+                    Capsule()
+                        .fill(MacUI.Brand.orange)
+                        .frame(width: max(4, geo.size.width * CGFloat(min(max(share, 0), 1))))
+                }
+            }
+            .frame(height: 5)
+        }
+
+        @ViewBuilder
+        private func icon(for app: DictationAppUsage) -> some View {
+            if app.id == DictationAppUsage.otherID {
+                placeholderIcon("square.stack")
+            } else if let bundleID = app.bundleID,
+                let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+            {
+                Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                    .resizable()
+                    .interpolation(.high)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            } else {
+                placeholderIcon("app.dashed")
+            }
+        }
+
+        private func placeholderIcon(_ systemName: String) -> some View {
+            Image(systemName: systemName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(MacUI.Surfaces.ink.opacity(0.08))
+                )
+        }
+    }
+#endif

--- a/StetMac/Features/MacShell/Setting/MacDictationUsageStatsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacDictationUsageStatsView.swift
@@ -1,0 +1,79 @@
+#if os(macOS)
+    import SwiftUI
+
+    struct MacDictationUsageStatsView: View {
+        let summary: DictationUsageSummary
+
+        private let columns = [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10),
+        ]
+
+        var body: some View {
+            LazyVGrid(columns: columns, spacing: 10) {
+                card(
+                    systemImage: "clock",
+                    value: summary.formattedDuration,
+                    unit: "",
+                    caption: "Total dictation time"
+                )
+                card(
+                    systemImage: "mic",
+                    value: summary.formattedWordCount,
+                    unit: "words",
+                    caption: "Words dictated"
+                )
+                card(
+                    systemImage: "hourglass",
+                    value: summary.formattedTimeSaved,
+                    unit: "",
+                    caption: "Time saved"
+                )
+                card(
+                    systemImage: "bolt.fill",
+                    value: summary.formattedWordsPerMinute,
+                    unit: "WPM",
+                    caption: "Average dictation speed"
+                )
+            }
+        }
+
+        private func card(
+            systemImage: String,
+            value: String,
+            unit: String,
+            caption: String
+        ) -> some View {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 16)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(value)
+                            .font(.system(size: 22, weight: .semibold, design: .rounded))
+                            .foregroundStyle(MacUI.Surfaces.ink)
+                        if !unit.isEmpty {
+                            Text(LocalizedStringKey(unit))
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Text(LocalizedStringKey(caption))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 24)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(MacUI.Surfaces.selection)
+            )
+        }
+    }
+#endif

--- a/StetMac/Features/MacShell/Setting/MacOverviewSettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacOverviewSettingsView.swift
@@ -1,0 +1,37 @@
+#if os(macOS)
+    import SwiftUI
+
+    struct MacOverviewSettingsView: View {
+        @Environment(\.scenePhase) private var scenePhase
+        @State private var usageSummary = DictationUsageSummary.empty
+        @State private var activityContributions: [Date: Double] = [:]
+        @State private var appUsage: [DictationAppUsage] = []
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    MacDictationUsageStatsView(summary: usageSummary)
+                    MacDictationActivityHeatmapView(contributions: activityContributions)
+                    MacDictationAppUsageView(apps: appUsage)
+
+                    Text("Time saved is compared with typing at 40 WPM.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, MacUI.SettingsViewMetrics.detailHorizontalPadding)
+                .padding(.top, 8)
+                .padding(.bottom, MacUI.SettingsViewMetrics.formBottomPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .macSettingsTracksTitleScroll()
+            .task { reload() }
+            .onChange(of: scenePhase) { _, phase in if phase == .active { reload() } }
+        }
+
+        private func reload() {
+            usageSummary = DictationStatsModel.shared.usageSummary()
+            activityContributions = DictationStatsModel.shared.activityContributions()
+            appUsage = DictationStatsModel.shared.appUsage()
+        }
+    }
+#endif

--- a/StetMac/Features/MacShell/Setting/MacSettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacSettingsView.swift
@@ -27,6 +27,7 @@
     }
 
     private enum MacSettingsTab: String, CaseIterable, Identifiable, Hashable {
+        case overview
         case general
         case appearance
         case dictation
@@ -56,7 +57,7 @@
             switch self {
             case .general, .dictation, .microphone, .transcription, .voice, .meetings, .openAI, .dictionary:
                 return MacUI.SettingsViewMetrics.groupedFormTitleHorizontalPadding
-            case .appearance, .history:
+            case .overview, .appearance, .history:
                 return MacUI.SettingsViewMetrics.detailHorizontalPadding
             #if DEBUG
                 case .shaderDebug:
@@ -67,7 +68,7 @@
 
         var section: MacSettingsSection {
             switch self {
-            case .general, .appearance:
+            case .overview, .general, .appearance:
                 return .app
             case .dictation, .microphone, .transcription:
                 return .dictation
@@ -86,6 +87,8 @@
 
         var title: String {
             switch self {
+            case .overview:
+                return "Overview"
             case .general:
                 return "General"
             case .appearance:
@@ -119,7 +122,7 @@
 
         @StateObject private var dictionaryViewModel = DictionaryViewModel()
         @StateObject private var openAISettingsViewModel = MacOpenAISettingsViewModel()
-        @State private var selectedTab: MacSettingsTab = .general
+        @State private var selectedTab: MacSettingsTab = .overview
         @State private var titleScrollStore = MacSettingsTitleScrollStore()
 
         var body: some View {
@@ -254,6 +257,8 @@
         @ViewBuilder
         private func selectedContent(for tab: MacSettingsTab) -> some View {
             switch tab {
+            case .overview:
+                MacOverviewSettingsView()
             case .general:
                 MacGeneralSettingsView()
             case .appearance:
@@ -290,7 +295,7 @@
             if visibleTabs.contains(selectedTab) {
                 return selectedTab
             }
-            return visibleTabs.first ?? .general
+            return visibleTabs.first ?? .overview
         }
 
         private func reloadStateFromPreferences() {
@@ -302,7 +307,7 @@
             if visibleTabs.contains(selectedTab) {
                 return
             }
-            selectedTab = visibleTabs.first ?? .general
+            selectedTab = visibleTabs.first ?? .overview
         }
     }
 #endif

--- a/StetMac/Shared/Models/DictationStatsModel.swift
+++ b/StetMac/Shared/Models/DictationStatsModel.swift
@@ -22,11 +22,118 @@
         var startedAt: Date = Date()
         var durationSeconds: Double = 0
         var wordCount: Int = 0
+        var targetBundleID: String? = nil
+        var targetAppName: String? = nil
 
-        init(startedAt: Date, durationSeconds: Double, wordCount: Int) {
+        init(
+            startedAt: Date,
+            durationSeconds: Double,
+            wordCount: Int,
+            targetBundleID: String? = nil,
+            targetAppName: String? = nil
+        ) {
             self.startedAt = startedAt
             self.durationSeconds = durationSeconds
             self.wordCount = wordCount
+            self.targetBundleID = targetBundleID
+            self.targetAppName = targetAppName
+        }
+    }
+
+    struct DictationAppUsage: Equatable, Identifiable, Sendable {
+        static let unknownID = "unknown"
+        static let otherID = "other"
+        static let unknownName = "Unknown"
+        static let otherName = "Other"
+
+        var id: String
+        var bundleID: String?
+        var name: String
+        var sessionCount: Int
+        var wordCount: Int
+        var durationSeconds: TimeInterval
+        var share: Double
+
+        var formattedWordCount: String {
+            DictationUsageSummary.formatCompactCount(wordCount)
+        }
+
+        var formattedSessionCount: String {
+            sessionCount == 1 ? "1 session" : "\(sessionCount) sessions"
+        }
+    }
+
+    struct DictationUsageSummary: Equatable, Sendable {
+        static let assumedTypingWordsPerMinute = 40.0
+        static let empty = DictationUsageSummary(sessionCount: 0, totalDuration: 0, wordCount: 0)
+
+        var sessionCount: Int
+        var totalDuration: TimeInterval
+        var wordCount: Int
+
+        var averageWordsPerMinute: Double? {
+            guard totalDuration > 0, wordCount > 0 else { return nil }
+            return Double(wordCount) / (totalDuration / 60)
+        }
+
+        var timeSaved: TimeInterval {
+            guard wordCount > 0 else { return 0 }
+            let typingDuration = Double(wordCount) / Self.assumedTypingWordsPerMinute * 60
+            return max(0, typingDuration - totalDuration)
+        }
+
+        var formattedDuration: String {
+            Self.formatDuration(totalDuration)
+        }
+
+        var formattedWordCount: String {
+            Self.formatCompactCount(wordCount)
+        }
+
+        var formattedTimeSaved: String {
+            Self.formatDuration(timeSaved)
+        }
+
+        var formattedWordsPerMinute: String {
+            guard let averageWordsPerMinute else { return "—" }
+            return "\(Int(averageWordsPerMinute.rounded()))"
+        }
+
+        private static func formatDuration(_ duration: TimeInterval) -> String {
+            let totalSeconds = max(0, Int(duration.rounded()))
+            let hours = totalSeconds / 3_600
+            let minutes = (totalSeconds % 3_600) / 60
+            let seconds = totalSeconds % 60
+
+            if hours > 0, minutes > 0 {
+                return "\(hours) hr \(minutes) min"
+            }
+            if hours > 0 {
+                return "\(hours) hr"
+            }
+            if minutes > 0 {
+                return "\(minutes) min"
+            }
+            return "\(seconds) sec"
+        }
+
+        static func formatCompactCount(_ count: Int) -> String {
+            switch count {
+            case 1_000_000...:
+                return compact(Double(count) / 1_000_000, suffix: "M")
+            case 1_000...:
+                return compact(Double(count) / 1_000, suffix: "K")
+            default:
+                return "\(count)"
+            }
+        }
+
+        private static func compact(_ value: Double, suffix: String) -> String {
+            let roundedToOneDecimal = (value * 10).rounded() / 10
+            if roundedToOneDecimal >= 100 || roundedToOneDecimal == roundedToOneDecimal.rounded() {
+                return "\(Int(roundedToOneDecimal.rounded()))\(suffix)"
+            }
+            return String(format: "%.1f\(suffix)", roundedToOneDecimal)
         }
     }
 
@@ -39,36 +146,166 @@
             self.modelContainer = modelContainer
         }
 
-        nonisolated func record(startedAt: Date, durationSeconds: Double, wordCount: Int) {
+        nonisolated func record(
+            startedAt: Date,
+            durationSeconds: Double,
+            wordCount: Int,
+            targetBundleID: String? = nil,
+            targetAppName: String? = nil
+        ) {
             guard let context = modelContext else { return }
             context.insert(
-                DictationSessionRecord(startedAt: startedAt, durationSeconds: durationSeconds, wordCount: wordCount)
+                DictationSessionRecord(
+                    startedAt: startedAt,
+                    durationSeconds: durationSeconds,
+                    wordCount: wordCount,
+                    targetBundleID: Self.normalized(targetBundleID),
+                    targetAppName: Self.normalized(targetAppName)
+                )
             )
             try? context.save()
         }
 
+        nonisolated func usageSummary(since date: Date? = nil) -> DictationUsageSummary {
+            let sessions = fetchSessions(since: date)
+            return DictationUsageSummary(
+                sessionCount: sessions.count,
+                totalDuration: sessions.reduce(0) { $0 + $1.durationSeconds },
+                wordCount: sessions.reduce(0) { $0 + $1.wordCount }
+            )
+        }
+
         nonisolated func todaySessionCount() -> Int {
-            fetchSessions(since: startOfToday()).count
+            usageSummary(since: startOfToday()).sessionCount
         }
 
         nonisolated func todayTotalDuration() -> TimeInterval {
-            fetchSessions(since: startOfToday()).reduce(0) { $0 + $1.durationSeconds }
+            usageSummary(since: startOfToday()).totalDuration
         }
 
         nonisolated func allTimeSessionCount() -> Int {
-            fetchSessions(since: nil).count
+            usageSummary().sessionCount
         }
 
         nonisolated func allTimeTotalDuration() -> TimeInterval {
-            fetchSessions(since: nil).reduce(0) { $0 + $1.durationSeconds }
+            usageSummary().totalDuration
         }
 
         nonisolated func todayTotalWordCount() -> Int {
-            fetchSessions(since: startOfToday()).reduce(0) { $0 + $1.wordCount }
+            usageSummary(since: startOfToday()).wordCount
         }
 
         nonisolated func allTimeTotalWordCount() -> Int {
-            fetchSessions(since: nil).reduce(0) { $0 + $1.wordCount }
+            usageSummary().wordCount
+        }
+
+        nonisolated func activityContributions(
+            now: Date = Date(),
+            calendar: Calendar = .current
+        ) -> [Date: Double] {
+            let today = calendar.startOfDay(for: now)
+            let since = calendar.date(byAdding: .day, value: -364, to: today)
+            let sessions = fetchSessions(since: since)
+            var totals: [Date: Double] = [:]
+            for session in sessions {
+                let day = calendar.startOfDay(for: session.startedAt)
+                totals[day, default: 0] += Double(session.wordCount)
+            }
+            return totals
+        }
+
+        nonisolated func appUsage(limit: Int = 6) -> [DictationAppUsage] {
+            let sessions = fetchSessions(since: nil)
+            guard !sessions.isEmpty else { return [] }
+
+            struct Accumulator {
+                var bundleID: String?
+                var name: String
+                var sessionCount: Int
+                var wordCount: Int
+                var durationSeconds: TimeInterval
+            }
+
+            var grouped: [String: Accumulator] = [:]
+            for session in sessions {
+                let bundleID = Self.normalized(session.targetBundleID)
+                let appName = Self.normalized(session.targetAppName)
+                let key: String
+                if let bundleID {
+                    key = bundleID
+                } else if let appName {
+                    key = "name:\(appName)"
+                } else {
+                    key = DictationAppUsage.unknownID
+                }
+
+                var current =
+                    grouped[key]
+                    ?? Accumulator(
+                        bundleID: bundleID,
+                        name: appName ?? DictationAppUsage.unknownName,
+                        sessionCount: 0,
+                        wordCount: 0,
+                        durationSeconds: 0
+                    )
+                current.sessionCount += 1
+                current.wordCount += session.wordCount
+                current.durationSeconds += session.durationSeconds
+                if current.name == DictationAppUsage.unknownName, let appName {
+                    current.name = appName
+                }
+                if current.bundleID == nil {
+                    current.bundleID = bundleID
+                }
+                grouped[key] = current
+            }
+
+            let totalWords = sessions.reduce(0) { $0 + $1.wordCount }
+            let totalSessions = sessions.count
+            let ranked = grouped.map { key, value in
+                DictationAppUsage(
+                    id: key,
+                    bundleID: value.bundleID,
+                    name: value.name,
+                    sessionCount: value.sessionCount,
+                    wordCount: value.wordCount,
+                    durationSeconds: value.durationSeconds,
+                    share: Self.share(
+                        words: value.wordCount,
+                        totalWords: totalWords,
+                        sessions: value.sessionCount,
+                        totalSessions: totalSessions
+                    )
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.wordCount != rhs.wordCount { return lhs.wordCount > rhs.wordCount }
+                if lhs.sessionCount != rhs.sessionCount { return lhs.sessionCount > rhs.sessionCount }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+
+            guard ranked.count > limit else { return ranked }
+
+            let top = Array(ranked.prefix(limit))
+            let rest = ranked.dropFirst(limit)
+            let otherWords = rest.reduce(0) { $0 + $1.wordCount }
+            let otherSessions = rest.reduce(0) { $0 + $1.sessionCount }
+            let otherDuration = rest.reduce(0) { $0 + $1.durationSeconds }
+            let other = DictationAppUsage(
+                id: DictationAppUsage.otherID,
+                bundleID: nil,
+                name: DictationAppUsage.otherName,
+                sessionCount: otherSessions,
+                wordCount: otherWords,
+                durationSeconds: otherDuration,
+                share: Self.share(
+                    words: otherWords,
+                    totalWords: totalWords,
+                    sessions: otherSessions,
+                    totalSessions: totalSessions
+                )
+            )
+            return top + [other]
         }
 
         nonisolated static func makeInMemoryModelContainer() throws -> ModelContainer {
@@ -109,6 +346,26 @@
 
         nonisolated private func startOfToday() -> Date {
             Calendar.current.startOfDay(for: Date())
+        }
+
+        nonisolated private static func normalized(_ value: String?) -> String? {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        nonisolated private static func share(
+            words: Int,
+            totalWords: Int,
+            sessions: Int,
+            totalSessions: Int
+        ) -> Double {
+            if totalWords > 0 {
+                return Double(words) / Double(totalWords)
+            }
+            if totalSessions > 0 {
+                return Double(sessions) / Double(totalSessions)
+            }
+            return 0
         }
 
         nonisolated private static func persistentStoreURL(

--- a/StetMacTests/Shared/Models/DictationStatsModelTests.swift
+++ b/StetMacTests/Shared/Models/DictationStatsModelTests.swift
@@ -1,0 +1,105 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+
+    @testable import Stet
+
+    @Suite("Dictation Stats Model", .serialized)
+    struct DictationStatsModelTests {
+        @Test func recordsSessionsIntoAnAllTimeSummary() throws {
+            let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
+            model.record(startedAt: Date(timeIntervalSince1970: 1), durationSeconds: 60, wordCount: 80)
+            model.record(startedAt: Date(timeIntervalSince1970: 100), durationSeconds: 120, wordCount: 160)
+
+            let summary = model.usageSummary()
+            #expect(summary.sessionCount == 2)
+            #expect(summary.totalDuration == 180)
+            #expect(summary.wordCount == 240)
+            #expect(summary.averageWordsPerMinute == 80)
+            #expect(summary.timeSaved == 180)
+        }
+
+        @Test func formatsDurationWordCountAndSpeed() {
+            let summary = DictationUsageSummary(
+                sessionCount: 1,
+                totalDuration: (13 * 3_600) + (20 * 60),
+                wordCount: 103_000
+            )
+
+            #expect(summary.formattedDuration == "13 hr 20 min")
+            #expect(summary.formattedWordCount == "103K")
+            #expect(summary.formattedWordsPerMinute == "129")
+            #expect(summary.formattedTimeSaved == "29 hr 35 min")
+        }
+
+        @Test func formatsEmptyAndCompactValues() {
+            #expect(DictationUsageSummary.empty.formattedDuration == "0 sec")
+            #expect(DictationUsageSummary.empty.formattedWordCount == "0")
+            #expect(DictationUsageSummary.empty.formattedWordsPerMinute == "—")
+            #expect(DictationUsageSummary.empty.formattedTimeSaved == "0 sec")
+
+            let hoursOnly = DictationUsageSummary(sessionCount: 1, totalDuration: 51 * 3_600, wordCount: 0)
+            #expect(hoursOnly.formattedDuration == "51 hr")
+
+            let thousands = DictationUsageSummary(sessionCount: 1, totalDuration: 60, wordCount: 1_500)
+            #expect(thousands.formattedWordCount == "1.5K")
+        }
+
+        @Test func activityContributionsMergeSessionsOnTheSameDay() throws {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+            calendar.firstWeekday = 1
+
+            let formatter = ISO8601DateFormatter()
+            let morning = formatter.date(from: "2026-09-12T08:00:00Z")!
+            let evening = formatter.date(from: "2026-09-12T18:00:00Z")!
+            let now = formatter.date(from: "2026-09-12T20:00:00Z")!
+
+            let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
+            model.record(startedAt: morning, durationSeconds: 60, wordCount: 100)
+            model.record(startedAt: evening, durationSeconds: 30, wordCount: 50)
+
+            let contributions = model.activityContributions(now: now, calendar: calendar)
+            let day = calendar.startOfDay(for: morning)
+            #expect(contributions[day] == 150)
+            #expect(contributions.count == 1)
+        }
+
+        @Test func appUsageGroupsByBundleAndRanksByWords() throws {
+            let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
+            model.record(
+                startedAt: Date(), durationSeconds: 30, wordCount: 40,
+                targetBundleID: "com.apple.Safari", targetAppName: "Safari")
+            model.record(
+                startedAt: Date(), durationSeconds: 20, wordCount: 10,
+                targetBundleID: "com.apple.Safari", targetAppName: "Safari")
+            model.record(
+                startedAt: Date(), durationSeconds: 60, wordCount: 100,
+                targetBundleID: "com.todesktop.230313mzl4w4u92", targetAppName: "Cursor")
+
+            let apps = model.appUsage()
+            #expect(apps.map(\.name) == ["Cursor", "Safari"])
+            #expect(apps[0].sessionCount == 1)
+            #expect(apps[0].wordCount == 100)
+            #expect(apps[1].sessionCount == 2)
+            #expect(apps[1].wordCount == 50)
+            #expect(apps[0].share == 100.0 / 150.0)
+        }
+
+        @Test func appUsageBucketsUnknownAndOther() throws {
+            let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 10)
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 9, targetBundleID: "a", targetAppName: "A")
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 8, targetBundleID: "b", targetAppName: "B")
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 7, targetBundleID: "c", targetAppName: "C")
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 1, targetBundleID: "d", targetAppName: "D")
+
+            let apps = model.appUsage(limit: 3)
+            #expect(apps.map(\.name) == ["Unknown", "A", "B", "Other"])
+            #expect(apps[0].sessionCount == 1)
+            #expect(apps[3].name == "Other")
+            #expect(apps[3].sessionCount == 2)
+            #expect(apps[3].wordCount == 8)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- Add an Overview tab that shows dictation time, word count, time saved vs 40 WPM typing, and average speed.
- Render the last 12 months with HeatmapKit’s GitHub-style contribution graph, and rank target apps by words and session count.
- Record the frontmost app’s name and bundle ID when a dictation completes so later sessions can be grouped; older records without an app show as Unknown.

## Test plan
- [ ] Open Settings → Overview and confirm the four summary cards match existing dictation history.
- [ ] Confirm the heatmap stays inside the card, month labels do not overlap, and recent activity lights the latest days.
- [ ] Dictate into another app with the hotkey, reopen Overview, and confirm that app appears by localized name (not bundle ID) with session count and word share.
- [ ] Confirm older sessions without app metadata still appear as Unknown and do not crash SwiftData on launch.


Made with [Cursor](https://cursor.com)