### PR TITLE
Stop dictation-complete system notifications

### DIFF
--- a/StetMac/App/Lifecycle/MacAppModel.swift
+++ b/StetMac/App/Lifecycle/MacAppModel.swift
@@ -95,7 +95,6 @@
                 systemAudioMuting: systemAudioMuting,
                 settingsStore: settingsStore,
                 interactionSoundPlayer: interactionSoundPlayer,
-                completionNotifier: MacDictationCompletionNotificationService.shared,
                 statsModel: .shared
             )
             let sessionController = MacAppSessionController(

--- a/StetMac/App/Workflows/MacDictationWorkflowController.swift
+++ b/StetMac/App/Workflows/MacDictationWorkflowController.swift
@@ -20,7 +20,6 @@
         private let systemAudioMuting: (any SystemAudioMuting)?
         private let settingsStore: DictationSettingsStore
         private let interactionSoundPlayer: any InteractionSoundPlaying
-        private let completionNotifier: (any MacDictationCompletionNotifying)?
         private let mediaResumeDelay: Duration
         private let mediaResumeSleep: @Sendable (Duration) async throws -> Void
         private let startPromptActivationDeadline: Duration
@@ -42,7 +41,6 @@
             systemAudioMuting: (any SystemAudioMuting)? = nil,
             settingsStore: DictationSettingsStore,
             interactionSoundPlayer: any InteractionSoundPlaying,
-            completionNotifier: (any MacDictationCompletionNotifying)? = nil,
             statsModel: DictationStatsModel? = nil,
             mediaResumeDelay: Duration = .seconds(1),
             startPromptActivationDeadline: Duration = .milliseconds(350),
@@ -54,7 +52,6 @@
             self.systemAudioMuting = systemAudioMuting
             self.settingsStore = settingsStore
             self.interactionSoundPlayer = interactionSoundPlayer
-            self.completionNotifier = completionNotifier
             self.statsModel = statsModel
             self.mediaResumeDelay = mediaResumeDelay
             self.mediaResumeSleep = mediaResumeSleep
@@ -242,9 +239,6 @@
             let settings = settingsSnapshot
             if outcome == .completed, settings.interactionSoundsEnabled {
                 interactionSoundPlayer.playFinish(preset: settings.interactionSoundPreset)
-            }
-            if outcome == .completed, settings.dictationCompletionNotificationsEnabled {
-                await completionNotifier?.notifyDictationCompleted()
             }
             return outcome
         }

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "Hintergrundaudio stummgeschaltet";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet kann Feedback geben und Ablenkungen während des Sprechens begrenzen.";
 "Stet can play a sound and show a notification after your words are inserted." = "Stet kann nach dem Einfügen deiner Wörter einen Ton abspielen und eine Mitteilung zeigen.";
-"Dictation complete" = "Diktat abgeschlossen";
 "Always show onboarding while debugging" = "Onboarding beim Debuggen immer anzeigen";
 "Restart Onboarding Now" = "Onboarding jetzt neu starten";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "Sie können auch mit `--force-onboarding` oder `STET_FORCE_ONBOARDING=1` starten.";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -47,7 +47,6 @@
 "Mute background audio" = "Mute background audio";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet can provide feedback and limit distractions while you are speaking.";
 "Stet can play a sound and show a notification after your words are inserted." = "Stet can play a sound and show a notification after your words are inserted.";
-"Dictation complete" = "Dictation complete";
 "Always show onboarding while debugging" = "Always show onboarding while debugging";
 "Restart Onboarding Now" = "Restart Onboarding Now";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`.";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "Silenciar audio de fondo";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet puede proporcionar comentarios y limitar las distracciones mientras hablas.";
 "Stet can play a sound and show a notification after your words are inserted." = "Stet puede reproducir un sonido y mostrar una notificación cuando se inserten tus palabras.";
-"Dictation complete" = "Dictado completado";
 "Always show onboarding while debugging" = "Mostrar siempre la guía de inicio al depurar";
 "Restart Onboarding Now" = "Reiniciar guía de inicio ahora";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "También puedes iniciar con `--force-onboarding` o `STET_FORCE_ONBOARDING=1`.";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "Désactiver le son en arrière-plan";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet peut fournir des retours et limiter les distractions pendant que vous parlez.";
 "Stet can play a sound and show a notification after your words are inserted." = "Stet peut jouer un son et afficher une notification une fois vos mots insérés.";
-"Dictation complete" = "Dictée terminée";
 "Always show onboarding while debugging" = "Toujours afficher la présentation lors du débogage";
 "Restart Onboarding Now" = "Redémarrer la présentation maintenant";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "Vous pouvez également lancer avec `--force-onboarding` ou `STET_FORCE_ONBOARDING=1`.";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "Disattiva audio in background";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet può fornire un feedback e limitare le distrazioni mentre parli.";
 "Stet can play a sound and show a notification after your words are inserted." = "Stet può riprodurre un suono e mostrare una notifica dopo l'inserimento delle parole.";
-"Dictation complete" = "Dettatura completata";
 "Always show onboarding while debugging" = "Mostra sempre la guida iniziale durante il debug";
 "Restart Onboarding Now" = "Riavvia guida iniziale adesso";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "Puoi avviare anche con `--force-onboarding` o `STET_FORCE_ONBOARDING=1`.";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "バックグラウンドオーディオをミュート";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stetは、話している間にフィードバックを提供し、気を散らすものを減らすことができます。";
 "Stet can play a sound and show a notification after your words are inserted." = "文字の挿入後、Stetはサウンドを再生し、通知を表示できます。";
-"Dictation complete" = "入力が完了しました";
 "Always show onboarding while debugging" = "デバッグ中は常にオンボーディングを表示";
 "Restart Onboarding Now" = "今すぐオンボーディングを再開";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "`--force-onboarding` または `STET_FORCE_ONBOARDING=1` を使用して起動することもできます。";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "백그라운드 오디오 음소거";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet은 말하는 동안 피드백을 제공하고 주의 산만을 줄일 수 있습니다.";
 "Stet can play a sound and show a notification after your words are inserted." = "텍스트가 삽입된 후 Stet이 소리를 재생하고 알림을 표시할 수 있습니다.";
-"Dictation complete" = "받아쓰기 완료";
 "Always show onboarding while debugging" = "디버깅 시 항상 온보딩 표시";
 "Restart Onboarding Now" = "지금 온보딩 다시 시작";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "`--force-onboarding` 또는 `STET_FORCE_ONBOARDING=1`로 시작할 수도 있습니다.";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "Silenciar áudio de fundo";
 "Stet can provide feedback and limit distractions while you are speaking." = "O Stet pode fornecer feedback e limitar distrações enquanto você fala.";
 "Stet can play a sound and show a notification after your words are inserted." = "O Stet pode reproduzir um som e mostrar uma notificação depois que suas palavras forem inseridas.";
-"Dictation complete" = "Ditado concluído";
 "Always show onboarding while debugging" = "Sempre mostrar guia inicial ao depurar";
 "Restart Onboarding Now" = "Reiniciar guia inicial agora";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "Você também pode iniciar com `--force-onboarding` ou `STET_FORCE_ONBOARDING=1`.";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -47,7 +47,6 @@
 "Mute background audio" = "静音后台音频";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet 可以在您说话时提供反馈并减少干扰。";
 "Stet can play a sound and show a notification after your words are inserted." = "文字插入后，Stet 可以播放提示音并显示通知。";
-"Dictation complete" = "听写完成";
 "Always show onboarding while debugging" = "调试时始终显示引导";
 "Restart Onboarding Now" = "立即重新开始引导";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "您也可以使用 `--force-onboarding` 或 `STET_FORCE_ONBOARDING=1` 启动。";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -46,7 +46,6 @@
 "Mute background audio" = "靜音背景音訊";
 "Stet can provide feedback and limit distractions while you are speaking." = "Stet 可以在您說話時提供回饋並減少干擾。";
 "Stet can play a sound and show a notification after your words are inserted." = "文字插入後，Stet 可以播放提示音並顯示通知。";
-"Dictation complete" = "聽寫完成";
 "Always show onboarding while debugging" = "除錯時始終顯示導引";
 "Restart Onboarding Now" = "立即重新開始導引";
 "You can also launch with `--force-onboarding` or `STET_FORCE_ONBOARDING=1`." = "您也可以使用 `--force-onboarding` 或 `STET_FORCE_ONBOARDING=1` 啟動。";

--- a/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
+++ b/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
@@ -3,16 +3,8 @@
     import UserNotifications
 
     @MainActor
-    protocol MacDictationCompletionNotifying: AnyObject {
-        func notifyDictationCompleted() async
-    }
-
-    @MainActor
-    final class MacDictationCompletionNotificationService: NSObject, MacDictationCompletionNotifying,
-        UNUserNotificationCenterDelegate
-    {
+    final class MacDictationCompletionNotificationService: NSObject, UNUserNotificationCenterDelegate {
         static let shared = MacDictationCompletionNotificationService()
-        static let requestIdentifier = "stet.dictation.completed"
 
         private let center: UNUserNotificationCenter
         private var didInstallDelegate = false
@@ -32,12 +24,6 @@
             let settings = await center.notificationSettings()
             guard settings.authorizationStatus == .notDetermined else { return }
             _ = try? await center.requestAuthorization(options: [.alert])
-        }
-
-        func notifyDictationCompleted() async {
-            let content = UNMutableNotificationContent()
-            content.title = String(localized: "Dictation complete")
-            await post(content, identifier: Self.requestIdentifier)
         }
 
         func notifyMeetingPhase(

--- a/StetMacTests/App/Workflows/MacDictationWorkflowControllerTests.swift
+++ b/StetMacTests/App/Workflows/MacDictationWorkflowControllerTests.swift
@@ -76,15 +76,6 @@
     }
 
     @MainActor
-    private final class TestCompletionNotifier: MacDictationCompletionNotifying {
-        private(set) var notifyCallCount = 0
-
-        func notifyDictationCompleted() async {
-            notifyCallCount += 1
-        }
-    }
-
-    @MainActor
     @Suite("Mac Dictation Workflow Controller", .serialized)
     struct MacDictationWorkflowControllerTests {
         private let promptActivationDeadline: Duration = .milliseconds(20)
@@ -96,7 +87,6 @@
             mediaPlaybackController: TestMediaPlaybackController? = nil,
             systemAudioMuting: TestSystemAudioMuting? = nil,
             interactionSoundPlayer: TestInteractionSoundPlayer? = nil,
-            completionNotifier: TestCompletionNotifier? = nil,
             frontmostBundleIdentifier: String? = nil,
             mediaResumeDelay: Duration = .zero,
             mediaResumeSleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
@@ -107,8 +97,7 @@
             textInjectionService: TestTextInjectionService,
             mediaPlaybackController: TestMediaPlaybackController,
             systemAudioMuting: TestSystemAudioMuting?,
-            interactionSoundPlayer: TestInteractionSoundPlayer,
-            completionNotifier: TestCompletionNotifier
+            interactionSoundPlayer: TestInteractionSoundPlayer
         ) {
             let defaults = defaults ?? TestSupport.makeUserDefaults()
             let speechService = speechService ?? ControllableSpeechService()
@@ -116,7 +105,6 @@
             let mediaPlaybackController = mediaPlaybackController ?? TestMediaPlaybackController()
             let systemAudioMuting = systemAudioMuting
             let interactionSoundPlayer = interactionSoundPlayer ?? TestInteractionSoundPlayer()
-            let completionNotifier = completionNotifier ?? TestCompletionNotifier()
             if defaults.object(forKey: MacPreferences.interactionSoundsEnabled) == nil {
                 defaults.set(false, forKey: MacPreferences.interactionSoundsEnabled)
             }
@@ -142,7 +130,6 @@
                 systemAudioMuting: systemAudioMuting,
                 settingsStore: settingsStore,
                 interactionSoundPlayer: interactionSoundPlayer,
-                completionNotifier: completionNotifier,
                 mediaResumeDelay: mediaResumeDelay,
                 startPromptActivationDeadline: promptActivationDeadline,
                 mediaResumeSleep: mediaResumeSleep
@@ -155,8 +142,7 @@
                 textInjectionService: textInjectionService,
                 mediaPlaybackController: mediaPlaybackController,
                 systemAudioMuting: systemAudioMuting,
-                interactionSoundPlayer: interactionSoundPlayer,
-                completionNotifier: completionNotifier
+                interactionSoundPlayer: interactionSoundPlayer
             )
         }
 
@@ -523,51 +509,6 @@
             let outcome = await subject.controller.handleCompletedResult(text: "hello") {}
             #expect(outcome == .completed)
             #expect(subject.interactionSoundPlayer.finishCallCount == 1)
-        }
-
-        @Test func completionNotificationPostsAfterSuccessfulTextDelivery() async {
-            let defaults = TestSupport.makeUserDefaults()
-            defaults.set(true, forKey: MacPreferences.dictationCompletionNotificationsEnabled)
-            let textInjectionService = TestTextInjectionService()
-            textInjectionService.pasteResult = true
-            let subject = makeController(
-                defaults: defaults,
-                textInjectionService: textInjectionService
-            )
-
-            let outcome = await subject.controller.handleCompletedResult(text: "hello there") {}
-            #expect(outcome == .completed)
-            #expect(subject.completionNotifier.notifyCallCount == 1)
-        }
-
-        @Test func completionNotificationDoesNotPostWhenDisabled() async {
-            let defaults = TestSupport.makeUserDefaults()
-            defaults.set(false, forKey: MacPreferences.dictationCompletionNotificationsEnabled)
-            let textInjectionService = TestTextInjectionService()
-            textInjectionService.pasteResult = true
-            let subject = makeController(
-                defaults: defaults,
-                textInjectionService: textInjectionService
-            )
-
-            let outcome = await subject.controller.handleCompletedResult(text: "hello") {}
-            #expect(outcome == .completed)
-            #expect(subject.completionNotifier.notifyCallCount == 0)
-        }
-
-        @Test func completionNotificationDoesNotPostWhenTextDeliveryFails() async {
-            let defaults = TestSupport.makeUserDefaults()
-            defaults.set(true, forKey: MacPreferences.dictationCompletionNotificationsEnabled)
-            let textInjectionService = TestTextInjectionService()
-            textInjectionService.pasteOutcome = .eventPostedVerificationUnavailable
-            let subject = makeController(
-                defaults: defaults,
-                textInjectionService: textInjectionService
-            )
-
-            let outcome = await subject.controller.handleCompletedResult(text: "hello") {}
-            #expect(outcome == .failed(.pasteVerificationUnavailable))
-            #expect(subject.completionNotifier.notifyCallCount == 0)
         }
 
         @Test func finishSoundDoesNotPlayWhenTextDeliveryFails() async {


### PR DESCRIPTION
## Summary
- Remove the macOS system banner that fired after every successful dictation insert.
- Leave meeting recording notifications and the existing settings toggle unchanged.

## Test plan
- [ ] Dictate once with text successfully inserted: no “Dictation complete” banner.
- [ ] Empty/silent dictation also does not post a completion banner.
- [ ] Start/stop a meeting: recording phase notifications still appear.
- [ ] Settings → Dictation still shows “Notify when dictation completes”; toggling it does not restore dictation banners.


Made with [Cursor](https://cursor.com)