### PR TITLE
Hide unknown apps from Overview usage

### DIFF
--- a/StetMac/Shared/Models/DictationStatsModel.swift
+++ b/StetMac/Shared/Models/DictationStatsModel.swift
@@ -41,9 +41,7 @@
     }
 
     struct DictationAppUsage: Equatable, Identifiable, Sendable {
-        static let unknownID = "unknown"
         static let otherID = "other"
-        static let unknownName = "Unknown"
         static let otherName = "Other"
 
         var id: String
@@ -236,14 +234,14 @@
                 } else if let appName {
                     key = "name:\(appName)"
                 } else {
-                    key = DictationAppUsage.unknownID
+                    continue
                 }
 
                 var current =
                     grouped[key]
                     ?? Accumulator(
                         bundleID: bundleID,
-                        name: appName ?? DictationAppUsage.unknownName,
+                        name: appName ?? bundleID ?? key,
                         sessionCount: 0,
                         wordCount: 0,
                         durationSeconds: 0
@@ -251,7 +249,7 @@
                 current.sessionCount += 1
                 current.wordCount += session.wordCount
                 current.durationSeconds += session.durationSeconds
-                if current.name == DictationAppUsage.unknownName, let appName {
+                if let appName {
                     current.name = appName
                 }
                 if current.bundleID == nil {
@@ -260,8 +258,10 @@
                 grouped[key] = current
             }
 
-            let totalWords = sessions.reduce(0) { $0 + $1.wordCount }
-            let totalSessions = sessions.count
+            guard !grouped.isEmpty else { return [] }
+
+            let totalWords = grouped.values.reduce(0) { $0 + $1.wordCount }
+            let totalSessions = grouped.values.reduce(0) { $0 + $1.sessionCount }
             let ranked = grouped.map { key, value in
                 DictationAppUsage(
                     id: key,

--- a/StetMacTests/Shared/Models/DictationStatsModelTests.swift
+++ b/StetMacTests/Shared/Models/DictationStatsModelTests.swift
@@ -86,7 +86,7 @@
             #expect(apps[0].share == 100.0 / 150.0)
         }
 
-        @Test func appUsageBucketsUnknownAndOther() throws {
+        @Test func appUsageOmitsUnknownAndBucketsOther() throws {
             let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
             model.record(startedAt: Date(), durationSeconds: 10, wordCount: 10)
             model.record(startedAt: Date(), durationSeconds: 10, wordCount: 9, targetBundleID: "a", targetAppName: "A")
@@ -95,11 +95,18 @@
             model.record(startedAt: Date(), durationSeconds: 10, wordCount: 1, targetBundleID: "d", targetAppName: "D")
 
             let apps = model.appUsage(limit: 3)
-            #expect(apps.map(\.name) == ["Unknown", "A", "B", "Other"])
-            #expect(apps[0].sessionCount == 1)
+            #expect(apps.map(\.name) == ["A", "B", "C", "Other"])
+            #expect(apps[0].share == 9.0 / 25.0)
             #expect(apps[3].name == "Other")
-            #expect(apps[3].sessionCount == 2)
-            #expect(apps[3].wordCount == 8)
+            #expect(apps[3].sessionCount == 1)
+            #expect(apps[3].wordCount == 1)
+        }
+
+        @Test func appUsageHidesListWhenEverySessionIsUnknown() throws {
+            let model = DictationStatsModel(modelContainer: try DictationStatsModel.makeInMemoryModelContainer())
+            model.record(startedAt: Date(), durationSeconds: 10, wordCount: 10)
+
+            #expect(model.appUsage().isEmpty)
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- Settings Overview no longer lists a catch-all **Unknown** row for dictation sessions that never recorded a target app.
- Rank and share now use known apps only; overflow still folds into **Other**. Sessions with no app metadata stay in the totals above, they just do not appear in By app.

## Test plan
- [ ] Open Settings → Overview with mixed history: known apps remain, Unknown is gone.
- [ ] Confirm word-count bars still add up among the remaining apps (plus Other).
- [ ] If every stored session has no target app, By app stays empty instead of showing Unknown.
- [x] `xcodebuild … -only-testing:StetTests/DictationStatsModelTests` passed.


Made with [Cursor](https://cursor.com)