### PR TITLE
Add the real Qoder CN bundle ID to paste compatibility

### DIFF
--- a/StetMac/Resources/app-compatibility.json
+++ b/StetMac/Resources/app-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "revision": 2,
+  "revision": 3,
   "bundleIDs": [
     "com.microsoft.vscode",
     "com.microsoft.vscodeinsiders",
@@ -31,6 +31,8 @@
     "com.baidu.baidunetdisk-mac",
     "com.qoder.work",
     "com.qoder.ide",
+    "com.qodercn.app",
+    "com.qoder.app",
     "io.open-design.desktop",
     "now.typeless.desktop",
     "app.motrix.native",

--- a/StetMacTests/Core/TextInput/AppCompatibilityStoreTests.swift
+++ b/StetMacTests/Core/TextInput/AppCompatibilityStoreTests.swift
@@ -15,6 +15,7 @@
             let store = AppCompatibilityStore()
             #expect(store.contains("com.openai.codex"))
             #expect(store.contains("COM.MICROSOFT.VSCODE"))
+            #expect(store.contains("com.qodercn.app"))
             #expect(store.contains("com.kingsoft.wpsoffice.mac.global"))
             #expect(!store.contains(nil))
             #expect(!store.contains("unknown.app"))


### PR DESCRIPTION
## Summary
- Qoder CN is an Electron app, but the list had guessed IDs (`com.qoder.work`, `com.qoder.ide`) that do not match the installed app.
- Add the verified Bundle ID `com.qodercn.app`, plus `com.qoder.app` for the international build, and bump the list to revision 3.

## Test plan
- [ ] Merge, then in Stet Settings → General → App Compatibility tap Check (or wait for the 24h refresh)
- [ ] Dictate into Qoder CN and confirm paste completes without the verification fallback
- [ ] `python3 scripts/validate-app-compatibility.py --base-ref origin/main`


Made with [Cursor](https://cursor.com)