### PR TITLE
Make MCP initialize idempotent so clients can reconnect

### DIFF
--- a/StetMac/Core/MCP/StetMCPProtocolServer.swift
+++ b/StetMac/Core/MCP/StetMCPProtocolServer.swift
@@ -18,6 +18,13 @@ actor StetMCPProtocolServer {
     static let listUnorganizedMeetingsToolName = "stet_list_unorganized_meetings"
     static let getMeetingTranscriptToolName = "stet_get_meeting_transcript"
 
+    private static let serverName = "stet"
+    private static let serverVersion = "1.0.0"
+    private static let serverTitle = "Stet Meetings"
+    private static let serverInstructions =
+        "Read meeting recordings already captured by Stet. Listing tools return metadata only. Use stet_get_meeting_transcript to fetch a saved transcript. Do not wait on transcription; Stet processes audio in the app."
+    private static let serverCapabilities = Server.Capabilities(tools: .init(listChanged: false))
+
     private let catalog: any MCPMeetingServing
     private let transport: StatelessHTTPServerTransport
     private let server: Server
@@ -27,12 +34,11 @@ actor StetMCPProtocolServer {
         self.catalog = catalog
         self.transport = StatelessHTTPServerTransport()
         self.server = Server(
-            name: "stet",
-            version: "1.0.0",
-            title: "Stet Meetings",
-            instructions:
-                "Read meeting recordings already captured by Stet. Listing tools return metadata only. Use stet_get_meeting_transcript to fetch a saved transcript. Do not wait on transcription; Stet processes audio in the app.",
-            capabilities: .init(tools: .init(listChanged: false))
+            name: Self.serverName,
+            version: Self.serverVersion,
+            title: Self.serverTitle,
+            instructions: Self.serverInstructions,
+            capabilities: Self.serverCapabilities
         )
     }
 
@@ -47,6 +53,11 @@ actor StetMCPProtocolServer {
             await Self.callTool(parameters, catalog: catalog)
         }
         try await server.start(transport: transport)
+        // Stateless HTTP has no session. Cursor reconnects by sending initialize
+        // again; the SDK's default handler rejects that for the process lifetime.
+        await server.withMethodHandler(Initialize.self) { params in
+            Self.initializeResult(requestedProtocolVersion: params.protocolVersion)
+        }
         started = true
     }
 
@@ -208,6 +219,23 @@ actor StetMCPProtocolServer {
                 ]),
                 "additionalProperties": .bool(false),
             ])
+        )
+    }
+
+    private nonisolated static func initializeResult(requestedProtocolVersion: String) -> Initialize.Result {
+        let protocolVersion =
+            Version.supported.contains(requestedProtocolVersion)
+            ? requestedProtocolVersion
+            : Version.latest
+        return Initialize.Result(
+            protocolVersion: protocolVersion,
+            capabilities: serverCapabilities,
+            serverInfo: .init(
+                name: serverName,
+                version: serverVersion,
+                title: serverTitle
+            ),
+            instructions: serverInstructions
         )
     }
 

--- a/StetMacTests/Core/MCP/StetMCPProtocolServerTests.swift
+++ b/StetMacTests/Core/MCP/StetMCPProtocolServerTests.swift
@@ -160,6 +160,46 @@ struct StetMCPProtocolServerTests {
         #expect(emptyInboxResult["isError"] as? Bool == true)
     }
 
+    @Test func initializeIsIdempotentForClientReconnects() async throws {
+        let server = StetMCPProtocolServer(catalog: MCPStubMeetingCatalog())
+        try await server.start()
+        defer { Task { await server.stop() } }
+
+        try await initialize(server, id: 1)
+        try await initialize(server, id: 2)
+
+        let listResponse = await server.handleRawRequest(
+            method: "POST",
+            headers: protocolHeaders,
+            body: try jsonData([
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/list",
+                "params": [:],
+            ])
+        )
+        #expect(listResponse.statusCode == 200)
+        let listJSON = try responseJSON(listResponse)
+        #expect(listJSON["error"] == nil)
+        let listResult = try #require(listJSON["result"] as? [String: Any])
+        let tools = try #require(listResult["tools"] as? [[String: Any]])
+        #expect(tools.count == 3)
+    }
+
+    @Test func initializeAcceptsStreamableHTTPAcceptHeader() async throws {
+        let server = StetMCPProtocolServer(catalog: MCPStubMeetingCatalog())
+        try await server.start()
+        defer { Task { await server.stop() } }
+
+        try await initialize(
+            server,
+            headers: [
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            ]
+        )
+    }
+
     private let protocolVersion = "2025-11-25"
 
     private var baseHeaders: [String: String] {
@@ -173,13 +213,17 @@ struct StetMCPProtocolServerTests {
         baseHeaders.merging(["MCP-Protocol-Version": protocolVersion]) { _, new in new }
     }
 
-    private func initialize(_ server: StetMCPProtocolServer) async throws {
+    private func initialize(
+        _ server: StetMCPProtocolServer,
+        headers: [String: String]? = nil,
+        id: Int = 1
+    ) async throws {
         let response = await server.handleRawRequest(
             method: "POST",
-            headers: baseHeaders,
+            headers: headers ?? baseHeaders,
             body: try jsonData([
                 "jsonrpc": "2.0",
-                "id": 1,
+                "id": id,
                 "method": "initialize",
                 "params": [
                     "protocolVersion": protocolVersion,
@@ -189,6 +233,12 @@ struct StetMCPProtocolServerTests {
             ])
         )
         #expect(response.statusCode == 200)
+        let json = try responseJSON(response)
+        #expect(json["error"] == nil)
+        let result = try #require(json["result"] as? [String: Any])
+        #expect(result["protocolVersion"] as? String == protocolVersion)
+        let serverInfo = try #require(result["serverInfo"] as? [String: Any])
+        #expect(serverInfo["name"] as? String == "stet")
     }
 }
 


### PR DESCRIPTION
## Summary

- Register a custom `Initialize` handler on the MCP `Server` so repeated handshakes succeed instead of being rejected.
- Hoist the server name, version, title, instructions and capabilities into `private static let` so the constructor and the new handler build one identical `Initialize.Result`.

The MCP Swift SDK's default `Initialize` handler latches `isInitialized` on the `Server` actor for its whole lifetime and throws `invalidRequest("Server is already initialized")` on every later handshake. That assumes one initialize per connection, which holds for stdio and `StatefulHTTPServerTransport`. Stet uses `StatelessHTTPServerTransport` — no `Mcp-Session-Id`, so a client has no credential to resume with and must re-initialize — while `StetMCPServerController` keeps one `Server` alive for the entire app run.

The result was N reconnects against a one-shot latch: the first handshake after launch worked, then every reconnect (Cursor window reload, `mcp.json` edit, server toggle, wake-from-sleep health check, a second MCP client on the same port) failed and the client reported the server as unreachable even though the port was listening. Restarting Stet temporarily "fixed" it.

The replacement handler is a pure function — it never reads or writes initialization state — so it returns the same result on call 1 and call 100.

It deliberately does not call `setInitialState`, so `clientInfo` / `clientCapabilities` / `protocolVersion` stay unset. That is safe today because `Server.Configuration.default` is `strict: false`, and `checkInitialized()` only gates requests under strict mode. If Stet ever enables strict mode or uses server-to-client capabilities (sampling, elicitation, roots), this needs real per-session state rather than a process-wide latch.

## Test plan

- [x] `initializeIsIdempotentForClientReconnects` — two `initialize` requests with different ids, then `tools/list` must return all three tools with no JSON-RPC error.
- [x] `initializeAcceptsStreamableHTTPAcceptHeader` — guards the spec-conformant `Accept: application/json, text/event-stream` header real clients send, so the transport's `AcceptHeaderValidator` cannot 406 it.
- [x] The shared `initialize` helper now asserts no error, an echoed `protocolVersion`, and `serverInfo.name == "stet"`.
- [ ] Manually reconnect the Cursor MCP server against a running Stet without restarting the app.