### PR TITLE
Add guided MCP setup to Settings

### DIFF
--- a/StetMac/App/Lifecycle/MacAppContracts.swift
+++ b/StetMac/App/Lifecycle/MacAppContracts.swift
@@ -81,7 +81,7 @@
     }
 
     @MainActor
-    protocol MacSettingsShellCoordinating: AnyObject, MacGeneralSettingsAppModeling {
+    protocol MacSettingsShellCoordinating: AnyObject, MacGeneralSettingsAppModeling, MacMCPSettingsAppModeling {
         func openSettings(using action: () -> Void)
         func settingsDidAppear()
         func settingsDidDisappear()

--- a/StetMac/App/Lifecycle/MacAppModel.swift
+++ b/StetMac/App/Lifecycle/MacAppModel.swift
@@ -21,11 +21,13 @@
         private let liveMeetingPhaseStore: MCPLiveMeetingPhaseStore?
         private var passiveListeningRuntime: MacPassiveListeningRuntime?
         private var meetingRecordingRuntime: MacMeetingRecordingRuntime?
+        private var mcpServerStateHandler: (@MainActor (StetMCPServerState) -> Void)?
 
         @Published private(set) var passiveListeningState: MacPassiveListeningState =
             .unavailable("Preparing passive listening")
         @Published private(set) var isPassiveListeningEnabled = true
         @Published private(set) var meetingRecordingPhase: MacMeetingRecordingPhase = .idle
+        @Published private(set) var mcpServerState: StetMCPServerState = .disabled
 
         private var cancellables = Set<AnyCancellable>()
 
@@ -114,6 +116,7 @@
             self.appearanceSettingsViewModel = .shared
             self.mcpServerController = mcpServerController
             self.liveMeetingPhaseStore = liveMeetingPhaseStore
+            self.mcpServerState = mcpServerController?.state ?? .disabled
             self.isPassiveListeningEnabled = MacFeatureAvailability.isPassiveListeningEnabled(
                 preference: settingsStore.loadPassiveListeningEnabled()
             )
@@ -131,6 +134,10 @@
                 }
                 .store(in: &cancellables)
             sessionController.activate(presentationModel: self, showInDock: launchConfiguration.showInDock)
+            mcpServerController?.onStateChange = { [weak self] state in
+                self?.mcpServerState = state
+                self?.mcpServerStateHandler?(state)
+            }
             mcpServerController?.startIfEnabled()
 
             sessionController.isMeetingSessionBusy = { [weak self] in
@@ -561,6 +568,17 @@
 
         func applyDockVisibility(showInDock: Bool) {
             sessionController.applyDockVisibility(showInDock: showInDock)
+        }
+
+        func setMCPServerEnabled(_ enabled: Bool) async -> StetMCPServerState {
+            guard let mcpServerController else { return .disabled }
+            await mcpServerController.setEnabled(enabled)
+            return mcpServerController.state
+        }
+
+        func setMCPServerStateHandler(_ handler: @escaping @MainActor (StetMCPServerState) -> Void) {
+            mcpServerStateHandler = handler
+            handler(mcpServerState)
         }
 
         var isDebugForceOnboardingEnabled: Bool {

--- a/StetMac/Core/MCP/StetMCPHTTPServer.swift
+++ b/StetMac/Core/MCP/StetMCPHTTPServer.swift
@@ -32,7 +32,7 @@ actor StetMCPHTTPServer {
         self.requestHandler = requestHandler
     }
 
-    func run() async throws {
+    func run(onReady: @Sendable () async -> Void = {}) async throws {
         guard channel == nil else { return }
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: max(1, min(2, System.coreCount)))
@@ -64,6 +64,7 @@ actor StetMCPHTTPServer {
 
         channel = boundChannel
         eventLoopGroup = group
+        await onReady()
 
         do {
             try await withTaskCancellationHandler {

--- a/StetMac/Core/MCP/StetMCPServerController.swift
+++ b/StetMac/Core/MCP/StetMCPServerController.swift
@@ -3,8 +3,15 @@
     import os
 
     nonisolated protocol StetMCPRuntimeServing: Sendable {
-        func run() async throws
+        func run(onReady: @Sendable () async -> Void) async throws
         func stop() async
+    }
+
+    nonisolated enum StetMCPServerState: Equatable, Sendable {
+        case disabled
+        case starting
+        case running
+        case failed(String)
     }
 
     actor StetMCPServer: StetMCPRuntimeServing {
@@ -19,10 +26,10 @@
             self.httpServer = httpServer
         }
 
-        func run() async throws {
+        func run(onReady: @Sendable () async -> Void) async throws {
             try await protocolServer.start()
             do {
-                try await httpServer.run()
+                try await httpServer.run(onReady: onReady)
                 await protocolServer.stop()
             } catch {
                 await protocolServer.stop()
@@ -45,6 +52,9 @@
         private let logger: Logger
         private var server: (any StetMCPRuntimeServing)?
         private var serverTask: Task<Void, Never>?
+        private var runID = UUID()
+        private(set) var state: StetMCPServerState = .disabled
+        var onStateChange: ((StetMCPServerState) -> Void)?
 
         init(
             defaults: UserDefaults = .standard,
@@ -82,31 +92,74 @@
 
         func startIfEnabled() {
             guard defaults.bool(forKey: MacPreferences.mcpServerEnabled) else { return }
+            start()
+        }
+
+        func setEnabled(_ enabled: Bool) async {
+            defaults.set(enabled, forKey: MacPreferences.mcpServerEnabled)
+            if enabled {
+                start()
+            } else {
+                await stop()
+            }
+        }
+
+        private func start() {
             guard serverTask == nil else { return }
 
             let server = makeServer()
             let logger = self.logger
+            let runID = UUID()
+            self.runID = runID
             self.server = server
-            serverTask = Task {
+            updateState(.starting)
+            serverTask = Task { [weak self] in
                 do {
-                    try await server.run()
+                    try await server.run {
+                        await self?.markRunning(runID: runID)
+                    }
                     logger.info("Stet MCP server stopped.")
+                    self?.finish(runID: runID, state: .disabled)
                 } catch is CancellationError {
                     logger.info("Stet MCP server cancelled.")
+                    self?.finish(runID: runID, state: .disabled)
                 } catch {
                     logger.error("Stet MCP server failed: \(error.localizedDescription)")
+                    self?.finish(runID: runID, state: .failed(error.localizedDescription))
                 }
             }
         }
 
-        func stop() {
-            guard let server else { return }
-            serverTask?.cancel()
+        func stop() async {
+            guard let server else {
+                updateState(.disabled)
+                return
+            }
+            let task = serverTask
+            task?.cancel()
+            await server.stop()
+            await task?.value
             serverTask = nil
             self.server = nil
-            Task {
-                await server.stop()
-            }
+            updateState(.disabled)
+        }
+
+        private func markRunning(runID: UUID) {
+            guard self.runID == runID else { return }
+            updateState(.running)
+        }
+
+        private func finish(runID: UUID, state: StetMCPServerState) {
+            guard self.runID == runID else { return }
+            serverTask = nil
+            server = nil
+            updateState(state)
+        }
+
+        private func updateState(_ state: StetMCPServerState) {
+            guard self.state != state else { return }
+            self.state = state
+            onStateChange?(state)
         }
 
         deinit {

--- a/StetMac/Features/MacShell/Setting/MacMCPSettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacMCPSettingsView.swift
@@ -1,0 +1,145 @@
+#if os(macOS)
+    import Combine
+    import SwiftUI
+
+    @MainActor
+    protocol MacMCPSettingsAppModeling: AnyObject {
+        var mcpServerState: StetMCPServerState { get }
+        func setMCPServerEnabled(_ enabled: Bool) async -> StetMCPServerState
+        func setMCPServerStateHandler(_ handler: @escaping @MainActor (StetMCPServerState) -> Void)
+    }
+
+    @MainActor
+    final class MacMCPSettingsViewModel: ObservableObject {
+        static let setupPrompt = """
+            Configure the Stet MCP server for this coding agent.
+
+            Server name: stet
+            Transport: HTTP
+            URL: http://127.0.0.1:49321/mcp
+
+            Use the MCP configuration format and location supported by the current coding agent. Preserve all existing MCP servers and settings. After updating the configuration, validate the configuration syntax, connect to the server, and call an available Stet tool to verify the integration. If the client must be reloaded, tell me exactly what to do.
+            """
+
+        @Published private(set) var state: StetMCPServerState = .disabled
+        @Published private(set) var copySucceeded = false
+
+        private let clipboardService: any ClipboardService
+        private weak var appModel: (any MacMCPSettingsAppModeling)?
+
+        init(clipboardService: (any ClipboardService)? = nil) {
+            self.clipboardService = clipboardService ?? SystemClipboardService()
+        }
+
+        var isEnabled: Bool {
+            state != .disabled
+        }
+
+        var isTransitioning: Bool {
+            state == .starting
+        }
+
+        func configure(appModel: any MacMCPSettingsAppModeling) {
+            self.appModel = appModel
+            state = appModel.mcpServerState
+            appModel.setMCPServerStateHandler { [weak self] state in
+                self?.state = state
+            }
+        }
+
+        func setEnabled(_ enabled: Bool) {
+            Task { [weak self] in
+                guard let self, let appModel = self.appModel else { return }
+                state = await appModel.setMCPServerEnabled(enabled)
+            }
+        }
+
+        func copySetupPrompt() {
+            copySucceeded = clipboardService.copy(Self.setupPrompt)
+        }
+    }
+
+    struct MacMCPSettingsView: View {
+        @EnvironmentObject private var settingsShellViewModel: MacSettingsShellViewModel
+        @StateObject private var viewModel = MacMCPSettingsViewModel()
+
+        var body: some View {
+            Form {
+                Section {
+                    Toggle(
+                        "MCP Server",
+                        isOn: Binding(
+                            get: { viewModel.isEnabled },
+                            set: { viewModel.setEnabled($0) }
+                        )
+                    )
+                    .disabled(viewModel.isTransitioning)
+
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 7, height: 7)
+                        Text(statusText)
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.callout)
+                } footer: {
+                    Text("Let your coding agent access Stet through MCP.")
+                }
+
+                Section("Connect your coding agent") {
+                    instructionRow(number: 1, text: "Turn on MCP Server")
+                    instructionRow(number: 2, text: "Copy the setup prompt")
+                    instructionRow(number: 3, text: "Paste it into your coding agent")
+
+                    Button(viewModel.copySucceeded ? "Copied" : "Copy Setup Prompt") {
+                        viewModel.copySetupPrompt()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.isEnabled)
+                }
+            }
+            .macSettingsFormStyle()
+            .padding(.bottom, MacUI.SettingsViewMetrics.formBottomPadding)
+            .task {
+                viewModel.configure(appModel: settingsShellViewModel)
+            }
+        }
+
+        private func instructionRow(number: Int, text: LocalizedStringKey) -> some View {
+            HStack(spacing: 10) {
+                Text("\(number)")
+                    .font(.caption.weight(.semibold))
+                    .frame(width: 22, height: 22)
+                    .background(MacUI.Surfaces.selection, in: Circle())
+                Text(text)
+            }
+        }
+
+        private var statusText: LocalizedStringKey {
+            switch viewModel.state {
+            case .disabled:
+                "Off"
+            case .starting:
+                "Starting…"
+            case .running:
+                "Running"
+            case .failed:
+                "Failed to start"
+            }
+        }
+
+        private var statusColor: Color {
+            switch viewModel.state {
+            case .running:
+                .green
+            case .failed:
+                .red
+            case .starting:
+                .orange
+            case .disabled:
+                .secondary
+            }
+        }
+    }
+#endif

--- a/StetMac/Features/MacShell/Setting/MacSettingsShellViewModel.swift
+++ b/StetMac/Features/MacShell/Setting/MacSettingsShellViewModel.swift
@@ -3,7 +3,7 @@
     import Foundation
 
     @MainActor
-    final class MacSettingsShellViewModel: ObservableObject, MacGeneralSettingsAppModeling {
+    final class MacSettingsShellViewModel: ObservableObject, MacGeneralSettingsAppModeling, MacMCPSettingsAppModeling {
         private let coordinator: any MacSettingsShellCoordinating
 
         init(coordinator: any MacSettingsShellCoordinating) {
@@ -32,6 +32,18 @@
 
         func applyDockVisibility(showInDock: Bool) {
             coordinator.applyDockVisibility(showInDock: showInDock)
+        }
+
+        var mcpServerState: StetMCPServerState {
+            coordinator.mcpServerState
+        }
+
+        func setMCPServerEnabled(_ enabled: Bool) async -> StetMCPServerState {
+            await coordinator.setMCPServerEnabled(enabled)
+        }
+
+        func setMCPServerStateHandler(_ handler: @escaping @MainActor (StetMCPServerState) -> Void) {
+            coordinator.setMCPServerStateHandler(handler)
         }
 
         var isDebugForceOnboardingEnabled: Bool {

--- a/StetMac/Features/MacShell/Setting/MacSettingsView.swift
+++ b/StetMac/Features/MacShell/Setting/MacSettingsView.swift
@@ -35,6 +35,7 @@
         case transcription
         case voice
         case meetings
+        case mcp
         case openAI
         case dictionary
         case history
@@ -55,7 +56,7 @@
 
         var titleHorizontalPadding: CGFloat {
             switch self {
-            case .general, .dictation, .microphone, .transcription, .voice, .meetings, .openAI, .dictionary:
+            case .general, .dictation, .microphone, .transcription, .voice, .meetings, .mcp, .openAI, .dictionary:
                 return MacUI.SettingsViewMetrics.groupedFormTitleHorizontalPadding
             case .overview, .appearance, .history:
                 return MacUI.SettingsViewMetrics.detailHorizontalPadding
@@ -68,7 +69,7 @@
 
         var section: MacSettingsSection {
             switch self {
-            case .overview, .general, .appearance:
+            case .overview, .general, .appearance, .mcp:
                 return .app
             case .dictation, .microphone, .transcription:
                 return .dictation
@@ -103,6 +104,8 @@
                 return "Voice"
             case .meetings:
                 return "Meetings"
+            case .mcp:
+                return "MCP"
             case .openAI:
                 return "Refine"
             case .dictionary:
@@ -273,6 +276,8 @@
                 MacVoiceSettingsView()
             case .meetings:
                 MacMeetingSettingsView()
+            case .mcp:
+                MacMCPSettingsView()
             case .openAI:
                 MacOpenAISettingsView(viewModel: openAISettingsViewModel)
             case .dictionary:

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "Optimieren";
 "Dictionary" = "Wörterbuch";
 "Debug" = "Debug";
+"MCP" = "MCP";
+"MCP Server" = "MCP-Server";
+"Let your coding agent access Stet through MCP." = "Erlaube deinem Coding-Agent den Zugriff auf Stet über MCP.";
+"Connect your coding agent" = "Coding-Agent verbinden";
+"Turn on MCP Server" = "MCP-Server einschalten";
+"Copy the setup prompt" = "Einrichtungsanweisung kopieren";
+"Paste it into your coding agent" = "In deinen Coding-Agent einfügen";
+"Copy Setup Prompt" = "Einrichtungsanweisung kopieren";
+"Copied" = "Kopiert";
+"Off" = "Aus";
+"Starting…" = "Wird gestartet…";
+"Running" = "Aktiv";
+"Failed to start" = "Start fehlgeschlagen";
 
 /* Settings search */
 "Search settings" = "Einstellungen durchsuchen";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -29,6 +29,21 @@
 "Refine" = "Refine";
 "Dictionary" = "Dictionary";
 "Debug" = "Debug";
+"MCP" = "MCP";
+
+/* MCP settings */
+"MCP Server" = "MCP Server";
+"Let your coding agent access Stet through MCP." = "Let your coding agent access Stet through MCP.";
+"Connect your coding agent" = "Connect your coding agent";
+"Turn on MCP Server" = "Turn on MCP Server";
+"Copy the setup prompt" = "Copy the setup prompt";
+"Paste it into your coding agent" = "Paste it into your coding agent";
+"Copy Setup Prompt" = "Copy Setup Prompt";
+"Copied" = "Copied";
+"Off" = "Off";
+"Starting…" = "Starting…";
+"Running" = "Running";
+"Failed to start" = "Failed to start";
 
 /* Settings search */
 "Search settings" = "Search settings";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "Refinar";
 "Dictionary" = "Diccionario";
 "Debug" = "Depurar";
+"MCP" = "MCP";
+"MCP Server" = "Servidor MCP";
+"Let your coding agent access Stet through MCP." = "Permite que tu agente de programación acceda a Stet mediante MCP.";
+"Connect your coding agent" = "Conecta tu agente de programación";
+"Turn on MCP Server" = "Activa el servidor MCP";
+"Copy the setup prompt" = "Copia las instrucciones de configuración";
+"Paste it into your coding agent" = "Pégalas en tu agente de programación";
+"Copy Setup Prompt" = "Copiar instrucciones";
+"Copied" = "Copiado";
+"Off" = "Desactivado";
+"Starting…" = "Iniciando…";
+"Running" = "En ejecución";
+"Failed to start" = "No se pudo iniciar";
 
 /* Settings search */
 "Search settings" = "Buscar en configuración";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "Améliorer";
 "Dictionary" = "Dictionnaire";
 "Debug" = "Débogage";
+"MCP" = "MCP";
+"MCP Server" = "Serveur MCP";
+"Let your coding agent access Stet through MCP." = "Autorisez votre agent de codage à accéder à Stet via MCP.";
+"Connect your coding agent" = "Connecter votre agent de codage";
+"Turn on MCP Server" = "Activer le serveur MCP";
+"Copy the setup prompt" = "Copier l’instruction de configuration";
+"Paste it into your coding agent" = "La coller dans votre agent de codage";
+"Copy Setup Prompt" = "Copier l’instruction";
+"Copied" = "Copié";
+"Off" = "Désactivé";
+"Starting…" = "Démarrage…";
+"Running" = "En cours";
+"Failed to start" = "Échec du démarrage";
 
 /* Settings search */
 "Search settings" = "Rechercher dans les réglages";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "Perfeziona";
 "Dictionary" = "Dizionario";
 "Debug" = "Debug";
+"MCP" = "MCP";
+"MCP Server" = "Server MCP";
+"Let your coding agent access Stet through MCP." = "Consenti al tuo agente di coding di accedere a Stet tramite MCP.";
+"Connect your coding agent" = "Connetti il tuo agente di coding";
+"Turn on MCP Server" = "Attiva il server MCP";
+"Copy the setup prompt" = "Copia le istruzioni di configurazione";
+"Paste it into your coding agent" = "Incollale nel tuo agente di coding";
+"Copy Setup Prompt" = "Copia istruzioni";
+"Copied" = "Copiato";
+"Off" = "Disattivato";
+"Starting…" = "Avvio…";
+"Running" = "In esecuzione";
+"Failed to start" = "Avvio non riuscito";
 
 /* Settings search */
 "Search settings" = "Cerca nelle impostazioni";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "改善";
 "Dictionary" = "辞書";
 "Debug" = "デバッグ";
+"MCP" = "MCP";
+"MCP Server" = "MCP サーバー";
+"Let your coding agent access Stet through MCP." = "Coding Agent が MCP 経由で Stet にアクセスできるようにします。";
+"Connect your coding agent" = "Coding Agent を接続";
+"Turn on MCP Server" = "MCP サーバーをオンにする";
+"Copy the setup prompt" = "設定指示をコピー";
+"Paste it into your coding agent" = "Coding Agent に貼り付ける";
+"Copy Setup Prompt" = "設定指示をコピー";
+"Copied" = "コピー済み";
+"Off" = "オフ";
+"Starting…" = "起動中…";
+"Running" = "実行中";
+"Failed to start" = "起動できませんでした";
 
 /* Settings search */
 "Search settings" = "設定を検索";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "개선";
 "Dictionary" = "사전";
 "Debug" = "디버그";
+"MCP" = "MCP";
+"MCP Server" = "MCP 서버";
+"Let your coding agent access Stet through MCP." = "Coding Agent가 MCP를 통해 Stet에 접근하도록 허용합니다.";
+"Connect your coding agent" = "Coding Agent 연결";
+"Turn on MCP Server" = "MCP 서버 켜기";
+"Copy the setup prompt" = "설정 지침 복사";
+"Paste it into your coding agent" = "Coding Agent에 붙여넣기";
+"Copy Setup Prompt" = "설정 지침 복사";
+"Copied" = "복사됨";
+"Off" = "꺼짐";
+"Starting…" = "시작 중…";
+"Running" = "실행 중";
+"Failed to start" = "시작하지 못함";
 
 /* Settings search */
 "Search settings" = "설정 검색";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "Refinar";
 "Dictionary" = "Dicionário";
 "Debug" = "Depurar";
+"MCP" = "MCP";
+"MCP Server" = "Servidor MCP";
+"Let your coding agent access Stet through MCP." = "Permita que seu agente de programação acesse o Stet pelo MCP.";
+"Connect your coding agent" = "Conecte seu agente de programação";
+"Turn on MCP Server" = "Ative o servidor MCP";
+"Copy the setup prompt" = "Copie as instruções de configuração";
+"Paste it into your coding agent" = "Cole no seu agente de programação";
+"Copy Setup Prompt" = "Copiar instruções";
+"Copied" = "Copiado";
+"Off" = "Desativado";
+"Starting…" = "Iniciando…";
+"Running" = "Em execução";
+"Failed to start" = "Falha ao iniciar";
 
 /* Settings search */
 "Search settings" = "Buscar nas configurações";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -29,6 +29,21 @@
 "Refine" = "优化";
 "Dictionary" = "词典";
 "Debug" = "调试";
+"MCP" = "MCP";
+
+/* MCP settings */
+"MCP Server" = "MCP 服务器";
+"Let your coding agent access Stet through MCP." = "让你的 Coding Agent 通过 MCP 访问 Stet。";
+"Connect your coding agent" = "连接你的 Coding Agent";
+"Turn on MCP Server" = "开启 MCP 服务器";
+"Copy the setup prompt" = "复制配置指令";
+"Paste it into your coding agent" = "将指令发送给你的 Coding Agent";
+"Copy Setup Prompt" = "复制配置指令";
+"Copied" = "已复制";
+"Off" = "已关闭";
+"Starting…" = "正在启动…";
+"Running" = "运行中";
+"Failed to start" = "启动失败";
 
 /* Settings search */
 "Search settings" = "搜索设置";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -28,6 +28,19 @@
 "Refine" = "最佳化";
 "Dictionary" = "詞典";
 "Debug" = "除錯";
+"MCP" = "MCP";
+"MCP Server" = "MCP 伺服器";
+"Let your coding agent access Stet through MCP." = "讓你的 Coding Agent 透過 MCP 存取 Stet。";
+"Connect your coding agent" = "連接你的 Coding Agent";
+"Turn on MCP Server" = "開啟 MCP 伺服器";
+"Copy the setup prompt" = "複製設定指令";
+"Paste it into your coding agent" = "將指令傳送給你的 Coding Agent";
+"Copy Setup Prompt" = "複製設定指令";
+"Copied" = "已複製";
+"Off" = "已關閉";
+"Starting…" = "正在啟動…";
+"Running" = "執行中";
+"Failed to start" = "啟動失敗";
 
 /* Settings search */
 "Search settings" = "搜尋設定";

--- a/StetMacTests/Core/MCP/StetMCPServerControllerTests.swift
+++ b/StetMacTests/Core/MCP/StetMCPServerControllerTests.swift
@@ -43,7 +43,7 @@
             _ = await TestSupport.eventuallyAsync {
                 await runtime.runCount == 1
             }
-            controller.stop()
+            await controller.stop()
 
             let stopped = await TestSupport.eventuallyAsync {
                 await runtime.stopCount == 1
@@ -64,6 +64,26 @@
             }
             #expect(attempted)
         }
+
+        @Test func setEnabledPersistsAndAppliesImmediately() async {
+            let defaults = TestSupport.makeUserDefaults()
+            let runtime = MCPRuntimeRecorder()
+            let controller = StetMCPServerController(defaults: defaults) { runtime }
+
+            await controller.setEnabled(true)
+            let running = await TestSupport.eventuallyAsync {
+                await MainActor.run { controller.state == .running }
+            }
+
+            #expect(running)
+            #expect(defaults.bool(forKey: MacPreferences.mcpServerEnabled))
+
+            await controller.setEnabled(false)
+
+            #expect(controller.state == .disabled)
+            #expect(!defaults.bool(forKey: MacPreferences.mcpServerEnabled))
+            #expect(await runtime.stopCount == 1)
+        }
     }
 
     private actor MCPRuntimeRecorder: StetMCPRuntimeServing {
@@ -75,10 +95,14 @@
             self.runError = runError
         }
 
-        func run() async throws {
+        func run(onReady: @Sendable () async -> Void) async throws {
             runCount += 1
             if let runError {
                 throw runError
+            }
+            await onReady()
+            while !Task.isCancelled {
+                try await Task.sleep(for: .seconds(60))
             }
         }
 

--- a/StetMacTests/Features/MacShell/Setting/MacMCPSettingsViewModelTests.swift
+++ b/StetMacTests/Features/MacShell/Setting/MacMCPSettingsViewModelTests.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+    import Testing
+
+    @testable import Stet
+
+    @MainActor
+    @Suite("Mac MCP Settings View Model")
+    struct MacMCPSettingsViewModelTests {
+        @Test func copiesPersistentSetupPrompt() {
+            let clipboard = TestClipboardService()
+            let viewModel = MacMCPSettingsViewModel(clipboardService: clipboard)
+
+            viewModel.copySetupPrompt()
+
+            #expect(viewModel.copySucceeded)
+            #expect(clipboard.copiedTexts == [MacMCPSettingsViewModel.setupPrompt])
+            #expect(clipboard.transientFlags == [false])
+            #expect(MacMCPSettingsViewModel.setupPrompt.contains("http://127.0.0.1:49321/mcp"))
+            #expect(MacMCPSettingsViewModel.setupPrompt.contains("Preserve all existing MCP servers"))
+        }
+
+        @Test func forwardsToggleAndTracksServerState() async {
+            let appModel = TestMacMCPSettingsAppModel()
+            let viewModel = MacMCPSettingsViewModel(clipboardService: TestClipboardService())
+            viewModel.configure(appModel: appModel)
+
+            viewModel.setEnabled(true)
+            let started = await TestSupport.eventuallyAsync {
+                await MainActor.run { appModel.enabledChanges == [true] }
+            }
+
+            #expect(started)
+            #expect(viewModel.state == .running)
+        }
+    }
+
+    @MainActor
+    private final class TestMacMCPSettingsAppModel: MacMCPSettingsAppModeling {
+        var mcpServerState: StetMCPServerState = .disabled
+        var enabledChanges: [Bool] = []
+        private var stateHandler: (@MainActor (StetMCPServerState) -> Void)?
+
+        func setMCPServerEnabled(_ enabled: Bool) async -> StetMCPServerState {
+            enabledChanges.append(enabled)
+            mcpServerState = enabled ? .running : .disabled
+            stateHandler?(mcpServerState)
+            return mcpServerState
+        }
+
+        func setMCPServerStateHandler(_ handler: @escaping @MainActor (StetMCPServerState) -> Void) {
+            stateHandler = handler
+            handler(mcpServerState)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- add a dedicated MCP Settings page with a live server toggle and concise three-step agent setup guide
- copy a hidden setup prompt that preserves existing client configuration and verifies the Stet connection
- report actual server startup state, support immediate start/stop, and localize the flow across supported languages

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (562 tests)
- `make lint`
- `plutil -lint StetMac/Resources/Localizations/*.lproj/Localizable.strings`