### PR TITLE
Add agent-synced meeting reminders

### DIFF
--- a/StetMac/App/Lifecycle/MacAppModel.swift
+++ b/StetMac/App/Lifecycle/MacAppModel.swift
@@ -19,8 +19,10 @@
         private let appearanceSettingsViewModel: MacAppearanceSettingsViewModel
         private let mcpServerController: StetMCPServerController?
         private let liveMeetingPhaseStore: MCPLiveMeetingPhaseStore?
+        private let expectedMeetingCoordinator: (any ExpectedMeetingServing)?
         private var passiveListeningRuntime: MacPassiveListeningRuntime?
         private var meetingRecordingRuntime: MacMeetingRecordingRuntime?
+        private var activeExpectedMeetingID: UUID?
 
         @Published private(set) var passiveListeningState: MacPassiveListeningState =
             .unavailable("Preparing passive listening")
@@ -33,6 +35,10 @@
             let settingsStore = DictationSettingsStore()
             let captureService = MacAudioCaptureService()
             let liveMeetingPhaseStore = MCPLiveMeetingPhaseStore()
+            let notificationService = MacDictationCompletionNotificationService.shared
+            let expectedMeetingCoordinator = ExpectedMeetingCoordinator(
+                reminders: notificationService
+            )
             let passiveListeningRuntime = MacPassiveListeningRuntime(captureService: captureService)
             let meetingRecordingRuntime = MacMeetingRecordingRuntime.live(
                 captureService: captureService,
@@ -64,11 +70,13 @@
                     pasteboardRestoreCoordinator: pasteboardRestoreCoordinator
                 ),
                 mcpServerController: StetMCPServerController.live(
-                    livePhaseStore: liveMeetingPhaseStore
+                    livePhaseStore: liveMeetingPhaseStore,
+                    expectedMeetings: expectedMeetingCoordinator
                 ),
                 passiveListeningRuntime: passiveListeningRuntime,
                 meetingRecordingRuntime: meetingRecordingRuntime,
-                liveMeetingPhaseStore: liveMeetingPhaseStore
+                liveMeetingPhaseStore: liveMeetingPhaseStore,
+                expectedMeetingCoordinator: expectedMeetingCoordinator
             )
         }
 
@@ -83,7 +91,8 @@
             mcpServerController: StetMCPServerController? = nil,
             passiveListeningRuntime: MacPassiveListeningRuntime? = nil,
             meetingRecordingRuntime: MacMeetingRecordingRuntime? = nil,
-            liveMeetingPhaseStore: MCPLiveMeetingPhaseStore? = nil
+            liveMeetingPhaseStore: MCPLiveMeetingPhaseStore? = nil,
+            expectedMeetingCoordinator: (any ExpectedMeetingServing)? = nil
         ) {
             let bootstrapper = MacAppBootstrapper(settingsStore: settingsStore)
             let captureCoordinator =
@@ -114,6 +123,7 @@
             self.appearanceSettingsViewModel = .shared
             self.mcpServerController = mcpServerController
             self.liveMeetingPhaseStore = liveMeetingPhaseStore
+            self.expectedMeetingCoordinator = expectedMeetingCoordinator
             self.isPassiveListeningEnabled = MacFeatureAvailability.isPassiveListeningEnabled(
                 preference: settingsStore.loadPassiveListeningEnabled()
             )
@@ -133,6 +143,18 @@
             sessionController.activate(presentationModel: self, showInDock: launchConfiguration.showInDock)
             mcpServerController?.startIfEnabled()
 
+            let notificationService = MacDictationCompletionNotificationService.shared
+            notificationService.onStartExpectedMeeting = { [weak self] id in
+                self?.startExpectedMeeting(id: id)
+            }
+            notificationService.onSkipExpectedMeeting = { [weak self] id in
+                guard let coordinator = self?.expectedMeetingCoordinator else { return }
+                Task { try? await coordinator.skip(id: id) }
+            }
+            if let expectedMeetingCoordinator {
+                Task { await expectedMeetingCoordinator.restoreReminders() }
+            }
+
             sessionController.isMeetingSessionBusy = { [weak self] in
                 self?.isMeetingBusy ?? false
             }
@@ -148,6 +170,14 @@
                         let previous = self.meetingRecordingPhase
                         self.meetingRecordingPhase = phase
                         self.liveMeetingPhaseStore?.update(phase)
+                        if case .processing = previous,
+                            phase == .idle || phase.isFailure,
+                            let id = self.activeExpectedMeetingID,
+                            let coordinator = self.expectedMeetingCoordinator
+                        {
+                            self.activeExpectedMeetingID = nil
+                            Task { try? await coordinator.markCompleted(id: id) }
+                        }
                         Task {
                             await MacDictationCompletionNotificationService.shared.notifyMeetingPhase(
                                 from: previous,
@@ -551,6 +581,24 @@
             Task { await meetingRecordingRuntime.toggle() }
         }
 
+        private func startExpectedMeeting(id: UUID) {
+            guard !isMeetingBusy, let expectedMeetingCoordinator, let meetingRecordingRuntime else {
+                return
+            }
+            Task { [weak self] in
+                guard let meeting = await expectedMeetingCoordinator.meeting(id: id),
+                    meeting.status == .scheduled,
+                    meeting.scheduledEndAt > Date()
+                else { return }
+                await meetingRecordingRuntime.start(expectedMeeting: meeting)
+                guard case .recording(_, let folderName) = await meetingRecordingRuntime.currentPhase() else {
+                    return
+                }
+                self?.activeExpectedMeetingID = id
+                try? await expectedMeetingCoordinator.markRecorded(id: id, meetingID: folderName)
+            }
+        }
+
         func previewInteractionSound(_ preset: InteractionSoundPreset) {
             interactionSoundPlayer.playPreview(preset: preset)
         }
@@ -597,6 +645,13 @@
 
         private var settingsSnapshot: DictationSettingsSnapshot {
             settingsStore.loadSnapshot()
+        }
+    }
+
+    private extension MacMeetingRecordingPhase {
+        var isFailure: Bool {
+            if case .failed = self { return true }
+            return false
         }
     }
 #endif

--- a/StetMac/Core/MCP/MCPMeetingCatalog.swift
+++ b/StetMac/Core/MCP/MCPMeetingCatalog.swift
@@ -17,6 +17,7 @@
         let status: String
         let speakerCount: Int
         let failureMessage: String?
+        let metadata: MCPMeetingMetadata?
 
         private enum CodingKeys: String, CodingKey {
             case id
@@ -26,6 +27,7 @@
             case status
             case speakerCount = "speaker_count"
             case failureMessage = "failure_message"
+            case metadata
         }
     }
 
@@ -42,6 +44,7 @@
         let speakerCount: Int
         let transcript: String?
         let failureMessage: String?
+        let metadata: MCPMeetingMetadata?
 
         private enum CodingKeys: String, CodingKey {
             case id
@@ -52,6 +55,46 @@
             case speakerCount = "speaker_count"
             case transcript
             case failureMessage = "failure_message"
+            case metadata
+        }
+    }
+
+    struct MCPMeetingMetadata: Codable, Equatable, Sendable {
+        let expectedMeetingID: UUID?
+        let source: String?
+        let externalID: String?
+        let title: String?
+        let scheduledStartAt: String?
+        let scheduledEndAt: String?
+        let attendees: [MeetingAttendee]
+        let meetingURL: URL?
+
+        init(_ metadata: MeetingMetadata) {
+            self.expectedMeetingID = metadata.expectedMeetingID
+            self.source = metadata.source
+            self.externalID = metadata.externalID
+            self.title = metadata.title
+            self.scheduledStartAt = metadata.scheduledStartAt.map(Self.iso8601String)
+            self.scheduledEndAt = metadata.scheduledEndAt.map(Self.iso8601String)
+            self.attendees = metadata.attendees
+            self.meetingURL = metadata.meetingURL
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case expectedMeetingID = "expected_meeting_id"
+            case source
+            case externalID = "external_id"
+            case title
+            case scheduledStartAt = "scheduled_start_at"
+            case scheduledEndAt = "scheduled_end_at"
+            case attendees
+            case meetingURL = "meeting_url"
+        }
+
+        private nonisolated static func iso8601String(_ date: Date) -> String {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter.string(from: date)
         }
     }
 
@@ -178,6 +221,7 @@
                 status: status,
                 speakerCount: record?.speakerCount ?? 0,
                 failureMessage: record?.failureMessage,
+                metadata: record?.metadata.map { MCPMeetingMetadata($0) },
                 directory: directory
             )
         }
@@ -190,8 +234,8 @@
             switch overlay {
             case .recording(_, let folderName) where folderName == id:
                 return .recording
-            case .processing where record == nil:
-                return .processing
+            case .processing:
+                if record == nil { return .processing }
             default:
                 break
             }
@@ -215,6 +259,7 @@
         let status: MCPMeetingStatus
         let speakerCount: Int
         let failureMessage: String?
+        let metadata: MCPMeetingMetadata?
         let directory: MeetingSessionDirectory
 
         var summary: MCPMeetingSummary {
@@ -225,7 +270,8 @@
                 durationSeconds: durationSeconds,
                 status: status.rawValue,
                 speakerCount: speakerCount,
-                failureMessage: failureMessage
+                failureMessage: failureMessage,
+                metadata: metadata
             )
         }
 
@@ -238,7 +284,8 @@
                 status: status.rawValue,
                 speakerCount: speakerCount,
                 transcript: transcript,
-                failureMessage: failureMessage
+                failureMessage: failureMessage,
+                metadata: metadata
             )
         }
 

--- a/StetMac/Core/MCP/StetMCPProtocolServer.swift
+++ b/StetMac/Core/MCP/StetMCPProtocolServer.swift
@@ -17,21 +17,27 @@ actor StetMCPProtocolServer {
     static let listMeetingsToolName = "stet_list_meetings"
     static let listUnorganizedMeetingsToolName = "stet_list_unorganized_meetings"
     static let getMeetingTranscriptToolName = "stet_get_meeting_transcript"
+    static let syncExpectedMeetingsToolName = "stet_sync_expected_meetings"
 
     private static let serverName = "stet"
     private static let serverVersion = "1.0.0"
     private static let serverTitle = "Stet Meetings"
     private static let serverInstructions =
-        "Read meeting recordings already captured by Stet. Listing tools return metadata only. Use stet_get_meeting_transcript to fetch a saved transcript. Do not wait on transcription; Stet processes audio in the app."
+        "Read meeting recordings captured by Stet and synchronize expected meetings for local reminders. Listing tools return metadata only. Use stet_get_meeting_transcript to fetch a saved transcript."
     private static let serverCapabilities = Server.Capabilities(tools: .init(listChanged: false))
 
     private let catalog: any MCPMeetingServing
+    private let expectedMeetings: (any ExpectedMeetingServing)?
     private let transport: StatelessHTTPServerTransport
     private let server: Server
     private var started = false
 
-    init(catalog: any MCPMeetingServing) {
+    init(
+        catalog: any MCPMeetingServing,
+        expectedMeetings: (any ExpectedMeetingServing)? = nil
+    ) {
         self.catalog = catalog
+        self.expectedMeetings = expectedMeetings
         self.transport = StatelessHTTPServerTransport()
         self.server = Server(
             name: Self.serverName,
@@ -46,11 +52,21 @@ actor StetMCPProtocolServer {
         guard !started else { return }
 
         let catalog = self.catalog
+        let expectedMeetings = self.expectedMeetings
         await server.withMethodHandler(ListTools.self) { _ in
-            .init(tools: [Self.listMeetingsTool, Self.listUnorganizedMeetingsTool, Self.getTranscriptTool])
+            .init(tools: [
+                Self.listMeetingsTool,
+                Self.listUnorganizedMeetingsTool,
+                Self.getTranscriptTool,
+                Self.syncExpectedMeetingsTool,
+            ])
         }
         await server.withMethodHandler(CallTool.self) { parameters in
-            await Self.callTool(parameters, catalog: catalog)
+            await Self.callTool(
+                parameters,
+                catalog: catalog,
+                expectedMeetings: expectedMeetings
+            )
         }
         try await server.start(transport: transport)
         // Stateless HTTP has no session. Cursor reconnects by sending initialize
@@ -98,6 +114,7 @@ actor StetMCPProtocolServer {
                 "status": .object(["type": .string("string")]),
                 "speaker_count": .object(["type": .string("integer")]),
                 "failure_message": .object(["type": .string("string")]),
+                "metadata": meetingMetadataSchema,
             ]),
             "required": .array([
                 .string("id"),
@@ -106,6 +123,35 @@ actor StetMCPProtocolServer {
                 .string("status"),
                 .string("speaker_count"),
             ]),
+            "additionalProperties": .bool(false),
+        ])
+    }
+
+    private nonisolated static var meetingMetadataSchema: Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                "expected_meeting_id": .object(["type": .string("string")]),
+                "source": .object(["type": .string("string")]),
+                "external_id": .object(["type": .string("string")]),
+                "title": .object(["type": .string("string")]),
+                "scheduled_start_at": .object(["type": .string("string")]),
+                "scheduled_end_at": .object(["type": .string("string")]),
+                "attendees": .object([
+                    "type": .string("array"),
+                    "items": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "name": .object(["type": .string("string")]),
+                            "email": .object(["type": .string("string")]),
+                        ]),
+                        "required": .array([.string("name")]),
+                        "additionalProperties": .bool(false),
+                    ]),
+                ]),
+                "meeting_url": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("attendees")]),
             "additionalProperties": .bool(false),
         ])
     }
@@ -209,6 +255,7 @@ actor StetMCPProtocolServer {
                     "speaker_count": .object(["type": .string("integer")]),
                     "transcript": .object(["type": .string("string")]),
                     "failure_message": .object(["type": .string("string")]),
+                    "metadata": meetingMetadataSchema,
                 ]),
                 "required": .array([
                     .string("id"),
@@ -220,6 +267,125 @@ actor StetMCPProtocolServer {
                 "additionalProperties": .bool(false),
             ])
         )
+    }
+
+    private nonisolated static var syncExpectedMeetingsTool: Tool {
+        Tool(
+            name: syncExpectedMeetingsToolName,
+            title: "Sync expected Stet meetings",
+            description:
+                "Reconciles a complete snapshot of expected meetings in a time window. Stet stores them separately from recordings and schedules a reminder five minutes before each meeting.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "window_start": .object(["type": .string("string"), "format": .string("date-time")]),
+                    "window_end": .object(["type": .string("string"), "format": .string("date-time")]),
+                    "meetings": .object([
+                        "type": .string("array"),
+                        "items": expectedMeetingInputSchema,
+                    ]),
+                ]),
+                "required": .array([.string("window_start"), .string("window_end"), .string("meetings")]),
+                "additionalProperties": .bool(false),
+            ]),
+            annotations: .init(
+                title: "Sync expected Stet meetings",
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false
+            ),
+            outputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "created": .object(["type": .string("integer")]),
+                    "updated": .object(["type": .string("integer")]),
+                    "cancelled": .object(["type": .string("integer")]),
+                    "meetings": .object([
+                        "type": .string("array"),
+                        "items": expectedMeetingOutputSchema,
+                    ]),
+                ]),
+                "required": .array([
+                    .string("created"),
+                    .string("updated"),
+                    .string("cancelled"),
+                    .string("meetings"),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        )
+    }
+
+    private nonisolated static var expectedMeetingOutputSchema: Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                "id": .object(["type": .string("string")]),
+                "source": .object(["type": .string("string")]),
+                "external_id": .object(["type": .string("string")]),
+                "scheduled_start_at": .object(["type": .string("string")]),
+                "scheduled_end_at": .object(["type": .string("string")]),
+                "title": .object(["type": .string("string")]),
+                "attendees": expectedMeetingInputSchema.objectValue?["properties"]?.objectValue?[
+                    "attendees"
+                ] ?? .object(["type": .string("array")]),
+                "meeting_url": .object(["type": .string("string")]),
+                "notes": .object(["type": .string("string")]),
+                "source_modified_at": .object(["type": .string("string")]),
+                "status": .object(["type": .string("string")]),
+                "recorded_meeting_id": .object(["type": .string("string")]),
+            ]),
+            "required": .array([
+                .string("id"),
+                .string("source"),
+                .string("external_id"),
+                .string("scheduled_start_at"),
+                .string("scheduled_end_at"),
+                .string("attendees"),
+                .string("status"),
+            ]),
+            "additionalProperties": .bool(false),
+        ])
+    }
+
+    private nonisolated static var expectedMeetingInputSchema: Value {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                "source": .object(["type": .string("string")]),
+                "external_id": .object(["type": .string("string")]),
+                "scheduled_start_at": .object(["type": .string("string"), "format": .string("date-time")]),
+                "scheduled_end_at": .object(["type": .string("string"), "format": .string("date-time")]),
+                "title": .object(["type": .string("string")]),
+                "attendees": .object([
+                    "type": .string("array"),
+                    "items": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "name": .object(["type": .string("string")]),
+                            "email": .object(["type": .string("string")]),
+                        ]),
+                        "required": .array([.string("name")]),
+                        "additionalProperties": .bool(false),
+                    ]),
+                ]),
+                "meeting_url": .object(["type": .string("string"), "format": .string("uri")]),
+                "notes": .object(["type": .string("string")]),
+                "source_modified_at": .object(["type": .string("string"), "format": .string("date-time")]),
+                "status": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("scheduled"), .string("cancelled")]),
+                ]),
+            ]),
+            "required": .array([
+                .string("source"),
+                .string("external_id"),
+                .string("scheduled_start_at"),
+                .string("scheduled_end_at"),
+            ]),
+            "additionalProperties": .bool(false),
+        ])
     }
 
     private nonisolated static func initializeResult(requestedProtocolVersion: String) -> Initialize.Result {
@@ -241,7 +407,8 @@ actor StetMCPProtocolServer {
 
     private nonisolated static func callTool(
         _ parameters: CallTool.Parameters,
-        catalog: any MCPMeetingServing
+        catalog: any MCPMeetingServing,
+        expectedMeetings: (any ExpectedMeetingServing)?
     ) async -> CallTool.Result {
         switch parameters.name {
         case listMeetingsToolName:
@@ -250,9 +417,192 @@ actor StetMCPProtocolServer {
             return await list(parameters.arguments, catalog: catalog, unorganized: true)
         case getMeetingTranscriptToolName:
             return await transcript(parameters.arguments, catalog: catalog)
+        case syncExpectedMeetingsToolName:
+            return await syncExpectedMeetings(parameters.arguments, service: expectedMeetings)
         default:
             return toolError("Unknown tool: \(parameters.name)")
         }
+    }
+
+    private nonisolated static func syncExpectedMeetings(
+        _ arguments: [String: Value]?,
+        service: (any ExpectedMeetingServing)?
+    ) async -> CallTool.Result {
+        guard let service else { return toolError("Expected meeting synchronization is unavailable.") }
+        do {
+            let arguments = arguments ?? [:]
+            let windowStart = try requiredDate("window_start", in: arguments)
+            let windowEnd = try requiredDate("window_end", in: arguments)
+            guard let values = arguments["meetings"]?.arrayValue else {
+                throw ExpectedMeetingError.invalidMeeting("meetings must be an array.")
+            }
+            let inputs = try values.map(parseExpectedMeeting)
+            let result = try await service.sync(
+                windowStart: windowStart,
+                windowEnd: windowEnd,
+                inputs: inputs
+            )
+            let output = MCPExpectedMeetingSyncOutput(result)
+            return try CallTool.Result(
+                content: [
+                    .text(
+                        text:
+                            "Synced \(output.meetings.count) expected meetings: \(output.created) created, \(output.updated) updated, \(output.cancelled) cancelled.",
+                        annotations: nil,
+                        _meta: nil
+                    )
+                ],
+                structuredContent: output,
+                isError: false
+            )
+        } catch {
+            return toolError(error.localizedDescription)
+        }
+    }
+
+    private struct MCPExpectedMeetingSyncOutput: Codable, Sendable {
+        let created: Int
+        let updated: Int
+        let cancelled: Int
+        let meetings: [MCPExpectedMeetingOutput]
+
+        init(_ result: ExpectedMeetingSyncResult) {
+            self.created = result.created
+            self.updated = result.updated
+            self.cancelled = result.cancelled
+            self.meetings = result.meetings.map(MCPExpectedMeetingOutput.init)
+        }
+    }
+
+    private struct MCPExpectedMeetingOutput: Codable, Sendable {
+        let id: UUID
+        let source: String
+        let externalID: String
+        let scheduledStartAt: String
+        let scheduledEndAt: String
+        let title: String?
+        let attendees: [MeetingAttendee]
+        let meetingURL: URL?
+        let notes: String?
+        let sourceModifiedAt: String?
+        let status: ExpectedMeetingStatus
+        let recordedMeetingID: String?
+
+        init(_ meeting: ExpectedMeeting) {
+            self.id = meeting.id
+            self.source = meeting.source
+            self.externalID = meeting.externalID
+            self.scheduledStartAt = Self.iso8601String(meeting.scheduledStartAt)
+            self.scheduledEndAt = Self.iso8601String(meeting.scheduledEndAt)
+            self.title = meeting.title
+            self.attendees = meeting.attendees
+            self.meetingURL = meeting.meetingURL
+            self.notes = meeting.notes
+            self.sourceModifiedAt = meeting.sourceModifiedAt.map(Self.iso8601String)
+            self.status = meeting.status
+            self.recordedMeetingID = meeting.recordedMeetingID
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case source
+            case externalID = "external_id"
+            case scheduledStartAt = "scheduled_start_at"
+            case scheduledEndAt = "scheduled_end_at"
+            case title
+            case attendees
+            case meetingURL = "meeting_url"
+            case notes
+            case sourceModifiedAt = "source_modified_at"
+            case status
+            case recordedMeetingID = "recorded_meeting_id"
+        }
+
+        private nonisolated static func iso8601String(_ date: Date) -> String {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter.string(from: date)
+        }
+    }
+
+    private nonisolated static func parseExpectedMeeting(_ value: Value) throws -> ExpectedMeetingInput {
+        guard let object = value.objectValue else {
+            throw ExpectedMeetingError.invalidMeeting("Each meeting must be an object.")
+        }
+        let source = try requiredString("source", in: object)
+        let externalID = try requiredString("external_id", in: object)
+        let attendees = try (object["attendees"]?.arrayValue ?? []).map { attendee in
+            guard let object = attendee.objectValue else {
+                throw ExpectedMeetingError.invalidMeeting("Each attendee must be an object.")
+            }
+            return MeetingAttendee(
+                name: try requiredString("name", in: object),
+                email: object["email"]?.stringValue
+            )
+        }
+        let rawStatus = object["status"]?.stringValue ?? ExpectedMeetingStatus.scheduled.rawValue
+        guard let status = ExpectedMeetingStatus(rawValue: rawStatus), status == .scheduled || status == .cancelled
+        else {
+            throw ExpectedMeetingError.invalidMeeting("status must be scheduled or cancelled.")
+        }
+        let meetingURL: URL?
+        if let rawURL = object["meeting_url"]?.stringValue {
+            guard let parsedURL = URL(string: rawURL) else {
+                throw ExpectedMeetingError.invalidMeeting("meeting_url must be a valid URL.")
+            }
+            meetingURL = parsedURL
+        } else {
+            meetingURL = nil
+        }
+        return ExpectedMeetingInput(
+            source: source,
+            externalID: externalID,
+            scheduledStartAt: try requiredDate("scheduled_start_at", in: object),
+            scheduledEndAt: try requiredDate("scheduled_end_at", in: object),
+            title: object["title"]?.stringValue,
+            attendees: attendees,
+            meetingURL: meetingURL,
+            notes: object["notes"]?.stringValue,
+            sourceModifiedAt: try optionalDate("source_modified_at", in: object),
+            status: status
+        )
+    }
+
+    private nonisolated static func requiredString(
+        _ key: String,
+        in object: [String: Value]
+    ) throws -> String {
+        guard let value = object[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty
+        else {
+            throw ExpectedMeetingError.invalidMeeting("\(key) is required.")
+        }
+        return value
+    }
+
+    private nonisolated static func requiredDate(
+        _ key: String,
+        in object: [String: Value]
+    ) throws -> Date {
+        guard let date = try optionalDate(key, in: object) else {
+            throw ExpectedMeetingError.invalidMeeting("\(key) is required.")
+        }
+        return date
+    }
+
+    private nonisolated static func optionalDate(
+        _ key: String,
+        in object: [String: Value]
+    ) throws -> Date? {
+        guard let raw = object[key]?.stringValue else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: raw) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        guard let date = formatter.date(from: raw) else {
+            throw ExpectedMeetingError.invalidMeeting("\(key) must be an ISO 8601 date-time.")
+        }
+        return date
     }
 
     private nonisolated static func list(

--- a/StetMac/Core/MCP/StetMCPServerController.swift
+++ b/StetMac/Core/MCP/StetMCPServerController.swift
@@ -61,6 +61,7 @@
 
         static func live(
             livePhaseStore: MCPLiveMeetingPhaseStore,
+            expectedMeetings: any ExpectedMeetingServing,
             meetingStore: MeetingRecordingStore = MeetingRecordingStore(),
             defaults: UserDefaults = .standard
         ) -> StetMCPServerController {
@@ -69,7 +70,10 @@
                     store: meetingStore,
                     livePhase: { livePhaseStore.current() }
                 )
-                let protocolServer = StetMCPProtocolServer(catalog: catalog)
+                let protocolServer = StetMCPProtocolServer(
+                    catalog: catalog,
+                    expectedMeetings: expectedMeetings
+                )
                 let httpServer = StetMCPHTTPServer { request in
                     await protocolServer.handleHTTPRequest(request)
                 }

--- a/StetMac/Core/Speech/ExpectedMeetingCoordinator.swift
+++ b/StetMac/Core/Speech/ExpectedMeetingCoordinator.swift
@@ -1,0 +1,235 @@
+#if os(macOS)
+    import Foundation
+
+    struct ExpectedMeetingInput: Codable, Equatable, Sendable {
+        var source: String
+        var externalID: String
+        var scheduledStartAt: Date
+        var scheduledEndAt: Date
+        var title: String?
+        var attendees: [MeetingAttendee]
+        var meetingURL: URL?
+        var notes: String?
+        var sourceModifiedAt: Date?
+        var status: ExpectedMeetingStatus
+
+        private enum CodingKeys: String, CodingKey {
+            case source
+            case externalID = "external_id"
+            case scheduledStartAt = "scheduled_start_at"
+            case scheduledEndAt = "scheduled_end_at"
+            case title
+            case attendees
+            case meetingURL = "meeting_url"
+            case notes
+            case sourceModifiedAt = "source_modified_at"
+            case status
+        }
+    }
+
+    struct ExpectedMeetingSyncResult: Codable, Equatable, Sendable {
+        var created: Int
+        var updated: Int
+        var cancelled: Int
+        var meetings: [ExpectedMeeting]
+    }
+
+    nonisolated protocol ExpectedMeetingReminderScheduling: Sendable {
+        func schedule(_ meeting: ExpectedMeeting) async
+        func cancel(_ meeting: ExpectedMeeting) async
+    }
+
+    nonisolated protocol ExpectedMeetingServing: Sendable {
+        func sync(
+            windowStart: Date,
+            windowEnd: Date,
+            inputs: [ExpectedMeetingInput]
+        ) async throws -> ExpectedMeetingSyncResult
+        func meeting(id: UUID) async -> ExpectedMeeting?
+        func skip(id: UUID) async throws
+        func markRecorded(id: UUID, meetingID: String) async throws
+        func markCompleted(id: UUID) async throws
+        func restoreReminders() async
+    }
+
+    enum ExpectedMeetingError: LocalizedError, Equatable, Sendable {
+        case invalidWindow
+        case invalidMeeting(String)
+        case meetingNotFound(UUID)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidWindow:
+                "window_end must be after window_start."
+            case .invalidMeeting(let message):
+                message
+            case .meetingNotFound(let id):
+                "No expected meeting found with id \(id.uuidString)."
+            }
+        }
+    }
+
+    actor ExpectedMeetingCoordinator: ExpectedMeetingServing {
+        private let store: ExpectedMeetingStore
+        private let reminders: any ExpectedMeetingReminderScheduling
+        private let now: @Sendable () -> Date
+        private var meetings: [ExpectedMeeting]
+
+        init(
+            store: ExpectedMeetingStore = ExpectedMeetingStore(),
+            reminders: any ExpectedMeetingReminderScheduling,
+            now: @escaping @Sendable () -> Date = Date.init
+        ) {
+            self.store = store
+            self.reminders = reminders
+            self.now = now
+            self.meetings = (try? store.load()) ?? []
+        }
+
+        func sync(
+            windowStart: Date,
+            windowEnd: Date,
+            inputs: [ExpectedMeetingInput]
+        ) async throws -> ExpectedMeetingSyncResult {
+            guard windowEnd > windowStart else { throw ExpectedMeetingError.invalidWindow }
+            var keys = Set<String>()
+            for input in inputs {
+                guard input.scheduledEndAt > input.scheduledStartAt else {
+                    throw ExpectedMeetingError.invalidMeeting(
+                        "scheduled_end_at must be after scheduled_start_at for \(input.externalID)."
+                    )
+                }
+                guard input.scheduledStartAt >= windowStart, input.scheduledStartAt < windowEnd else {
+                    throw ExpectedMeetingError.invalidMeeting(
+                        "Meeting \(input.externalID) is outside the synchronization window."
+                    )
+                }
+                let key = Self.key(source: input.source, externalID: input.externalID)
+                guard keys.insert(key).inserted else {
+                    throw ExpectedMeetingError.invalidMeeting("Duplicate meeting \(input.externalID).")
+                }
+            }
+
+            var created = 0
+            var updated = 0
+            var cancelled = 0
+            for input in inputs {
+                let index = meetings.firstIndex {
+                    $0.source == input.source && $0.externalID == input.externalID
+                }
+                if let index {
+                    let existing = meetings[index]
+                    var replacement = ExpectedMeeting(
+                        id: existing.id,
+                        source: input.source,
+                        externalID: input.externalID,
+                        scheduledStartAt: input.scheduledStartAt,
+                        scheduledEndAt: input.scheduledEndAt,
+                        title: input.title,
+                        attendees: input.attendees,
+                        meetingURL: input.meetingURL,
+                        notes: input.notes,
+                        sourceModifiedAt: input.sourceModifiedAt,
+                        status: input.status,
+                        recordedMeetingID: existing.recordedMeetingID
+                    )
+                    if existing.status == .recording || existing.status == .completed {
+                        replacement.status = existing.status
+                    }
+                    if existing.status == .skipped && input.status == .scheduled {
+                        replacement.status = .skipped
+                    }
+                    if replacement != existing {
+                        await reminders.cancel(existing)
+                        meetings[index] = replacement
+                        updated += 1
+                    }
+                } else {
+                    meetings.append(
+                        ExpectedMeeting(
+                            id: UUID(),
+                            source: input.source,
+                            externalID: input.externalID,
+                            scheduledStartAt: input.scheduledStartAt,
+                            scheduledEndAt: input.scheduledEndAt,
+                            title: input.title,
+                            attendees: input.attendees,
+                            meetingURL: input.meetingURL,
+                            notes: input.notes,
+                            sourceModifiedAt: input.sourceModifiedAt,
+                            status: input.status,
+                            recordedMeetingID: nil
+                        )
+                    )
+                    created += 1
+                }
+            }
+
+            for index in meetings.indices
+            where meetings[index].scheduledStartAt >= windowStart
+                && meetings[index].scheduledStartAt < windowEnd
+                && meetings[index].status == .scheduled
+                && !keys.contains(Self.key(source: meetings[index].source, externalID: meetings[index].externalID))
+            {
+                meetings[index].status = .cancelled
+                await reminders.cancel(meetings[index])
+                cancelled += 1
+            }
+
+            meetings.sort { $0.scheduledStartAt < $1.scheduledStartAt }
+            try store.save(meetings)
+            for meeting in meetings where meeting.status == .scheduled && meeting.scheduledEndAt > now() {
+                await reminders.schedule(meeting)
+            }
+            return ExpectedMeetingSyncResult(
+                created: created,
+                updated: updated,
+                cancelled: cancelled,
+                meetings: meetings.filter {
+                    $0.scheduledStartAt >= windowStart && $0.scheduledStartAt < windowEnd
+                }
+            )
+        }
+
+        func meeting(id: UUID) -> ExpectedMeeting? {
+            meetings.first { $0.id == id }
+        }
+
+        func skip(id: UUID) async throws {
+            guard let index = meetings.firstIndex(where: { $0.id == id }) else {
+                throw ExpectedMeetingError.meetingNotFound(id)
+            }
+            meetings[index].status = .skipped
+            await reminders.cancel(meetings[index])
+            try store.save(meetings)
+        }
+
+        func markRecorded(id: UUID, meetingID: String) async throws {
+            guard let index = meetings.firstIndex(where: { $0.id == id }) else {
+                throw ExpectedMeetingError.meetingNotFound(id)
+            }
+            meetings[index].status = .recording
+            meetings[index].recordedMeetingID = meetingID
+            await reminders.cancel(meetings[index])
+            try store.save(meetings)
+        }
+
+        func markCompleted(id: UUID) throws {
+            guard let index = meetings.firstIndex(where: { $0.id == id }) else {
+                throw ExpectedMeetingError.meetingNotFound(id)
+            }
+            meetings[index].status = .completed
+            try store.save(meetings)
+        }
+
+        func restoreReminders() async {
+            for meeting in meetings where meeting.status == .scheduled && meeting.scheduledEndAt > now() {
+                await reminders.schedule(meeting)
+            }
+        }
+
+        private nonisolated static func key(source: String, externalID: String) -> String {
+            "\(source)\u{0}\(externalID)"
+        }
+    }
+#endif

--- a/StetMac/Core/Speech/ExpectedMeetingStore.swift
+++ b/StetMac/Core/Speech/ExpectedMeetingStore.swift
@@ -1,0 +1,115 @@
+#if os(macOS)
+    import Foundation
+
+    struct MeetingAttendee: Codable, Equatable, Sendable {
+        var name: String
+        var email: String?
+    }
+
+    enum ExpectedMeetingStatus: String, Codable, Sendable {
+        case scheduled
+        case recording
+        case skipped
+        case cancelled
+        case completed
+    }
+
+    struct ExpectedMeeting: Codable, Equatable, Identifiable, Sendable {
+        var id: UUID
+        var source: String
+        var externalID: String
+        var scheduledStartAt: Date
+        var scheduledEndAt: Date
+        var title: String?
+        var attendees: [MeetingAttendee]
+        var meetingURL: URL?
+        var notes: String?
+        var sourceModifiedAt: Date?
+        var status: ExpectedMeetingStatus
+        var recordedMeetingID: String?
+
+        var reminderIdentifier: String {
+            "stet.expected-meeting.\(id.uuidString)"
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case source
+            case externalID = "external_id"
+            case scheduledStartAt = "scheduled_start_at"
+            case scheduledEndAt = "scheduled_end_at"
+            case title
+            case attendees
+            case meetingURL = "meeting_url"
+            case notes
+            case sourceModifiedAt = "source_modified_at"
+            case status
+            case recordedMeetingID = "recorded_meeting_id"
+        }
+    }
+
+    struct MeetingMetadata: Codable, Equatable, Sendable {
+        var expectedMeetingID: UUID?
+        var source: String?
+        var externalID: String?
+        var title: String?
+        var scheduledStartAt: Date?
+        var scheduledEndAt: Date?
+        var attendees: [MeetingAttendee]
+        var meetingURL: URL?
+
+        init(expectedMeeting: ExpectedMeeting) {
+            self.expectedMeetingID = expectedMeeting.id
+            self.source = expectedMeeting.source
+            self.externalID = expectedMeeting.externalID
+            self.title = expectedMeeting.title
+            self.scheduledStartAt = expectedMeeting.scheduledStartAt
+            self.scheduledEndAt = expectedMeeting.scheduledEndAt
+            self.attendees = expectedMeeting.attendees
+            self.meetingURL = expectedMeeting.meetingURL
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case expectedMeetingID = "expected_meeting_id"
+            case source
+            case externalID = "external_id"
+            case title
+            case scheduledStartAt = "scheduled_start_at"
+            case scheduledEndAt = "scheduled_end_at"
+            case attendees
+            case meetingURL = "meeting_url"
+        }
+    }
+
+    struct ExpectedMeetingStore: Sendable {
+        let fileURL: URL
+        private let fileManager: FileManager
+
+        init(fileManager: FileManager = .default, fileURL: URL? = nil) {
+            self.fileManager = fileManager
+            self.fileURL =
+                fileURL
+                ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                .appendingPathComponent("Stet", isDirectory: true)
+                .appendingPathComponent("expected-meetings.json")
+        }
+
+        func load() throws -> [ExpectedMeeting] {
+            guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try decoder.decode([ExpectedMeeting].self, from: Data(contentsOf: fileURL))
+        }
+
+        func save(_ meetings: [ExpectedMeeting]) throws {
+            try fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(meetings).write(to: fileURL, options: .atomic)
+        }
+    }
+#endif

--- a/StetMac/Core/Speech/MacMeetingRecordingRuntime.swift
+++ b/StetMac/Core/Speech/MacMeetingRecordingRuntime.swift
@@ -30,6 +30,7 @@
         private var frameTask: Task<Void, Never>?
         private var processingTask: Task<Void, Never>?
         private var session: ActiveSession?
+        private var pendingExpectedMeeting: ExpectedMeeting?
         private var phaseHandler: @MainActor @Sendable (MacMeetingRecordingPhase) -> Void = { _ in }
 
         private struct ActiveSession {
@@ -37,6 +38,7 @@
             var writer: MeetingAudioWriter
             var samples: [Float]
             var startedAt: Date
+            var metadata: MeetingMetadata?
         }
 
         init(dependencies: Dependencies) {
@@ -89,8 +91,10 @@
                     directory: directory,
                     writer: writer,
                     samples: [],
-                    startedAt: startedAt
+                    startedAt: startedAt,
+                    metadata: pendingExpectedMeeting.map(MeetingMetadata.init)
                 )
+                pendingExpectedMeeting = nil
                 let folderName = directory.url.lastPathComponent
                 await setPhase(.recording(startedAt: startedAt, folderName: folderName))
                 let stream = await dependencies.makeFrameStream()
@@ -106,6 +110,15 @@
                     await dependencies.endExclusiveCapture()
                 }
                 await setPhase(.failed(error.localizedDescription))
+            }
+        }
+
+        func start(expectedMeeting: ExpectedMeeting) async {
+            guard !isBusy() else { return }
+            pendingExpectedMeeting = expectedMeeting
+            await start()
+            if case .failed = phase {
+                pendingExpectedMeeting = nil
             }
         }
 
@@ -127,11 +140,13 @@
             let samples = active.samples
             let directory = active.directory
             let startedAt = active.startedAt
+            let metadata = active.metadata
             processingTask = Task {
                 await self.completeStoppedSession(
                     samples: samples,
                     directory: directory,
-                    startedAt: startedAt
+                    startedAt: startedAt,
+                    metadata: metadata
                 )
             }
         }
@@ -139,7 +154,8 @@
         private func completeStoppedSession(
             samples: [Float],
             directory: MeetingSessionDirectory,
-            startedAt: Date
+            startedAt: Date,
+            metadata: MeetingMetadata?
         ) async {
             let endedAt = dependencies.now()
 
@@ -148,7 +164,8 @@
                 let markdown = MeetingTranscriptDocument.markdown(
                     startedAt: startedAt,
                     endedAt: endedAt,
-                    turns: turns
+                    turns: turns,
+                    metadata: metadata
                 )
                 try markdown.write(to: directory.transcriptURL, atomically: true, encoding: .utf8)
                 let record = MeetingSessionRecord(
@@ -157,7 +174,8 @@
                     durationSeconds: endedAt.timeIntervalSince(startedAt),
                     status: "completed",
                     failureMessage: nil,
-                    speakerCount: Set(turns.map(\.speakerLabel)).count
+                    speakerCount: Set(turns.map(\.speakerLabel)).count,
+                    metadata: metadata
                 )
                 try writeRecord(record, to: directory.sessionURL)
                 await setPhase(.idle)
@@ -167,6 +185,7 @@
                     startedAt: startedAt,
                     endedAt: endedAt,
                     turns: [],
+                    metadata: metadata,
                     note: "Processing failed: \(error.localizedDescription). The audio file was kept."
                 )
                 try? markdown.write(to: directory.transcriptURL, atomically: true, encoding: .utf8)
@@ -176,7 +195,8 @@
                     durationSeconds: endedAt.timeIntervalSince(startedAt),
                     status: "failed",
                     failureMessage: error.localizedDescription,
-                    speakerCount: 0
+                    speakerCount: 0,
+                    metadata: metadata
                 )
                 try? writeRecord(record, to: directory.sessionURL)
                 await setPhase(.failed(error.localizedDescription))

--- a/StetMac/Core/Speech/MeetingRecordingStore.swift
+++ b/StetMac/Core/Speech/MeetingRecordingStore.swift
@@ -122,6 +122,7 @@
         var failureMessage: String?
         var speakerCount: Int
         var organizedAt: Date? = nil
+        var metadata: MeetingMetadata? = nil
 
         func jsonData() throws -> Data {
             let encoder = JSONEncoder()

--- a/StetMac/Core/Speech/MeetingTranscriptDocument.swift
+++ b/StetMac/Core/Speech/MeetingTranscriptDocument.swift
@@ -15,16 +15,31 @@
             startedAt: Date,
             endedAt: Date,
             turns: [MeetingTranscriptTurn],
+            metadata: MeetingMetadata? = nil,
             note: String? = nil
         ) -> String {
+            let heading = metadata?.title?.nilIfPlaceholder ?? "Meeting · \(displayTimestamp(startedAt))"
             var lines = [
-                "# Meeting · \(displayTimestamp(startedAt))",
+                "# \(heading)",
                 "",
                 "Started: \(displayTimestamp(startedAt))",
                 "Ended: \(displayTimestamp(endedAt))",
                 "Duration: \(formatDuration(endedAt.timeIntervalSince(startedAt)))",
-                "",
             ]
+            if let scheduledStartAt = metadata?.scheduledStartAt,
+                let scheduledEndAt = metadata?.scheduledEndAt
+            {
+                lines.append(
+                    "Scheduled: \(displayTimestamp(scheduledStartAt))–\(displayTimestamp(scheduledEndAt))"
+                )
+            }
+            if let attendees = metadata?.attendees, !attendees.isEmpty {
+                lines.append("Attendees: \(attendees.map(\.name).joined(separator: ", "))")
+            }
+            if let meetingURL = metadata?.meetingURL {
+                lines.append("Meeting: \(meetingURL.absoluteString)")
+            }
+            lines.append("")
             if let note, !note.isEmpty {
                 lines.append(note)
                 lines.append("")
@@ -86,6 +101,16 @@
             let minutes = total / 60
             let remainder = total % 60
             return String(format: "%d:%02d", minutes, remainder)
+        }
+    }
+
+    private extension String {
+        nonisolated var nilIfPlaceholder: String? {
+            let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, trimmed.caseInsensitiveCompare("(NO Title)") != .orderedSame else {
+                return nil
+            }
+            return trimmed
         }
     }
 #endif

--- a/StetMac/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/de.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "Mikrofon";
 "Default (Built-in Microphone)" = "Standard (Integriertes Mikrofon)";
 "Start Recording" = "Aufnahme starten";
+"Meeting soon" = "Besprechung beginnt bald";
+"Starts at %@." = "Beginnt um %@.";
+"Starts at %@ with %@." = "Beginnt um %@ mit %@.";
 "Stop Recording" = "Aufnahme stoppen";
 "Play Recording" = "Aufnahme abspielen";
 "Stop Playback" = "Wiedergabe stoppen";

--- a/StetMac/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/en.lproj/Localizable.strings
@@ -56,6 +56,9 @@
 "Microphone" = "Microphone";
 "Default (Built-in Microphone)" = "Default (Built-in Microphone)";
 "Start Recording" = "Start Recording";
+"Meeting soon" = "Meeting soon";
+"Starts at %@." = "Starts at %@.";
+"Starts at %@ with %@." = "Starts at %@ with %@.";
 "Stop Recording" = "Stop Recording";
 "Play Recording" = "Play Recording";
 "Stop Playback" = "Stop Playback";

--- a/StetMac/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/es.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "Micrófono";
 "Default (Built-in Microphone)" = "Predeterminado (Micrófono integrado)";
 "Start Recording" = "Iniciar grabación";
+"Meeting soon" = "La reunión empieza pronto";
+"Starts at %@." = "Empieza a las %@.";
+"Starts at %@ with %@." = "Empieza a las %@ con %@.";
 "Stop Recording" = "Detener grabación";
 "Play Recording" = "Reproducir grabación";
 "Stop Playback" = "Detener reproducción";

--- a/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/fr.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "Microphone";
 "Default (Built-in Microphone)" = "Par défaut (Microphone intégré)";
 "Start Recording" = "Démarrer l'enregistrement";
+"Meeting soon" = "Réunion imminente";
+"Starts at %@." = "Commence à %@.";
+"Starts at %@ with %@." = "Commence à %@ avec %@.";
 "Stop Recording" = "Arrêter l'enregistrement";
 "Play Recording" = "Lire l'enregistrement";
 "Stop Playback" = "Arrêter la lecture";

--- a/StetMac/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/it.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "Microfono";
 "Default (Built-in Microphone)" = "Predefinito (Microfono integrato)";
 "Start Recording" = "Avvia registrazione";
+"Meeting soon" = "Riunione imminente";
+"Starts at %@." = "Inizia alle %@.";
+"Starts at %@ with %@." = "Inizia alle %@ con %@.";
 "Stop Recording" = "Interrompi registrazione";
 "Play Recording" = "Riproduci registrazione";
 "Stop Playback" = "Interrompi riproduzione";

--- a/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ja.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "マイク";
 "Default (Built-in Microphone)" = "デフォルト（内蔵マイク）";
 "Start Recording" = "録音開始";
+"Meeting soon" = "まもなく会議です";
+"Starts at %@." = "%@に開始します。";
+"Starts at %@ with %@." = "%@に%@と開始します。";
 "Stop Recording" = "録音停止";
 "Play Recording" = "録音を再生";
 "Stop Playback" = "再生停止";

--- a/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/ko.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "마이크";
 "Default (Built-in Microphone)" = "기본값 (내장 마이크)";
 "Start Recording" = "녹음 시작";
+"Meeting soon" = "회의가 곧 시작됩니다";
+"Starts at %@." = "%@에 시작합니다.";
+"Starts at %@ with %@." = "%@에 %@와 함께 시작합니다.";
 "Stop Recording" = "녹음 중지";
 "Play Recording" = "녹음 재생";
 "Stop Playback" = "재생 중지";

--- a/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "Microfone";
 "Default (Built-in Microphone)" = "Padrão (Microfone embutido)";
 "Start Recording" = "Iniciar gravação";
+"Meeting soon" = "Reunião em breve";
+"Starts at %@." = "Começa às %@.";
+"Starts at %@ with %@." = "Começa às %@ com %@.";
 "Stop Recording" = "Parar gravação";
 "Play Recording" = "Reproduzir gravação";
 "Stop Playback" = "Parar reprodução";

--- a/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -56,6 +56,9 @@
 "Microphone" = "麦克风";
 "Default (Built-in Microphone)" = "默认（内建麦克风）";
 "Start Recording" = "开始录音";
+"Meeting soon" = "会议即将开始";
+"Starts at %@." = "%@ 开始。";
+"Starts at %@ with %@." = "%@ 开始，与会人：%@。";
 "Stop Recording" = "停止录音";
 "Play Recording" = "播放录音";
 "Stop Playback" = "停止播放";

--- a/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StetMac/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -55,6 +55,9 @@
 "Microphone" = "麥克風";
 "Default (Built-in Microphone)" = "預設（內建麥克風）";
 "Start Recording" = "開始錄音";
+"Meeting soon" = "會議即將開始";
+"Starts at %@." = "%@ 開始。";
+"Starts at %@ with %@." = "%@ 開始，與會者：%@。";
 "Stop Recording" = "停止錄音";
 "Play Recording" = "播放錄音";
 "Stop Playback" = "停止播放";

--- a/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
+++ b/StetMac/Shared/Utilities/MacDictationCompletionNotificationService.swift
@@ -6,8 +6,15 @@
     final class MacDictationCompletionNotificationService: NSObject, UNUserNotificationCenterDelegate {
         static let shared = MacDictationCompletionNotificationService()
 
+        static let expectedMeetingCategoryIdentifier = "stet.expected-meeting"
+        static let startExpectedMeetingActionIdentifier = "stet.expected-meeting.start"
+        static let skipExpectedMeetingActionIdentifier = "stet.expected-meeting.skip"
+        static let expectedMeetingIDKey = "expectedMeetingID"
+
         private let center: UNUserNotificationCenter
         private var didInstallDelegate = false
+        var onStartExpectedMeeting: (@MainActor @Sendable (UUID) -> Void)?
+        var onSkipExpectedMeeting: (@MainActor @Sendable (UUID) -> Void)?
 
         init(center: UNUserNotificationCenter = .current()) {
             self.center = center
@@ -17,6 +24,24 @@
         func installDelegateIfNeeded() {
             guard !didInstallDelegate else { return }
             center.delegate = self
+            center.setNotificationCategories([
+                UNNotificationCategory(
+                    identifier: Self.expectedMeetingCategoryIdentifier,
+                    actions: [
+                        UNNotificationAction(
+                            identifier: Self.startExpectedMeetingActionIdentifier,
+                            title: String(localized: "Start Recording"),
+                            options: [.foreground]
+                        ),
+                        UNNotificationAction(
+                            identifier: Self.skipExpectedMeetingActionIdentifier,
+                            title: String(localized: "Skip"),
+                            options: []
+                        ),
+                    ],
+                    intentIdentifiers: []
+                )
+            ])
             didInstallDelegate = true
         }
 
@@ -60,12 +85,100 @@
             try? await center.add(request)
         }
 
+        func scheduleExpectedMeeting(_ meeting: ExpectedMeeting) async {
+            let now = Date()
+            guard meeting.status == .scheduled, meeting.scheduledEndAt > now else {
+                center.removePendingNotificationRequests(withIdentifiers: [meeting.reminderIdentifier])
+                return
+            }
+            await requestAuthorizationIfNeeded()
+            let settings = await center.notificationSettings()
+            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+                return
+            }
+
+            let content = UNMutableNotificationContent()
+            content.title = meeting.title?.nonPlaceholderMeetingTitle ?? String(localized: "Meeting soon")
+            content.body = Self.expectedMeetingBody(meeting)
+            content.categoryIdentifier = Self.expectedMeetingCategoryIdentifier
+            content.userInfo = [Self.expectedMeetingIDKey: meeting.id.uuidString]
+
+            let reminderDate = max(
+                meeting.scheduledStartAt.addingTimeInterval(-5 * 60),
+                now.addingTimeInterval(1)
+            )
+            let components = Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute, .second],
+                from: reminderDate
+            )
+            let request = UNNotificationRequest(
+                identifier: meeting.reminderIdentifier,
+                content: content,
+                trigger: UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+            )
+            center.removePendingNotificationRequests(withIdentifiers: [meeting.reminderIdentifier])
+            try? await center.add(request)
+        }
+
+        func cancelExpectedMeeting(_ meeting: ExpectedMeeting) {
+            center.removePendingNotificationRequests(withIdentifiers: [meeting.reminderIdentifier])
+            center.removeDeliveredNotifications(withIdentifiers: [meeting.reminderIdentifier])
+        }
+
         nonisolated func userNotificationCenter(
             _ center: UNUserNotificationCenter,
             willPresent notification: UNNotification,
             withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
         ) {
             completionHandler([.banner, .list])
+        }
+
+        nonisolated func userNotificationCenter(
+            _ center: UNUserNotificationCenter,
+            didReceive response: UNNotificationResponse,
+            withCompletionHandler completionHandler: @escaping () -> Void
+        ) {
+            defer { completionHandler() }
+            guard
+                let rawID = response.notification.request.content.userInfo[Self.expectedMeetingIDKey]
+                    as? String,
+                let id = UUID(uuidString: rawID)
+            else { return }
+
+            Task { @MainActor [weak self] in
+                switch response.actionIdentifier {
+                case Self.startExpectedMeetingActionIdentifier,
+                    UNNotificationDefaultActionIdentifier:
+                    self?.onStartExpectedMeeting?(id)
+                case Self.skipExpectedMeetingActionIdentifier:
+                    self?.onSkipExpectedMeeting?(id)
+                default:
+                    break
+                }
+            }
+        }
+
+        nonisolated static func expectedMeetingBody(_ meeting: ExpectedMeeting) -> String {
+            let time = meeting.scheduledStartAt.formatted(date: .omitted, time: .shortened)
+            let names = meeting.attendees.map(\.name).filter { !$0.isEmpty }
+            guard !names.isEmpty else {
+                return String(format: String(localized: "Starts at %@."), time)
+            }
+            return String(
+                format: String(localized: "Starts at %@ with %@."),
+                time,
+                names.joined(separator: ", ")
+            )
+        }
+    }
+
+    extension MacDictationCompletionNotificationService: ExpectedMeetingReminderScheduling {
+        nonisolated func schedule(_ meeting: ExpectedMeeting) async {
+            await scheduleExpectedMeeting(meeting)
+        }
+
+        nonisolated func cancel(_ meeting: ExpectedMeeting) async {
+            await cancelExpectedMeeting(meeting)
         }
     }
 
@@ -101,6 +214,16 @@
             default:
                 return nil
             }
+        }
+    }
+
+    private extension String {
+        nonisolated var nonPlaceholderMeetingTitle: String? {
+            let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, trimmed.caseInsensitiveCompare("(NO Title)") != .orderedSame else {
+                return nil
+            }
+            return trimmed
         }
     }
 #endif

--- a/StetMacTests/Core/MCP/StetMCPProtocolServerTests.swift
+++ b/StetMacTests/Core/MCP/StetMCPProtocolServerTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 @Suite("Stet MCP Protocol Server")
 struct StetMCPProtocolServerTests {
-    @Test func listsTheThreeMeetingTools() async throws {
+    @Test func listsMeetingTools() async throws {
         let server = StetMCPProtocolServer(catalog: MCPStubMeetingCatalog())
         try await server.start()
         defer { Task { await server.stop() } }
@@ -31,6 +31,7 @@ struct StetMCPProtocolServerTests {
                 StetMCPProtocolServer.listMeetingsToolName,
                 StetMCPProtocolServer.listUnorganizedMeetingsToolName,
                 StetMCPProtocolServer.getMeetingTranscriptToolName,
+                StetMCPProtocolServer.syncExpectedMeetingsToolName,
             ])
         #expect(tools.allSatisfy { $0["inputSchema"] != nil && $0["outputSchema"] != nil })
     }
@@ -98,6 +99,82 @@ struct StetMCPProtocolServerTests {
         let structured = try #require(getResult["structuredContent"] as? [String: Any])
         #expect(structured["transcript"] as? String == "hello from the room")
         #expect(structured["id"] as? String == "2026-09-12 16-20-01")
+    }
+
+    @Test func syncsExpectedMeetingsThroughMCP() async throws {
+        let expectedMeetings = MCPExpectedMeetingStub()
+        let server = StetMCPProtocolServer(
+            catalog: MCPStubMeetingCatalog(),
+            expectedMeetings: expectedMeetings
+        )
+        try await server.start()
+        defer { Task { await server.stop() } }
+        try await initialize(server)
+
+        let response = await server.handleRawRequest(
+            method: "POST",
+            headers: protocolHeaders,
+            body: try jsonData([
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": [
+                    "name": StetMCPProtocolServer.syncExpectedMeetingsToolName,
+                    "arguments": [
+                        "window_start": "2026-09-12T00:00:00+08:00",
+                        "window_end": "2026-09-13T00:00:00+08:00",
+                        "meetings": [
+                            [
+                                "source": "calendar",
+                                "external_id": "event-1",
+                                "scheduled_start_at": "2026-09-12T21:00:00+08:00",
+                                "scheduled_end_at": "2026-09-12T22:30:00+08:00",
+                                "title": "Project sync",
+                                "attendees": [["name": "Taylor", "email": "taylor@example.com"]],
+                                "meeting_url": "https://example.com/meeting",
+                            ]
+                        ],
+                    ],
+                ],
+            ])
+        )
+
+        let result = try #require(try responseJSON(response)["result"] as? [String: Any])
+        #expect(result["isError"] as? Bool == false)
+        let captured = await expectedMeetings.capturedInputs
+        #expect(captured.count == 1)
+        #expect(captured.first?.externalID == "event-1")
+        #expect(captured.first?.attendees.first?.name == "Taylor")
+    }
+
+    @Test func syncRejectsMissingMeetingsSnapshot() async throws {
+        let server = StetMCPProtocolServer(
+            catalog: MCPStubMeetingCatalog(),
+            expectedMeetings: MCPExpectedMeetingStub()
+        )
+        try await server.start()
+        defer { Task { await server.stop() } }
+        try await initialize(server)
+
+        let response = await server.handleRawRequest(
+            method: "POST",
+            headers: protocolHeaders,
+            body: try jsonData([
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": [
+                    "name": StetMCPProtocolServer.syncExpectedMeetingsToolName,
+                    "arguments": [
+                        "window_start": "2026-09-12T00:00:00+08:00",
+                        "window_end": "2026-09-13T00:00:00+08:00",
+                    ],
+                ],
+            ])
+        )
+
+        let result = try #require(try responseJSON(response)["result"] as? [String: Any])
+        #expect(result["isError"] as? Bool == true)
     }
 
     @Test func unknownToolInvalidLimitAndCatalogFailuresAreToolErrors() async throws {
@@ -183,7 +260,7 @@ struct StetMCPProtocolServerTests {
         #expect(listJSON["error"] == nil)
         let listResult = try #require(listJSON["result"] as? [String: Any])
         let tools = try #require(listResult["tools"] as? [[String: Any]])
-        #expect(tools.count == 3)
+        #expect(tools.count == 4)
     }
 
     @Test func initializeAcceptsStreamableHTTPAcceptHeader() async throws {
@@ -251,7 +328,8 @@ private struct MCPStubMeetingCatalog: MCPMeetingServing {
         durationSeconds: 1511,
         status: "ready",
         speakerCount: 2,
-        failureMessage: nil
+        failureMessage: nil,
+        metadata: nil
     )
 
     func listMeetings(limit: Int) throws -> MCPMeetingListOutput {
@@ -273,9 +351,29 @@ private struct MCPStubMeetingCatalog: MCPMeetingServing {
             status: summary.status,
             speakerCount: summary.speakerCount,
             transcript: "hello from the room",
-            failureMessage: nil
+            failureMessage: nil,
+            metadata: nil
         )
     }
+}
+
+private actor MCPExpectedMeetingStub: ExpectedMeetingServing {
+    private(set) var capturedInputs: [ExpectedMeetingInput] = []
+
+    func sync(
+        windowStart: Date,
+        windowEnd: Date,
+        inputs: [ExpectedMeetingInput]
+    ) -> ExpectedMeetingSyncResult {
+        capturedInputs = inputs
+        return ExpectedMeetingSyncResult(created: inputs.count, updated: 0, cancelled: 0, meetings: [])
+    }
+
+    func meeting(id: UUID) -> ExpectedMeeting? { nil }
+    func skip(id: UUID) throws {}
+    func markRecorded(id: UUID, meetingID: String) async throws {}
+    func markCompleted(id: UUID) throws {}
+    func restoreReminders() {}
 }
 
 private func jsonData(_ object: [String: Any]) throws -> Data {

--- a/StetMacTests/Core/Speech/ExpectedMeetingCoordinatorTests.swift
+++ b/StetMacTests/Core/Speech/ExpectedMeetingCoordinatorTests.swift
@@ -1,0 +1,143 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+
+    @testable import Stet
+
+    @Suite("Expected Meeting Coordinator")
+    struct ExpectedMeetingCoordinatorTests {
+        @Test func syncIsIdempotentAndPersistsMeetings() async throws {
+            let fileURL = TestSupport.temporaryDirectoryURL().appendingPathComponent("expected.json")
+            let reminders = ReminderRecorder()
+            let now = Date(timeIntervalSince1970: 1_704_067_200)
+            let coordinator = ExpectedMeetingCoordinator(
+                store: ExpectedMeetingStore(fileURL: fileURL),
+                reminders: reminders,
+                now: { now }
+            )
+            let input = makeInput(start: now.addingTimeInterval(3_600))
+
+            let first = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [input]
+            )
+            let second = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [input]
+            )
+
+            #expect(first.created == 1)
+            #expect(first.updated == 0)
+            #expect(second.created == 0)
+            #expect(second.updated == 0)
+            #expect(first.meetings.first?.id == second.meetings.first?.id)
+            #expect(try ExpectedMeetingStore(fileURL: fileURL).load() == second.meetings)
+        }
+
+        @Test func missingMeetingInWindowIsCancelled() async throws {
+            let fileURL = TestSupport.temporaryDirectoryURL().appendingPathComponent("expected.json")
+            let reminders = ReminderRecorder()
+            let now = Date(timeIntervalSince1970: 1_704_067_200)
+            let coordinator = ExpectedMeetingCoordinator(
+                store: ExpectedMeetingStore(fileURL: fileURL),
+                reminders: reminders,
+                now: { now }
+            )
+            _ = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [makeInput(start: now.addingTimeInterval(3_600))]
+            )
+
+            let result = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: []
+            )
+
+            #expect(result.cancelled == 1)
+            #expect(result.meetings.first?.status == .cancelled)
+            #expect(await reminders.cancelledCount == 1)
+        }
+
+        @Test func markRecordedLinksExpectedMeetingToSession() async throws {
+            let fileURL = TestSupport.temporaryDirectoryURL().appendingPathComponent("expected.json")
+            let now = Date(timeIntervalSince1970: 1_704_067_200)
+            let coordinator = ExpectedMeetingCoordinator(
+                store: ExpectedMeetingStore(fileURL: fileURL),
+                reminders: ReminderRecorder(),
+                now: { now }
+            )
+            let result = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [makeInput(start: now.addingTimeInterval(3_600))]
+            )
+            let id = try #require(result.meetings.first?.id)
+
+            try await coordinator.markRecorded(id: id, meetingID: "2026-09-12 21-00-00")
+            let recording = await coordinator.meeting(id: id)
+            #expect(recording?.status == .recording)
+            #expect(recording?.recordedMeetingID == "2026-09-12 21-00-00")
+
+            try await coordinator.markCompleted(id: id)
+            #expect(await coordinator.meeting(id: id)?.status == .completed)
+        }
+
+        @Test func repeatedSyncDoesNotReactivateSkippedMeeting() async throws {
+            let fileURL = TestSupport.temporaryDirectoryURL().appendingPathComponent("expected.json")
+            let now = Date(timeIntervalSince1970: 1_704_067_200)
+            let coordinator = ExpectedMeetingCoordinator(
+                store: ExpectedMeetingStore(fileURL: fileURL),
+                reminders: ReminderRecorder(),
+                now: { now }
+            )
+            let input = makeInput(start: now.addingTimeInterval(3_600))
+            let first = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [input]
+            )
+            let id = try #require(first.meetings.first?.id)
+            try await coordinator.skip(id: id)
+
+            let repeated = try await coordinator.sync(
+                windowStart: now,
+                windowEnd: now.addingTimeInterval(86_400),
+                inputs: [input]
+            )
+
+            #expect(repeated.meetings.first?.status == .skipped)
+        }
+
+        private func makeInput(start: Date) -> ExpectedMeetingInput {
+            ExpectedMeetingInput(
+                source: "calendar",
+                externalID: "event-1",
+                scheduledStartAt: start,
+                scheduledEndAt: start.addingTimeInterval(1_800),
+                title: "Project sync",
+                attendees: [MeetingAttendee(name: "Taylor", email: "taylor@example.com")],
+                meetingURL: URL(string: "https://example.com/meeting"),
+                notes: nil,
+                sourceModifiedAt: nil,
+                status: .scheduled
+            )
+        }
+    }
+
+    private actor ReminderRecorder: ExpectedMeetingReminderScheduling {
+        private(set) var scheduledCount = 0
+        private(set) var cancelledCount = 0
+
+        func schedule(_ meeting: ExpectedMeeting) {
+            scheduledCount += 1
+        }
+
+        func cancel(_ meeting: ExpectedMeeting) {
+            cancelledCount += 1
+        }
+    }
+#endif

--- a/StetMacTests/Core/Speech/MacMeetingRecordingRuntimeTests.swift
+++ b/StetMacTests/Core/Speech/MacMeetingRecordingRuntimeTests.swift
@@ -81,6 +81,58 @@
             #expect(record.status == "completed")
         }
 
+        @Test func expectedMeetingMetadataIsSavedWithRecording() async throws {
+            let root = TestSupport.temporaryDirectoryURL()
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let (stream, continuation) = AsyncStream<AudioCaptureFrame>.makeStream()
+            let startedAt = Date(timeIntervalSince1970: 1_704_067_200)
+            let expected = ExpectedMeeting(
+                id: UUID(),
+                source: "calendar",
+                externalID: "event-1",
+                scheduledStartAt: startedAt,
+                scheduledEndAt: startedAt.addingTimeInterval(1_800),
+                title: "Project sync",
+                attendees: [MeetingAttendee(name: "Taylor", email: nil)],
+                meetingURL: nil,
+                notes: nil,
+                sourceModifiedAt: nil,
+                status: .scheduled,
+                recordedMeetingID: nil
+            )
+            let runtime = MacMeetingRecordingRuntime(
+                dependencies: MacMeetingRecordingRuntime.Dependencies(
+                    store: MeetingRecordingStore(rootDirectory: root),
+                    ensureCaptureRunning: {},
+                    beginExclusiveCapture: {},
+                    endExclusiveCapture: {},
+                    makeFrameStream: { stream },
+                    processor: MeetingSessionProcessor(
+                        sampleRate: 16_000,
+                        diarize: { _ in [] },
+                        transcribe: { _ in "" },
+                        identify: { _ in PassiveSpeakerMatch(identity: .other, similarity: nil) }
+                    ),
+                    now: { startedAt }
+                )
+            )
+
+            await runtime.start(expectedMeeting: expected)
+            continuation.finish()
+            await runtime.stop()
+
+            let directory = try #require(
+                try MeetingRecordingStore(rootDirectory: root).sessionDirectories().first
+            )
+            let session = try JSONDecoder.iso8601.decode(
+                MeetingSessionRecord.self,
+                from: Data(contentsOf: directory.appendingPathComponent("session.json"))
+            )
+            #expect(session.metadata?.expectedMeetingID == expected.id)
+            #expect(session.metadata?.title == "Project sync")
+            #expect(session.metadata?.attendees.first?.name == "Taylor")
+        }
+
         @Test func stopCompletesWhileCaptureStreamKeepsProducing() async throws {
             let root = TestSupport.temporaryDirectoryURL()
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -244,6 +296,14 @@
                 }
             )
             continuation.finish()
+        }
+    }
+
+    private extension JSONDecoder {
+        static var iso8601: JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return decoder
         }
     }
 

--- a/StetMacTests/Core/Speech/MeetingTranscriptDocumentTests.swift
+++ b/StetMacTests/Core/Speech/MeetingTranscriptDocumentTests.swift
@@ -67,5 +67,36 @@
             #expect(markdown.contains("1 min 35s"))
             #expect(!markdown.localizedCaseInsensitiveContains("rewrite"))
         }
+
+        @Test func markdownIncludesExpectedMeetingMetadata() {
+            let scheduledStart = Date(timeIntervalSince1970: 1_704_067_200)
+            let metadata = MeetingMetadata(
+                expectedMeeting: ExpectedMeeting(
+                    id: UUID(),
+                    source: "calendar",
+                    externalID: "event-1",
+                    scheduledStartAt: scheduledStart,
+                    scheduledEndAt: scheduledStart.addingTimeInterval(1_800),
+                    title: "Project sync",
+                    attendees: [MeetingAttendee(name: "Taylor", email: nil)],
+                    meetingURL: URL(string: "https://example.com/meeting"),
+                    notes: nil,
+                    sourceModifiedAt: nil,
+                    status: .scheduled,
+                    recordedMeetingID: nil
+                )
+            )
+            let markdown = MeetingTranscriptDocument.markdown(
+                startedAt: scheduledStart.addingTimeInterval(60),
+                endedAt: scheduledStart.addingTimeInterval(120),
+                turns: [],
+                metadata: metadata
+            )
+
+            #expect(markdown.contains("# Project sync"))
+            #expect(markdown.contains("Attendees: Taylor"))
+            #expect(markdown.contains("Meeting: https://example.com/meeting"))
+            #expect(markdown.contains("Scheduled:"))
+        }
     }
 #endif

--- a/StetMacTests/Shared/Utilities/MacMeetingRecordingNotificationTests.swift
+++ b/StetMacTests/Shared/Utilities/MacMeetingRecordingNotificationTests.swift
@@ -44,5 +44,28 @@
         @Test func idleDoesNotPostABanner() {
             #expect(MacMeetingRecordingNotification.payload(from: .idle, to: .idle) == nil)
         }
+
+        @Test func expectedMeetingBodyIncludesTimeAndAttendees() {
+            let start = Date(timeIntervalSince1970: 1_704_067_200)
+            let meeting = ExpectedMeeting(
+                id: UUID(),
+                source: "calendar",
+                externalID: "event-1",
+                scheduledStartAt: start,
+                scheduledEndAt: start.addingTimeInterval(1_800),
+                title: "Project sync",
+                attendees: [MeetingAttendee(name: "Taylor", email: nil)],
+                meetingURL: nil,
+                notes: nil,
+                sourceModifiedAt: nil,
+                status: .scheduled,
+                recordedMeetingID: nil
+            )
+
+            let body = MacDictationCompletionNotificationService.expectedMeetingBody(meeting)
+
+            #expect(body.contains("Taylor"))
+            #expect(!body.isEmpty)
+        }
     }
 #endif


### PR DESCRIPTION
## Summary
- add persistent expected meetings that agents can reconcile through the idempotent `stet_sync_expected_meetings` MCP tool
- schedule localized notifications five minutes before meetings with Start Recording and Skip actions
- link notification-started recordings to structured calendar metadata and expose that metadata through transcripts and MCP responses

## Behavior
- expected meetings remain separate from recorded meeting sessions until the user starts recording
- MCP synchronization cannot start the microphone; recording requires the local notification action
- repeated snapshots update meetings by `source + external_id`, cancel missing meetings in the supplied window, and preserve locally skipped meetings
- Stet restores pending reminders after relaunch and immediately reminds for meetings already within the five-minute window

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (568 tests)
- `make lint`
- `plutil -lint StetMac/Resources/Localizations/*.lproj/Localizable.strings`
- `git diff --check`